### PR TITLE
Addition of TRiSK++ to ocean dynamical core

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1720,6 +1720,9 @@
                         <var name="invBtB"/>
                         <var name="weightsOnEdge_lsqr"/>
 			<var name="kineticEnergyCell"/>
+                        <var name="kineticEnergyEdge"/>
+                        <var name="u_perp"/>
+                        <var name="divergence"/>
 			<var name="relativeVorticityCell"/>
 			<var name="areaCellGlobal"/>
 			<var name="areaEdgeGlobal"/>
@@ -2571,6 +2574,14 @@
 			 description="kinetic energy of horizontal velocity on cells"
 			 packages="forwardMode;analysisMode"
 		/>
+                <var name="kineticEnergyEdge" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-2}"
+                         description="kinetic energy of horizontal velocity on edges"
+                         packages="forwardMode;analysisMode"
+                />
+                <var name="u_perp" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-2}"
+                         description="tangential velocity on edges needed for the computation of kineticEnergyEdge in TRSK++"
+                         packages="forwardMode;analysisMode"
+                />
 		<var name="viscosity" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-1}"
 			 description="horizontal viscosity"
 			 packages="forwardMode;analysisMode"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -190,6 +190,10 @@
 					description="Time integration method."
 					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'"
 		/>
+		<nml_option name="config_triskCV" type="logical" default_value=".false." units="unitless"
+                                        description="Turns on the computation of the kinetic energy in the TRiSK-CV way."
+                                        possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">
 		<nml_option name="config_hmix_scaleWithMesh" type="logical" default_value=".false." units="unitless"
@@ -1711,6 +1715,10 @@
 			<var name="xtime"/>
 			<var name="zMid"/>
 			<var name="zTop"/>
+                        <var name="areaCVEdge"/>
+                        <var name="weightsEdgeToCell"/>
+                        <var name="invBtB"/>
+                        <var name="weightsOnEdge_lsqr"/>
 			<var name="kineticEnergyCell"/>
 			<var name="relativeVorticityCell"/>
 			<var name="areaCellGlobal"/>
@@ -2165,6 +2173,15 @@
 		<var name="weightsOnEdge" type="real" dimensions="maxEdges2 nEdges" units="unitless"
 			 description="Reconstruction weights associated with each of the edgesOnEdge, used to reconstruct the tangentialVelocity from normalVelocities on neighboring edges."
 		/>
+                <var name="weightsOnEdge_lsqr" type="real" dimensions="maxEdges2 nEdges" units="unitless"
+			 desription="Weights associated with each of the edgesOnEdge needed for the tangential velocity in the kinetic energy for TRiSK-CV."
+                />
+                <var name="weightsEdgeToCell" type="real" dimensions="maxEdges nCells" units="unitless"
+                         desription="Weights needed for the edge to cell mapping in TRiSK-CV."
+                />
+                <var name="areaCVEdge" type="real" dimensions="nEdges" units="m^2"
+                         desription="Areas of the diamond-shaped control volumes for TRiSK-CV."
+                />
 		<var name="dvEdge" type="real" dimensions="nEdges" units="m"
 			 description="Length of each edge, computed as the distance between verticesOnEdge."
 		/>
@@ -2210,6 +2227,9 @@
 		<var name="kiteAreasOnVertex" type="real" dimensions="vertexDegree nVertices" units="m^2"
 			 description="Area of the portions of each dual cell that are part of each cellsOnVertex."
 		/>
+                <var name="invBtB" type="real" dimensions="vertexDegree vertexDegree nEdges" units="m^2"
+                         description="3x3 matrix needed for each edge in the kinetic energy for TRiSK-CV."
+                />
 		<var name="fEdge" type="real" dimensions="nEdges" units="s^{-1}"
 			 description="Coriolis parameter at edges."
 		/>

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -86,6 +86,8 @@ module ocn_forward_mode
    use ocn_constants
    use ocn_config
 
+   use ocn_ke_triskcv
+
    implicit none
    private
 
@@ -167,6 +169,8 @@ module ocn_forward_mode
       ! Initialize variables needed for all
       !-----------------------------------------------------------------
       ierr = 0
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
 
       ! Setup ocean config pool
       call ocn_config_init(domain % configs)
@@ -295,6 +299,18 @@ module ocn_forward_mode
 
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
       call mpas_get_timeInterval(timeStep, dt=dt)
+
+      if (config_triskCV) then
+         ! Compute the areas of the diamond-shaped control volumes needed in
+         ! TRiSK-CV
+         call controlVolumeEdge(domain, meshPool)
+         ! Compute a matrix needed in TRiSK-CV for the computation of the
+         ! kinetic energy
+         call buildInvMatrixBtB(domain, meshPool)
+         ! Compute the weightsOnEdge needed in TRiSK-CV for the computation of
+         ! the kinetic energy in TRiSK-CV
+         call Wlsqr(domain, meshPool)
+      end if
 
       call ocn_init_routines_block(block, dt, ierr)
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -564,6 +564,16 @@ module ocn_time_integration_split
          ! BEGIN baroclinic iterations on linear Coriolis term
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+         !do iEdge = 1, nEdgesAll
+         !do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+         !   if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+         !      do j = 1, nEdgesOnEdge(iEdge)
+         !         print*, indexToEdgeID(iEdge), k, j, normalVelocityNew(k,edgesOnEdge(j,iEdge))
+         !      end do
+         !   end if
+         !end do
+         !end do
+
          do j=1,numClinicIterations(splitExplicitStep)
 
             call mpas_timer_start('bcl iters on linear Coriolis')
@@ -571,6 +581,16 @@ module ocn_time_integration_split
             ! Put f*normalBaroclinicVelocity^{perp} in
             ! normalVelocityNew as a work variable
             call ocn_fuperp(statePool, meshPool, 2)
+
+            !do iEdge = 1, nEdgesAll
+            !do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            !   if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+            !      do i = 1, nEdgesOnEdge(iEdge)
+            !         print*, indexToEdgeID(iEdge), k, i, normalVelocityNew(k,edgesOnEdge(i,iEdge))
+            !      end do
+            !   end if
+            !end do
+            !end do
 
             !TODO: look at loop optimizations here
             ! Only need to loop over owned cells, since there is a halo
@@ -644,7 +664,17 @@ module ocn_time_integration_split
                               'normalBaroclinicVelocity', timeLevel=2)
             call mpas_timer_stop("se halo normalBaroclinicVelocity")
 
-            call mpas_timer_stop('bcl iters on linear Coriolis')
+            call mpas_timer_stop('bcl iters on linear Coriolis') 
+
+            !do iEdge = 1, nEdgesAll
+            !do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            !   if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+            !      do i = 1, nEdgesOnEdge(iEdge)
+            !         print*, indexToEdgeID(iEdge), k, i, normalVelocityNew(k,edgesOnEdge(i,iEdge))
+            !      end do
+            !   end if
+            !end do
+            !end do
 
          end do  ! do j=1,config_n_bcl_iter
 
