### PR TITLE
Add sigma-z coordinate generation to MPAS-Ocean init mode

### DIFF
--- a/components/mpas-ocean/src/mode_init/Registry.xml
+++ b/components/mpas-ocean/src/mode_init/Registry.xml
@@ -77,7 +77,7 @@
 	<nml_record name="init_vertical_grid" mode="init">
 		<nml_option name="config_init_vertical_grid_type" type="character" default_value="z-star" units="unitless"
 					description="Which vertical grid to initialize with.  Without ice-shelf cavities (i.e. ssh=0 everywhere), 'z-star' and 'z-level' are the same."
-					possible_values="'z-star', 'z-level', or 'haney-number'"
+					possible_values="'z-star', 'z-level', 'sigma-z', or 'haney-number'"
 		/>
 	</nml_record>
 	<nml_record name="constrain_Haney_number" mode="init">

--- a/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
@@ -343,6 +343,38 @@
 			description="Number of smoothing iterations on ecosystem variables."
 			possible_values="Any positive integer value greater or equal to 0."
 		/>
+		<nml_option name="config_global_ocean_sigmaz_wt_depth1" type="real" default_value="100.0" units="m"
+			description="Depth of first point for the sigma-z weight function definition"
+			possible_values="Any positive real value greater than 0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_wt_depth2" type="real" default_value="200.0" units="m"
+			description="Depth of point for the sigma-z weight function definition"
+			possible_values="Any positive real value greater than 0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_weight2" type="real" default_value="0.75" units="dimensionless"
+			description="Weight of point for the sigma-z weight function definition"
+			possible_values="value between 1.0 (fully z-level) and 0.0 (fully sigma), but typically between 0.5 and 1.0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_wt_depth3" type="real" default_value="1000.0" units="m"
+			description="Depth of point for the sigma-z weight function definition"
+			possible_values="Any positive real value greater than 0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_weight3" type="real" default_value="0.75" units="dimensionless"
+			description="Weight of point for the sigma-z weight function definition"
+			possible_values="value between 1.0 (fully z-level) and 0.0 (fully sigma), but typically between 0.5 and 1.0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_wt_depth4" type="real" default_value="2000.0" units="m"
+			description="Depth of point for the sigma-z weight function definition"
+			possible_values="Any positive real value greater than 0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_weight4" type="real" default_value="0.5" units="dimensionless"
+			description="Weight of point for the sigma-z weight function definition"
+			possible_values="value between 1.0 (fully z-level) and 0.0 (fully sigma), but typically between 0.5 and 1.0."
+		/>
+		<nml_option name="config_global_ocean_sigmaz_smooth_iterations" type="integer" default_value="3" units="unitless"
+			description="Number of smoothing iterations on bathymetry for sigma-z weights"
+			possible_values="Any positive integer value greater or equal to 0."
+		/>
 	</nml_record>
 	<var_struct name="scratch" time_levs="1">
 		<var name="cullStack" type="integer" dimensions="nCells" persistence="scratch"

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
@@ -861,12 +861,17 @@ contains
      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:, :), pointer :: cellsOnCell
 
-     integer :: iCell, k
+     integer :: iCell, k, j, iSmooth, coc, counter
 
      logical :: useZStar, useZLevel
 
      real (kind=RKIND) :: depth, layerStretch
+      real (kind=RKIND) :: x1,x2,x3,x4,y1,y2,y3,y4
+      real (kind=RKIND), dimension(:), allocatable :: weight_sigma_z, depthCellBot, &
+         bottomDepthSmooth, bottomDepthSmoothNew
 
    !--------------------------------------------------------------------
 