@@ -652,7 +682,7 @@ module ocn_time_integration_split
          call mpas_dmpar_field_halo_exch(domain, 'barotropicForcing')
          call mpas_timer_stop('se halo barotropicForcing')
 
-         call mpas_timer_stop("se bcl vel")
+         call mpas_timer_stop("se bcl vel")       
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! END baroclinic iterations on linear Coriolis term
@@ -1645,6 +1675,8 @@ module ocn_time_integration_split
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
+ 
+            !print*, '1' 
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! If large iteration complete, compute all variables at
@@ -1652,6 +1684,16 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          elseif (splitExplicitStep == numTSIterations) then
+
+            !do iEdge = 1, nEdgesAll
+            !do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            !   if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+            !      do j = 1, nEdgesOnEdge(iEdge)
+            !         print*, indexToEdgeID(iEdge), k, j, normalVelocityNew(k,edgesOnEdge(j,iEdge))
+            !      end do
+            !   end if
+            !end do
+            !end do
 
             !$omp parallel
             !$omp do schedule(runtime) private(k)
@@ -1855,6 +1897,7 @@ module ocn_time_integration_split
 
             !$omp parallel
             !$omp do schedule(runtime) private(k)
+
             do iEdge = 1, nEdgesAll
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
@@ -1864,7 +1907,7 @@ module ocn_time_integration_split
             end do
             end do ! iEdges
             !$omp end do
-            !$omp end parallel
+            !$omp end parallel 
 
          endif ! splitExplicitStep
 
@@ -1879,6 +1922,8 @@ module ocn_time_integration_split
 
       call mpas_timer_start("se implicit vert mix")
 
+      !call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', timeLevel=2)
+
       ! Call ocean diagnostic solve in preparation for vertical mixing.
       ! Note it is called again after vertical mixing, because u and
       ! tracers change. For Richardson vertical mixing, only density,
@@ -1889,7 +1934,8 @@ module ocn_time_integration_split
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
 
-      call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
+      !print*, '2'
+      call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity') 
 
       ! Compute normalGMBolusVelocity; it will be added to the
       ! baroclinic modes in Stage 2 above.
@@ -1953,6 +1999,8 @@ module ocn_time_integration_split
 
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
+
+      !print*, '3' 
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -83,7 +83,7 @@ mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_o
 
 mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
-mpas_ocn_mesh.o:
+mpas_ocn_mesh.o: 
 
 mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -217,7 +217,7 @@ mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o
 
 mpas_ocn_vel_tidal_potential.o: mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_ke_triskCV.o:
+mpas_ocn_ke_triskCV.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o mpas_ocn_thick_ale.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -70,15 +70,16 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_time_varying_forcing.o \
 	   mpas_ocn_wetting_drying.o \
 	   mpas_ocn_vel_tidal_potential.o \
-	   mpas_ocn_vel_forcing_topographic_wave_drag.o
+	   mpas_ocn_vel_forcing_topographic_wave_drag.o \
+	   mpas_ocn_ke_triskCV.o
 
 all: $(OBJS)
 
-mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
+mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_ke_triskCV.o
 
 mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_ke_triskCV.o
 
 mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
@@ -215,6 +216,8 @@ mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o
 
 mpas_ocn_vel_tidal_potential.o: mpas_ocn_diagnostics_variables.o
+
+mpas_ocn_ke_triskCV.o:
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -37,6 +37,7 @@ module ocn_diagnostics
    use ocn_diagnostics_variables
    use ocn_mesh
    use ocn_surface_land_ice_fluxes
+   use ocn_ke_triskcv
 
    implicit none
    private
@@ -1478,13 +1479,24 @@ contains
       !-----------------------------------------------------------------
 
       integer :: nCells, nEdges
-      integer :: iCell, iVertex, iEdge
+      integer :: iCell, iVertex, iEdge, jEdge
       integer :: i, j, k
       integer :: edgeSignOnCell_temp, eoe
       real(kind=RKIND) :: invAreaCell1
-      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp, &
+                          weightsOnEdge_lsqr_temp
+
+      type (domain_type) :: domain
+      type (mpas_pool_type), pointer :: meshPool
+      real(kind=RKIND), dimension(:, :), pointer :: weightsOnEdge_lsqr
 
       real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport,div_huGMBolus
+      real (kind=RKIND), dimension(:,:), allocatable:: kineticEnergyEdge, u_perp
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr', weightsOnEdge_lsqr)
+
 #ifdef MPAS_OPENACC
       !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus)
 #endif
@@ -1528,6 +1540,7 @@ contains
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
+      allocate(u_perp(nVertLevels,nEdges), kineticEnergyEdge(nVertLevels,nEdges))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
@@ -1547,7 +1560,7 @@ contains
 #endif
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
-         kineticEnergyCell(:, iCell) = 0.0_RKIND
+         !kineticEnergyCell(:, iCell) = 0.0_RKIND
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
          div_huGMBolus(:) = 0.0_RKIND
@@ -1562,8 +1575,8 @@ contains
 
                divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
                div_hu(k) = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * r_tmp
-               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
-                                              + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
+               !kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
+               !                               + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
                ! Compute vertical velocity from the horizontal total transport
                div_huTransport(k) = div_huTransport(k) &
                                     - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp &
@@ -1583,12 +1596,59 @@ contains
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      if (config_triskCV) then
+         kineticEnergyEdge(:,:) = 0.0_RKIND
+         do iEdge = 1, nEdges 
+            u_perp(:,iEdge) = 0.0_RKIND
+            do j = 1, nEdgesOnEdge(iEdge)
+               jEdge = edgesOnEdge(j,iEdge)
+               weightsOnEdge_lsqr_temp = weightsOnEdge_lsqr(j,iEdge)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  u_perp(k,iEdge) = u_perp(k,iEdge) + weightsOnEdge_lsqr_temp*normalVelocity(k,jEdge)
+               end do
+            end do
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               kineticEnergyEdge(k,iEdge) = 0.5_RKIND*(normalVelocity(k,iEdge)*normalVelocity(k,iEdge) + u_perp(k,iEdge)*u_perp(k,iEdge))
+            end do
+         end do
+         kineticEnergyCell(:, iCell) = 0.0_RKIND
+         do iCell = 1, nCells 
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  !ke_baricentric(k,iCell) = ke_baricentric(k,iCell) + weightsEdgeToCell(i,iCell)*ke_edge(k,edgesOnCell(i,iCell))
+                  kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) + 0.25_RKIND * dcEdge(iEdge) * dvEdge(iEdge) * kineticEnergyEdge(k,iEdge)
+               end do 
+            end do
+            do k = 1, nVertLevels
+               !ke_baricentric(k,iCell) = ke_baricentric(k,iCell) / !areaCell(iCell)
+               kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) / areaCell(iCell)
+            end do
+         end do
+      else
+         do iCell = 1, nCells
+            kineticEnergyCell(:, iCell) = 0.0_RKIND
+            invAreaCell1 = invAreaCell(iCell)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               dcEdge_temp = dcEdge(iEdge)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
+                   kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
+                                                  + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
+               end do
+            end do
+         end do   
+      end if
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
+      deallocate(u_perp,kineticEnergyEdge)
 
       nEdges = nEdgesHalo( 2 )
 #ifdef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -28,6 +28,7 @@ module ocn_diagnostics
    use mpas_vector_reconstruction
    use mpas_stream_manager
    use mpas_io_units
+   use mpas_dmpar
 
    use ocn_constants
    use ocn_config
@@ -222,13 +223,13 @@ contains
       ! inputs: relativeVorticity, layerThicknessEdge, normalVelocity, normalTransportVelocity, 
       !         normalGMBolusVelocity
       ! outputs: vertTransportVelocityTop, vertGMBolusVelocityTop, relativeVorticityCell, 
-      !          divergence, kineticEnergyCell, tangentialVelocity
+      !          divergence, kineticEnergyCell, kineticEnergyEdge, u_perp, tangentialVelocity
       ! in and out: vertVelocityTop
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-             kineticEnergyCell, tangentialVelocity)
+             kineticEnergyCell, kineticEnergyEdge, u_perp, tangentialVelocity)
 
       !
       ! Compute kinetic energy
@@ -1430,7 +1431,7 @@ contains
                 layerThicknessEdge, normalVelocity, normalTransportVelocity, &
                 normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
                 vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-                kineticEnergyCell, tangentialVelocity)!{{{
+                kineticEnergyCell, kineticEnergyEdge, u_perp, tangentialVelocity)!{{{
 
       implicit none
 
@@ -1470,6 +1471,10 @@ contains
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          kineticEnergyCell
       real (kind=RKIND), dimension(:,:), intent(out) :: &
+         kineticEnergyEdge
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         u_perp
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
          tangentialVelocity
 
       !-----------------------------------------------------------------
@@ -1486,16 +1491,10 @@ contains
       real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp, &
                           weightsOnEdge_lsqr_temp
 
-      type (domain_type) :: domain
-      type (mpas_pool_type), pointer :: meshPool
-      real(kind=RKIND), dimension(:, :), pointer :: weightsOnEdge_lsqr
-
       real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport,div_huGMBolus
-      real (kind=RKIND), dimension(:,:), allocatable:: kineticEnergyEdge, u_perp
+      !real (kind=RKIND), dimension(:,:), allocatable:: u_perp, kineticEnergyEdge
 
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
-
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr', weightsOnEdge_lsqr)
+      !call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell, timeLevel)
 
 #ifdef MPAS_OPENACC
       !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus)
@@ -1535,12 +1534,13 @@ contains
 
       ! Need 0,1,2 halo cells
       nCells = nCellsHalo( 2 )
+      nEdges = nEdgesHalo( 2 ) !nEdgesAll
 
       !
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
-      allocate(u_perp(nVertLevels,nEdges), kineticEnergyEdge(nVertLevels,nEdges))
+      !allocate(u_perp(nVertLevels,nEdges), kineticEnergyEdge(nVertLevels,nEdges))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
@@ -1596,33 +1596,37 @@ contains
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  
       if (config_triskCV) then
+         !nCells = nCellsAll 
          kineticEnergyEdge(:,:) = 0.0_RKIND
          do iEdge = 1, nEdges 
             u_perp(:,iEdge) = 0.0_RKIND
             do j = 1, nEdgesOnEdge(iEdge)
                jEdge = edgesOnEdge(j,iEdge)
                weightsOnEdge_lsqr_temp = weightsOnEdge_lsqr(j,iEdge)
-               do k = minLevelCell(iCell), maxLevelCell(iCell)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)  
                   u_perp(k,iEdge) = u_perp(k,iEdge) + weightsOnEdge_lsqr_temp*normalVelocity(k,jEdge)
-               end do
+                  !if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+                  !   print*, indexToEdgeID(iEdge), k, j, weightsOnEdge_lsqr_temp, normalVelocity(k,jEdge), u_perp(k,iEdge)
+                  !end if
+               end do   
             end do
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
+          end do
+          do iEdge = 1, nEdges
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                kineticEnergyEdge(k,iEdge) = 0.5_RKIND*(normalVelocity(k,iEdge)*normalVelocity(k,iEdge) + u_perp(k,iEdge)*u_perp(k,iEdge))
             end do
          end do
-         kineticEnergyCell(:, iCell) = 0.0_RKIND
-         do iCell = 1, nCells 
+         do iCell = 1, nCells
+            kineticEnergyCell(:, iCell) = 0.0_RKIND 
             do i = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i, iCell)
-               do k = minLevelCell(iCell), maxLevelCell(iCell)
-                  !ke_baricentric(k,iCell) = ke_baricentric(k,iCell) + weightsEdgeToCell(i,iCell)*ke_edge(k,edgesOnCell(i,iCell))
+               do k = minLevelCell(iCell), maxLevelCell(iCell) 
                   kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) + 0.25_RKIND * dcEdge(iEdge) * dvEdge(iEdge) * kineticEnergyEdge(k,iEdge)
                end do 
             end do
-            do k = 1, nVertLevels
-               !ke_baricentric(k,iCell) = ke_baricentric(k,iCell) / !areaCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell) 
                kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) / areaCell(iCell)
             end do
          end do
@@ -1633,8 +1637,9 @@ contains
             do i = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i, iCell)
                dcEdge_temp = dcEdge(iEdge)
+               dvEdge_temp = dvEdge(iEdge)
                do k = minLevelCell(iCell), maxLevelCell(iCell)
-                  r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
+                   r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
                    kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
                                                   + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
                end do
@@ -1648,7 +1653,7 @@ contains
 #endif
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
-      deallocate(u_perp,kineticEnergyEdge)
+      !deallocate(u_perp, kineticEnergyEdge)
 
       nEdges = nEdgesHalo( 2 )
 #ifdef MPAS_OPENACC
@@ -2339,6 +2344,19 @@ contains
                normalVelocity(k,iEdge) = normalVelocity(k,iEdge) + weightsOnEdge(j,iEdge) * normalBaroclinicVelocity(k,eoe) &
                                        * fEdge(eoe)
             end do