@@ -874,6 +879,7 @@ contains
 
      if (config_init_vertical_grid_type /= 'z-level' .and. &
          config_init_vertical_grid_type /= 'z-star' .and. &
+         config_init_vertical_grid_type /= 'sigma-z' .and. &
          config_init_vertical_grid_type /= 'haney-number') then
 
          call mpas_log_write('Unexpected value for config_init_vertical_grid_type ' // &
@@ -954,7 +960,8 @@ contains
 
          block_ptr => block_ptr % next
        end do !block_ptr
-     else  ! config_init_vertical_grid_type == 'z-level'
+
+     else if(config_init_vertical_grid_type == 'z-level') then
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
@@ -1050,6 +1057,157 @@ contains
 
          block_ptr => block_ptr % next
        end do !block_ptr
+
+     else if(config_init_vertical_grid_type == 'sigma-z') then
+
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
+
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+
+         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+         allocate(weight_sigma_z(nVertLevels))
+         allocate(depthCellBot(nVertLevels))
+         allocate(bottomDepthSmooth(nCells))
+         allocate(bottomDepthSmoothNew(nCells))
+
+         ! create sigma-z weight function
+         do k = 1, nVertLevels
+           x1= config_global_ocean_sigmaz_wt_depth1; y1=1.0_RKIND
+           x2= config_global_ocean_sigmaz_wt_depth2; y2=config_global_ocean_sigmaz_weight2
+           x3= config_global_ocean_sigmaz_wt_depth3; y3=config_global_ocean_sigmaz_weight3
+           x4= config_global_ocean_sigmaz_wt_depth4; y4=config_global_ocean_sigmaz_weight4
+           if (refBottomDepth(k) < x1) then
+             weight_sigma_z(k) = y1
+           elseif (refBottomDepth(k) < x2) then
+             weight_sigma_z(k) = y1 + (refBottomDepth(k) - x1)/(x2-x1)*(y2-y1)
+           elseif (refBottomDepth(k) < x3) then
+             weight_sigma_z(k) = y2 + (refBottomDepth(k) - x2)/(x3-x2)*(y3-y2)
+           elseif (refBottomDepth(k) < x4) then
+             weight_sigma_z(k) = y3 + (refBottomDepth(k) - x3)/(x4-x3)*(y4-y3)
+           else
+             weight_sigma_z(k) = y4
+           endif
+         end do
+
+         ! smooth bottom depth for sigma-z coordinate calculation
+         bottomDepthSmooth = bottomDepth
+         if (config_global_ocean_sigmaz_smooth_iterations>0) then
+           call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+           call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+
+           ! create smoothed bottom depth variable, so sigma-z layers are smoothed
+           do iSmooth = 1, config_global_ocean_sigmaz_smooth_iterations
+             do iCell = 1, nCells
+               bottomDepthSmoothNew(iCell) = bottomDepthSmooth(iCell)
+                     counter = 1
+                     do j = 1, nEdgesOnCell(iCell)
+                        coc = cellsOnCell(j, iCell)
+                        if (coc<nCells+1) then
+                           bottomDepthSmoothNew(iCell) = bottomDepthSmoothNew(iCell) + bottomDepthSmooth (coc)
+                           counter = counter + 1
+                        end if
+                     end do ! edgesOnCell
+
+               bottomDepthSmoothNew(iCell) = bottomDepthSmoothNew(iCell) / counter
+             end do
+             bottomDepthSmooth = bottomDepthSmoothNew
+           end do
+         end if
+
+         ! compute minLevelCell and maxLevelCell based on refBottomDepth, ssh and bottomDepth
+         do iCell = 1, nCells
+           do k = 1, nVertLevels-1
+             depthCellBot(k) = refBottomDepth(k)*( weight_sigma_z(k) &
+                + (1.0_RKIND - weight_sigma_z(k)) * bottomDepthSmooth(iCell) / refBottomDepth(nVertLevels))
+           end do
+           depthCellBot(nVertLevels) = refBottomDepth(nVertLevels)+0.1_RKIND
+
+           if ((bottomDepth(iCell) == 0.0_RKIND) .or. (bottomDepth(iCell) <= -ssh(iCell))) then
+              cycle
+           end if
+
+           maxLevelCell(iCell) = -1
+           do k = 1, nVertLevels
+             depth = depthCellBot(k)
+             if (depth >= bottomDepth(iCell)) then
+               maxLevelCell(iCell) = k
+               exit
+             end if
+           end do
+
+           minLevelCell(iCell) = -1
+           do k = 1, nVertLevels
+             depth = depthCellBot(k)
+             if (-depth < ssh(iCell)) then
+               minLevelCell(iCell) = k
+               exit
+             end if
+           end do
+
+           ! alter pbcs
+           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), depthCellBot, maxLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! alter ptcs
+           call ocn_alter_ssh_for_ptcs(ssh(iCell), refBottomDepth, minLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_ssh_for_ptcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! layerThickness is z-level
+           call ocn_compute_z_level_layerThickness(layerThickness(:,iCell), depthCellBot, ssh(iCell), &
+                                                   bottomDepth(iCell), minLevelCell(iCell),             &
+                                                   maxLevelCell(iCell), nVertLevels, iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_z_level_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! cases with SSH > 0 require a resting thickness that is stretched to compensate for the SSH
+           restingThickness(:, iCell) = 0.0_RKIND
+
+           if (maxLevelCell(iCell)  > 0) then
+             layerStretch = (ssh(iCell) + bottomDepth(iCell))/bottomDepth(iCell)
+             do k = minLevelCell(iCell), maxLevelCell(iCell)
+               restingThickness(k, iCell) = layerThickness(k, iCell)/layerStretch
+             end do
+           end if
+
+           ! compute zMid
+           call ocn_compute_zMid_from_layerThickness(zMid(:,iCell), layerThickness(:,iCell), ssh(iCell),    &
+                                                     minLevelCell(iCell), maxLevelCell(iCell), nVertLevels, &
+                                                     iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_zMid_from_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+         end do !iCell
+
+         deallocate(weight_sigma_z, depthCellBot)
+
+         block_ptr => block_ptr % next
+       end do !block_ptr
      end if
 
    end subroutine ocn_init_vertical_grid
@@ -1107,6 +1265,8 @@ contains
                            zMean, weight, rx1Goal, dzVertMean, &
                            zMidNext, frac, stretch, localMaxRx1Edge, &
                            localStretchMax, localStretchMin
+      real (kind=RKIND) :: x1,x2,x3,x4,y1,y2,y3,y4
+      real (kind=RKIND), dimension(:), allocatable :: weight_sigma_z
 
       logical :: moveInterface
 


### PR DESCRIPTION
Until now, E3SM simulations have all used z-star coordinates, where the initial vertical grid is exactly z-level (each layer has horizontally uniform layer thickness), and during the simulation layers expand and contract with the sea surface height.  This PR adds the ability to generate a hybrid sigma-z coordinate, where layers partially tilt as they approach shallower bathymetry, as in sigma coordinates, but also lose layers from the bottom along steep inclines like the continental slope.

All changes are in MPAS-Ocean init mode. No modifications of forward mode, or any E3SM simulation code, is required.