+
+            !if(k==5 .and. indexToEdgeID(iEdge)==1000) then
+            !print*, '---inside---'
+            !   do j = 1, nEdgesOnEdge(iEdge)
+            !      print*, indexToEdgeID(iEdge), k, j, normalVelocity(k,edgesOnEdge(j,iEdge)) 
+            !      print*, "----associated normalBaroclinicVelocity"
+            !      do eoe = 1, nEdgesOnEdge(edgesOnEdge(j,iEdge))
+            !         print*, eoe, normalBaroclinicVelocity(k,edgesOnEdge(eoe,edgesOnEdge(j,iEdge)))
+            !      end do
+            !   end do
+            !print*, '---end inside---'
+            !end if
+
          end do
       end do
 #ifdef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -58,6 +58,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
    real (kind=RKIND), dimension(:,:), pointer :: layerThickEdge
    real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
+   real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyEdge
+   real (kind=RKIND), dimension(:,:), pointer :: u_perp
    real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertGMBolusVelocityTop
@@ -451,6 +453,10 @@ contains
                    barotropicForcing)
          call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', &
                    kineticEnergyCell)
+         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyEdge', &
+                   kineticEnergyEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'u_perp', &
+                   u_perp)
 
          call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', &
                    transportVelocityX)
@@ -689,6 +695,8 @@ contains
          !$acc                   GMStreamFuncZonal,               &
          !$acc                   relativeVorticity,               &
          !$acc                   kineticEnergyCell,               &
+         !$acc                   kineticEnergyEdge,               &
+         !$acc                   u_perp,                          &
          !$acc                   normPlanetVortEdge,              &
          !$acc                   velocityMeridional,              &
          !$acc                   transportVelocityX,              &
@@ -926,6 +934,8 @@ contains
          !$acc                   GMStreamFuncZonal,               &
          !$acc                   relativeVorticity,               &
          !$acc                   kineticEnergyCell,               &
+         !$acc                   kineticEnergyEdge,               &
+         !$acc                   u_perp,                          &
          !$acc                   normPlanetVortEdge,              &
          !$acc                   velocityMeridional,              &
          !$acc                   transportVelocityX,              &
@@ -1124,6 +1134,8 @@ contains
                  GMStreamFuncZonal,               &
                  relativeVorticity,               &
                  kineticEnergyCell,               &
+                 kineticEnergyEdge,               &
+                 u_perp,                          &
                  normPlanetVortEdge,              &
                  velocityMeridional,              &
                  transportVelocityX,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -38,6 +38,7 @@ module ocn_init_routines
    use ocn_constants
    use ocn_config
    use ocn_mesh
+   use ocn_ke_triskcv
 
    use ocn_surface_land_ice_fluxes
    use ocn_forcing
@@ -96,6 +97,7 @@ contains
       real (kind=RKIND), intent(in) :: dt
       integer, intent(out) :: err
 
+      type (domain_type) :: domain
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool, tracersPool
       type (mpas_pool_type), pointer :: forcingPool, scratchPool
@@ -136,6 +138,18 @@ contains
             boundaryLayerDepth(iCell) = layerThickness(minLevelCell(iCell), iCell) * 0.5_RKIND
             indMLD(iCell) = minLevelCell(iCell)
          end do
+      end if
+
+      if (config_triskCV) then      
+         ! Compute the areas of the diamond-shaped control volumes needed in
+         ! TRiSK-CV
+         call controlVolumeEdge(domain, meshPool)
+         ! Compute a matrix needed in TRiSK-CV for the computation of the
+         ! kinetic energy
+         call buildInvMatrixBtB(domain, meshPool)
+         ! Compute the weightsOnEdge needed in TRiSK-CV for the computation of
+         ! the kinetic energy in TRiSK-CV
+         call Wlsqr(domain, meshPool)   
       end if
 
       call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, scratchPool, tracersPool)

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -140,19 +140,21 @@ contains
          end do
       end if
 
-      if (config_triskCV) then      
-         ! Compute the areas of the diamond-shaped control volumes needed in
-         ! TRiSK-CV
-         call controlVolumeEdge(domain, meshPool)
-         ! Compute a matrix needed in TRiSK-CV for the computation of the
-         ! kinetic energy
-         call buildInvMatrixBtB(domain, meshPool)
-         ! Compute the weightsOnEdge needed in TRiSK-CV for the computation of
-         ! the kinetic energy in TRiSK-CV
-         call Wlsqr(domain, meshPool)   
-      end if
+      !if (config_triskCV) then      
+      !   ! Compute the areas of the diamond-shaped control volumes needed in
+      !   ! TRiSK-CV
+      !   call controlVolumeEdge(domain, meshPool)
+      !   ! Compute a matrix needed in TRiSK-CV for the computation of the
+      !   ! kinetic energy
+      !   call buildInvMatrixBtB(domain, meshPool)
+      !   ! Compute the weightsOnEdge needed in TRiSK-CV for the computation of
+      !   ! the kinetic energy in TRiSK-CV
+      !   call Wlsqr(domain, meshPool)   
+      !end if
 
       call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, scratchPool, tracersPool)
+      !print*, '0'
+      !call mpas_dmpar_field_halo_exch(domain, 'kineticEnergyCell')
 
       layerThickness(:, nCells+1) = 0.0_RKIND
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_ke_triskCV.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_ke_triskCV.F
@@ -1,0 +1,514 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the
+! LICENSE file
+! distributed with this code, or at
+! http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_ke_triskCV
+!
+!> \brief MPAS ocean driver for the kinetic energy in TRiSK-CV
+!> \author Sara Calandrini
+!> \date   17 September 2021
+!> \details
+!>  This module contains the routines for computing the kinetic 
+!>  energy in TRiSK-CV. 
+!
+!-----------------------------------------------------------------------
+
+module ocn_ke_triskCV
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_constants
+   use mpas_threading
+   use mpas_vector_reconstruction
+   use mpas_stream_manager
+   use mpas_io_units
+   use mpas_dmpar
+
+   use ocn_constants
+   use ocn_config 
+   use ocn_thick_ale
+   use ocn_diagnostics_variables
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: controlVolumeEdge, &
+             buildInvMatrixBtB, &
+             Wlsqr, &
+             inv_3x3, &
+             sphericalTriangleArea, &
+             sphere_distance
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------  
+
+!***********************************************************************
+
+contains
+
+   subroutine controlVolumeEdge(domain, meshPool)
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! controlVolumeEdge computes the areas associated to every edge in the 
+   ! TRiSK++ discretization 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (mpas_pool_type), intent(inout) :: meshPool
+      type (domain_type), intent(inout) :: domain
+      integer :: vertex1, vertex2, cell1, cell2, iEdge, jEdge, i, k
+      real (kind=RKIND) :: a, b 
+      real (kind=RKIND), dimension(:), pointer :: areaCVEdge
+      real (kind=RKIND), dimension(:,:), pointer :: weightsEdgeToCell
+
+      call mpas_pool_get_array(meshPool, 'areaCVEdge', areaCVEdge)
+      call mpas_pool_get_array(meshPool, 'weightsEdgeToCell', weightsEdgeToCell)
+
+
+      areaCVEdge(:) = 0.0_RKIND
+      weightsEdgeToCell(:,:) = 0.0_RKIND
+      do iEdge = 1, nEdgesAll !nEdgesArray(3)
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+         a = sphericalTriangleArea(latVertex(vertex1), lonVertex(vertex1), latVertex(vertex2), lonVertex(vertex2), latCell(cell1), lonCell(cell1))
+         !if (latCell(cell2)==0.0 .AND. lonCell(cell2)==0.0) then
+         if (cell2 > nCellsAll) then 
+            b = 0.0_RKIND
+         else
+            b = sphericalTriangleArea(latVertex(vertex1), lonVertex(vertex1), latVertex(vertex2), lonVertex(vertex2), latCell(cell2), lonCell(cell2))
+         end if 
+         areaCVEdge(iEdge) = a+b
+         do i = 1, nEdgesOnCell(cell1)
+            jEdge = edgesOnCell(i,cell1)
+            if (iEdge == jEdge) then
+               weightsEdgeToCell(i,cell1) = a
+            end if
+         end do
+         do i = 1, nEdgesOnCell(cell2)
+            jEdge = edgesOnCell(i,cell2)
+            if (iEdge == jEdge) then
+               weightsEdgeToCell(i,cell2) = b
+            end if
+         end do
+      end do
+      call mpas_dmpar_field_halo_exch(domain, 'weightsEdgeToCell')
+      call mpas_dmpar_field_halo_exch(domain, 'areaCVEdge')
+
+      !do iEdge = 1, nEdgesAll
+      !   print*, iEdge, areaCVEdge(iEdge) 
+      !end do
+
+   end subroutine controlVolumeEdge
+
+   subroutine buildInvMatrixBtB(domain, meshPool)
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! buildMatrixBtB computes the least square matrix B^{T}B needed for the
+   ! computation of the kinetic energy in the TRiSK++ discretization 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (mpas_pool_type), intent(inout) :: meshPool
+      type (domain_type), intent(inout) :: domain
+      integer :: iEdge, jEdge, i, j, k
+      integer, dimension(2) :: iEdgeCells, jEdgeCells
+      real (kind=RKIND) :: re_x, re_y, re_z, ne_x, ne_y, ne_z, norm, xTangent, yTangent, zTangent, detinv
+      real (kind=RKIND), dimension(:), pointer :: areaCVEdge   
+      real (kind=RKIND), dimension(:,:,:), pointer :: invBtB
+      real (kind=RKIND), dimension(:,:), allocatable :: BtB
+
+      call mpas_pool_get_array(meshPool, 'areaCVEdge', areaCVEdge)
+      !call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
+      !call mpas_pool_get_array(meshPool, 'zEdge', zEdge)
+      call mpas_pool_get_array(meshPool, 'invBtB', invBtB)
+
+      allocate(BtB(vertexDegree, vertexDegree))
+
+      invBtB(:,:,:) = 0.0_RKIND
+      !print*, nEdgesHalo
+
+      !do iEdge = 1, nEdgesAll
+      !   print*, iEdge, areaCVEdge(iEdge)
+      !end do
+
+      do iEdge = 1, nEdgesHalo(3)
+         BtB(:,:) = 0.0_RKIND
+         iEdgeCells(1) = cellsOnEdge(1,iEdge)
+         iEdgeCells(2) = cellsOnEdge(2,iEdge)
+         norm = sqrt(xEdge(iEdge)**2.0 + yEdge(iEdge)**2.0 + zEdge(iEdge)**2.0)
+         re_x = xEdge(iEdge)/norm
+         re_y = yEdge(iEdge)/norm
+         re_z = zEdge(iEdge)/norm
+         !print*, re_x*ne_x + re_y*ne_y + re_z*ne_z !e-3
+         do j = 1, nEdgesOnEdge(iEdge)
+            !print*, nEdgesOnEdge(iEdge)
+            jEdge = edgesOnEdge(j,iEdge)
+            jEdgeCells(1) = cellsOnEdge(1,jEdge)
+            jEdgeCells(2) = cellsOnEdge(2,jEdge)
+            ne_x = (xCell(jEdgeCells(1)) - xCell(jEdgeCells(2)))
+            ne_y = (yCell(jEdgeCells(1)) - yCell(jEdgeCells(2)))
+            ne_z = (zCell(jEdgeCells(1)) - zCell(jEdgeCells(2)))
+            norm = sqrt(ne_x**2.0 + ne_y**2.0 + ne_z**2.0)
+            ne_x = ne_x/norm
+            ne_y = ne_y/norm
+            ne_z = ne_z/norm
+            BtB(1,1) = BtB(1,1) + areaCVEdge(jEdge) * ne_x * areaCVEdge(jEdge) * ne_x
+            BtB(2,2) = BtB(2,2) + areaCVEdge(jEdge) * ne_y * areaCVEdge(jEdge) * ne_y
+            BtB(3,3) = BtB(3,3) + areaCVEdge(jEdge) * ne_z * areaCVEdge(jEdge) * ne_z
+            BtB(1,2) = BtB(1,2) + areaCVEdge(jEdge) * ne_x * areaCVEdge(jEdge) * ne_y
+            BtB(1,3) = BtB(1,3) + areaCVEdge(jEdge) * ne_x * areaCVEdge(jEdge) * ne_z
+            BtB(2,3) = BtB(2,3) + areaCVEdge(jEdge) * ne_y * areaCVEdge(jEdge) * ne_z
+         end do
+         BtB(1,1) = BtB(1,1) + re_x*re_x
+         BtB(2,2) = BtB(2,2) + re_y*re_y
+         BtB(3,3) = BtB(3,3) + re_z*re_z
+         BtB(1,2) = BtB(1,2) + re_x*re_y
+         BtB(1,3) = BtB(1,3) + re_x*re_z
+         BtB(2,1) = BtB(1,2)
+         BtB(2,3) = BtB(2,3) + re_y*re_z
+         BtB(3,1) = BtB(1,3)
+         BtB(3,2) = BtB(2,3)
+
+         !Calculate the inverse determinant of the matrix
+
+         !print*, iEdge, BtB(1,1), BtB(2,2), BtB(3,3), BtB(1,2), BtB(1,3), BtB(2,1), &
+         !        BtB(2,3), BtB(3,1), BtB(3,2)
+
+         !print*, iEdge, nEdgesOnEdge(iEdge), iEdgeCells(1), iEdgeCells(2), (BtB(1,1)*BtB(2,2)*BtB(3,3) - BtB(1,1)*BtB(2,3)*BtB(3,2)&
+         !       - BtB(1,2)*BtB(2,1)*BtB(3,3) + BtB(1,2)*BtB(2,3)*BtB(3,1)&
+         !       + BtB(1,3)*BtB(2,1)*BtB(3,2) - BtB(1,3)*BtB(2,2)*BtB(3,1))
+
+         if (iEdgeCells(2) > nCellsAll) then 
+            detinv = 0.0_RKIND
+         else
+            detinv = 1.0_RKIND/(BtB(1,1)*BtB(2,2)*BtB(3,3) - BtB(1,1)*BtB(2,3)*BtB(3,2)&
+                   - BtB(1,2)*BtB(2,1)*BtB(3,3) + BtB(1,2)*BtB(2,3)*BtB(3,1)&
+                   + BtB(1,3)*BtB(2,1)*BtB(3,2) - BtB(1,3)*BtB(2,2)*BtB(3,1))
+         end if
+         !print*, iEdge, detinv
+
+         ! Calculate the inverse of the matrix
+         invBtB(1,1,iEdge) = +detinv * (BtB(2,2)*BtB(3,3) - BtB(2,3)*BtB(3,2))
+         invBtB(2,1,iEdge) = -detinv * (BtB(2,1)*BtB(3,3) - BtB(2,3)*BtB(3,1))
+         invBtB(3,1,iEdge) = +detinv * (BtB(2,1)*BtB(3,2) - BtB(2,2)*BtB(3,1))
+         invBtB(1,2,iEdge) = -detinv * (BtB(1,2)*BtB(3,3) - BtB(1,3)*BtB(3,2))
+         invBtB(2,2,iEdge) = +detinv * (BtB(1,1)*BtB(3,3) - BtB(1,3)*BtB(3,1))
+         invBtB(3,2,iEdge) = -detinv * (BtB(1,1)*BtB(3,2) - BtB(1,2)*BtB(3,1))
+         invBtB(1,3,iEdge) = +detinv * (BtB(1,2)*BtB(2,3) - BtB(1,3)*BtB(2,2))
+         invBtB(2,3,iEdge) = -detinv * (BtB(1,1)*BtB(2,3) - BtB(1,3)*BtB(2,1))
+         invBtB(3,3,iEdge) = +detinv * (BtB(1,1)*BtB(2,2) - BtB(1,2)*BtB(2,1))
+      end do
+      call mpas_dmpar_field_halo_exch(domain, 'invBtB')
+
+      deallocate(BtB)
+
+   end subroutine buildInvMatrixBtB
+
+   subroutine inv_3x3(amat,adim,ainv,vdim, adet)
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! inv3x3 computes the inverse of a 3x3 matrix 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+       implicit none
+
+   !------------------------------------------- arguments !
+       integer, intent( in) :: adim
+       real (kind=RKIND), intent( in) :: amat(adim,*)
+       integer, intent( in) :: vdim
+       real (kind=RKIND), intent(out) :: ainv(vdim,*)
+       real (kind=RKIND), intent(out) :: adet
+
+   !------------------------------------------- variables !
+       real (kind=RKIND) :: &
+       aa2233,aa2332,aa2133,aa2331,aa2132, &
+       aa2231,aa1233,aa1332,aa1223,aa1322, &
+       aa1133,aa1331,aa1123,aa1321,aa1132, &
+       aa1231,aa1122,aa1221
+
+   !------------------------------------------- form A^-1 !
+       aa2233 = amat(2,2) * amat(3,3)
+       aa2332 = amat(2,3) * amat(3,2)
+       aa2133 = amat(2,1) * amat(3,3)
+       aa2331 = amat(2,3) * amat(3,1)
+       aa2132 = amat(2,1) * amat(3,2)
+       aa2231 = amat(2,2) * amat(3,1)
+
+       adet =  &
+       amat(1,1) *  (aa2233 - aa2332) - &
+           amat(1,2) *  (aa2133 - aa2331) + &
+           amat(1,3) *  (aa2132 - aa2231)
+
+       aa1233 = amat(1,2) * amat(3,3)
+       aa1332 = amat(1,3) * amat(3,2)
+       aa1223 = amat(1,2) * amat(2,3)
+       aa1322 = amat(1,3) * amat(2,2)
+       aa1133 = amat(1,1) * amat(3,3)
+       aa1331 = amat(1,3) * amat(3,1)
+       aa1123 = amat(1,1) * amat(2,3)
+       aa1321 = amat(1,3) * amat(2,1)
+       aa1132 = amat(1,1) * amat(3,2)
+       aa1231 = amat(1,2) * amat(3,1)
+       aa1122 = amat(1,1) * amat(2,2)
+       aa1221 = amat(1,2) * amat(2,1)
+
+       ainv(1,1) =  (aa2233 - aa2332)
+       ainv(1,2) = -(aa1233 - aa1332)
+       ainv(1,3) =  (aa1223 - aa1322)
+
+       ainv(2,1) = -(aa2133 - aa2331)
+       ainv(2,2) =  (aa1133 - aa1331)
+       ainv(2,3) = -(aa1123 - aa1321)
+
+       ainv(3,1) =  (aa2132 - aa2231)
+       ainv(3,2) = -(aa1132 - aa1231)
+       ainv(3,3) =  (aa1122 - aa1221)
+
+       return
+
+   end subroutine inv_3x3
+
+   subroutine Wlsqr(domain, meshPool)
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! buildMatrixBtB computes the least square weightsOnEdge needed for the
+   ! computation of the kinetic energy in the TRiSK++ discretization 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (mpas_pool_type), intent(inout) :: meshPool
+      type (domain_type), intent(inout) :: domain
+      integer :: iEdge, jEdge, iEoE, i, j, k, cell1
+      integer, dimension(2) :: iEdgeCells, jEdgeCells
+      real (kind=RKIND) :: re_x, re_y, re_z, ne_x, ne_y, ne_z, norm, xTangent, yTangent, zTangent, normTangent, detinv   
+      real (kind=RKIND), dimension(:), pointer :: areaCVEdge
+      real (kind=RKIND), dimension(:,:,:), pointer :: invBtB
+
+      real (kind=RKIND), pointer :: sphere_radius
+      real (kind=RKIND) :: tmat(25,3), matt(3,25), rmat(3,3), rinv(3,3), &
+                           rdet, xmul, ymul, zmul
+      real (kind=RKIND), dimension(:), allocatable :: elen
+      real (kind=RKIND), dimension(:,:), allocatable :: enrm, edir, eprp
+
+      call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+      call mpas_pool_get_array(meshPool, 'areaCVEdge', areaCVEdge) 
+      call mpas_pool_get_array(meshPool, 'invBtB', invBtB)
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr', weightsOnEdge_lsqr)
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
+
+      allocate(enrm(nEdgesHalo(3),3))
+      allocate(edir(nEdgesAll,3))
+      allocate(eprp(nEdgesHalo(3),3))
+      allocate(elen(nEdgesAll))
+
+   !- build lsqr weights for each edge in the mesh
+      do iEdge = 1, nEdgesHalo(3)
+         tmat(:,:) = 0.0_RKIND
+         matt(:,:) = 0.0_RKIND
+         rmat(:,:) = 0.0_RKIND
+         rinv(:,:) = 0.0_RKIND
+
+      !- unit tangent (on spherical surface) to each edge (in E^3)
+         eprp(iEdge,1) = xVertex(verticesOnEdge(2,iEdge)) - &
+                    xVertex(verticesOnEdge(1,iEdge))
+         eprp(iEdge,2) = yVertex(verticesOnEdge(2,iEdge)) - &
+                    yVertex(verticesOnEdge(1,iEdge))
+         eprp(iEdge,3) = zVertex(verticesOnEdge(2,iEdge)) - &
+                    zVertex(verticesOnEdge(1,iEdge))
+
+         norm = sqrt(eprp(iEdge,1)**2 + eprp(iEdge,2)**2 + eprp(iEdge,3)**2)
+
+         eprp(iEdge,1) = eprp(iEdge,1) / norm
+         eprp(iEdge,2) = eprp(iEdge,2) / norm
+         eprp(iEdge,3) = eprp(iEdge,3) / norm
+
+      !- unit normals (to spherical surface) at each edge
+         enrm(iEdge,1) = xEdge(iEdge) / sphere_radius
+         enrm(iEdge,2) = yEdge(iEdge) / sphere_radius
+         enrm(iEdge,3) = zEdge(iEdge) / sphere_radius
+
+      !- assemble lsqr matrix T: n_hat dot u = u_e
+         tmat(1,1) = enrm(iEdge,1)
+         tmat(1,2) = enrm(iEdge,2)
+         tmat(1,3) = enrm(iEdge,3)
+
+         do jEdge = 1, nEdgesOnEdge(iEdge)
+            iEoE = edgesOnEdge(jEdge,iEdge)
+
+         !- unit normals (on spherical surface) to each edge (in E^3)
+            if (cellsOnEdge(2,iEoE)>nCellsAll) then
+               cell1 = cellsOnEdge(1,iEoE)
+               !do i = 1, nEdgesOnCell(cell1)
+               !   if(iEoE == edgesOnCell(i,cell1)) then  
+               !      edir(iEoE,1) = edgeSignOnCell(i,cell1)*(xEdge(iEoE) - xCell(cell1))
+               !      edir(iEoE,2) = edgeSignOnCell(i,cell1)*(yEdge(iEoE) - yCell(cell1))
+               !      edir(iEoE,3) = edgeSignOnCell(i,cell1)*(zEdge(iEoE) - zCell(cell1))
+               !   end if
+               !end do
+               edir(iEoE,1) = xEdge(iEoE) - xCell(cell1)
+               edir(iEoE,2) = yEdge(iEoE) - yCell(cell1)
+               edir(iEoE,3) = zEdge(iEoE) - zCell(cell1)
+            else
+               edir(iEoE,1) = xCell(cellsOnEdge(2,iEoE)) - &
+                            xCell(cellsOnEdge(1,iEoE))
+               edir(iEoE,2) = yCell(cellsOnEdge(2,iEoE)) - &
+                            yCell(cellsOnEdge(1,iEoE))
+               edir(iEoE,3) = zCell(cellsOnEdge(2,iEoE)) - &
+                            zCell(cellsOnEdge(1,iEoE))
+            end if 
+
+            elen(iEoE) = sqrt(edir(iEoE,1)**2 + edir(iEoE,2)**2 + edir(iEoE,3)**2)
+
+           ! if(iEdge==2380) then
+           !    print*, jEdge, cellsOnEdge(1,iEoE), cellsOnEdge(2,iEoE), xCell(cellsOnEdge(2,iEoE)), yCell(cellsOnEdge(2,iEoE)), zCell(cellsOnEdge(2,iEoE)), elen(iEoE)
+           ! end if
+
+            edir(iEoE,1) = edir(iEoE,1) / elen(iEoE)
+            edir(iEoE,2) = edir(iEoE,2) / elen(iEoE)
+            edir(iEoE,3) = edir(iEoE,3) / elen(iEoE)
+
+            tmat(jEdge+1,1) = edir(iEoE,1)
+            tmat(jEdge+1,2) = edir(iEoE,2)
+            tmat(jEdge+1,3) = edir(iEoE,3)
+         end do
+
+      !- form lsqr matrices: (T'*T) * u = T' * u_e
+         matt = transpose(tmat)
+
+         rmat = matmul(matt,tmat)
+
+      !- factorise matrices: r_inv = (T'*T) ^ -1
+         call inv_3x3(rmat, 3, rinv, 3, rdet)
+
+      !- assemble lsqr weight: t_hat dot r_inv * T'
+         do jEdge = 1, nEdgesOnEdge(iEdge)
+            xmul = ( &
+               rinv(1,1) * matt(1,jEdge+1) + &
+               rinv(1,2) * matt(2,jEdge+1) + &
+               rinv(1,3) * matt(3,jEdge+1) &
+            ) / rdet
+
+            ymul = ( &
+               rinv(2,1) * matt(1,jEdge+1) + &
+               rinv(2,2) * matt(2,jEdge+1) + &
+               rinv(2,3) * matt(3,jEdge+1) &
+            ) / rdet
+
+            zmul = ( &
+               rinv(3,1) * matt(1,jEdge+1) + &
+               rinv(3,2) * matt(2,jEdge+1) + &
+               rinv(3,3) * matt(3,jEdge+1) &
+            ) / rdet
+
+            weightsOnEdge_lsqr(jEdge,iEdge) = &
+               eprp(iEdge,1) * xmul + &
+               eprp(iEdge,2) * ymul + &
+               eprp(iEdge,3) * zmul
+
+            if(iEdge==2380) then
+            !   print*, jEdge, xmul, rinv(1,1), rinv(1,2), rinv(1,3), matt(1,jEdge+1), matt(2,jEdge+1), matt(3,jEdge+1), rdet 
+               print*, jEdge, eprp(iEdge,1), eprp(iEdge,2), eprp(iEdge,3), xmul, ymul, zmul, weightsOnEdge_lsqr(jEdge,iEdge), weightsOnEdge(jEdge,iEdge)
+            end if 
+
+         end do
+      end do
+
+      call mpas_dmpar_field_halo_exch(domain, 'weightsOnEdge_lsqr')
+
+      !do iEdge = 1, nEdgesAll
+      !   do jEdge = 1, nEdgesOnEdge(iEdge)
+      !      if (weightsOnEdge_lsqr(jEdge,iEdge) > 1.0_RKIND) then
+      !      print*, iEdge, cellsOnEdge(1,iEdge), cellsOnEdge(2,iEdge), weightsOnEdge_lsqr(jEdge,iEdge), weightsOnEdge(jEdge,iEdge)
+      !      end if
+      !   end do
+      !end do
+
+      deallocate(eprp)
+      deallocate(edir)
+      deallocate(enrm)
+      deallocate(elen) 
+
+   end subroutine Wlsqr
+
+
+   real function sphericalTriangleArea(laEdge, loEdge, laVertex, loVertex, laCell, loCell)
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! sphericalTriangleArea uses the spherical analog of Heron's formula to
+   ! compute the area of a triangle on the surface of a sphere
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      real (kind=RKIND), intent(in) :: laEdge, loEdge, laVertex, loVertex, laCell, loCell
+      real (kind=RKIND) :: tanqe, s, a, b, c, one, radius
+      one = 1.0
+      radius = 6371220.0 
+
+      a = sphere_distance(laCell, loCell, laVertex, loVertex, one)
+      b = sphere_distance(laCell, loCell, laEdge, loEdge, one)
+      c = sphere_distance(laEdge, loEdge, laVertex, loVertex, one)
+      s = 0.5*(a+b+c)
+      !print*, 'printing a, b, c e s', a, b, c, s 
+      !print*, 'printing tan', tan(0.5*s), tan(0.5*(s-a)), tan(0.5*(s-b)),
+      !tan(0.5*(s-c))
+
+      tanqe = sqrt(tan(0.5*s)*tan(0.5*(s-a))*tan(0.5*(s-b))*tan(0.5*(s-c)))
+      sphericalTriangleArea = 4.*atan(tanqe)*radius**2
+
+      !print*, 'printing a, b, c, s e tanqe', a, b, c, s, tanqe
+
+   end function sphericalTriangleArea
+
+   real function sphere_distance(lat1, lon1, lat2, lon2, radius)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Compute the great-circle distance between (lat1, lon1) and (lat2, lon2) on
+   ! a sphere with given radius.
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      real (kind=RKIND), intent(in) :: lat1, lon1, lat2, lon2, radius
+
+      real (kind=RKIND) :: arg1
+
+      arg1 = sqrt( sin(0.5*(lat2-lat1))**2 +  &
+                   cos(lat1)*cos(lat2)*sin(0.5*(lon2-lon1))**2 )
+      sphere_distance = 2.*radius*asin(arg1)
+
+   end function sphere_distance
+
+
+end module ocn_ke_triskCV
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -30,7 +30,7 @@ module ocn_mesh
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_constants
-   use mpas_log
+   use mpas_log 
 
    use ocn_config
 
@@ -144,6 +144,7 @@ module ocn_mesh
 
    real(kind=RKIND), public, dimension(:, :), pointer :: &
       weightsOnEdge, &! weights on each edge
+      weightsOnEdge_lsqr, &
       kiteAreasOnVertex, &! real (vertexDegree nVertices)
       edgeTangentVectors, &! tangent unit vector at edge
       edgeNormalVectors, &! normal  unit vector at edge
@@ -436,6 +437,8 @@ contains
                                areaTriangle)
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
+      call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr', &
+                               weightsOnEdge_lsqr)
       call mpas_pool_get_array(meshPool, 'bottomDepth', &
                                bottomDepth)
       call mpas_pool_get_array(meshPool, 'refBottomDepth', &
@@ -455,6 +458,8 @@ contains
 
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
+      call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr', &
+                               weightsOnEdge_lsqr)
       call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', &
                                kiteAreasOnVertex)
       call mpas_pool_get_array(meshPool, 'edgeTangentVectors', &
@@ -649,6 +654,7 @@ contains
          !$acc                   edgeSignOnCell,           &
          !$acc                   edgeSignOnVertex,         &
          !$acc                   weightsOnEdge,            &
+         !$acc                   weightsOnEdge_lsqr,       &
          !$acc                   kiteAreasOnVertex,        &
          !$acc                   edgeTangentVectors,       &
          !$acc                   edgeNormalVectors,        &
@@ -778,6 +784,7 @@ contains
       !$acc                  edgeSignOnCell,    &
       !$acc                  edgeSignOnVertex,  &
       !$acc                  weightsOnEdge,     &
+      !$acc                  weightsOnEdge_lsqr,  &
       !$acc                  kiteAreasOnVertex, &
       !$acc                  edgeTangentVectors,&
       !$acc                  edgeNormalVectors, &
@@ -859,6 +866,7 @@ contains
                meshDensity, &
                angleEdge, &
                weightsOnEdge, &
+               weightsOnEdge_lsqr, &
                kiteAreasOnVertex, &
                edgeTangentVectors, &
                edgeNormalVectors, &
@@ -1031,6 +1039,8 @@ contains
       !                                    areaTriangle)
       !call mpas_pool_get_array(meshPool, 'weightsOnEdge',     &
       !                                    weightsOnEdge)
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr',     &
+      !                                    weightsOnEdge_lsqr)
       !call mpas_pool_get_array(meshPool, 'bottomDepth',       &
       !                                    bottomDepth)
       !call mpas_pool_get_array(meshPool, 'refBottomDepth',    &
@@ -1050,6 +1060,8 @@ contains
       !
       !call mpas_pool_get_array(meshPool, 'weightsOnEdge',             &
       !                                    weightsOnEdge)
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge_lsqr',             &
+      !                                    weightsOnEdge_lsqr)
       !call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex',         &
       !                                    kiteAreasOnVertex)
       !call mpas_pool_get_array(meshPool, 'edgeTangentVectors',        &
@@ -1205,6 +1217,7 @@ contains
       !$acc               edgeSignOnCell,           &
       !$acc               edgeSignOnVertex,         &
       !$acc               weightsOnEdge,            &
+      !$acc               weightsOnEdge_lsqr,       &
       !$acc               kiteAreasOnVertex,        &
       !$acc               edgeTangentVectors,       &
       !$acc               edgeNormalVectors,        &


### PR DESCRIPTION
Changed the way the kinetic energy is computed. Now kineticEnergyCell is mapped from kineticEnergyEdge and for the construction of kineticEnergyEdge new weightsOnEdge are computed based on a least-square approach. On init, a new subroutine that computes these weightsOnEdge_lsqr is called.