### PR TITLE
KPP improvements (AMOC PR 6/6)

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2513,6 +2513,10 @@
 			 description="potential density: density displaced adiabatically to the mid-depth of top layer"
 			 packages="forwardMode;analysisMode"
 		/>
+	    <var name="sfcParcelDensity" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3}"
+			 description="density of a surface layer averaged parcel displaced adiabatically to middle of a given layer"
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="inSituThermalExpansionCoeff"
 			 type="real" dimensions="nVertLevels nCells Time" units="C^{-1}"
 			 description="Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign).  This is in situ, i.e. not displaced to another depth."

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -50,6 +50,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: density
    real (kind=RKIND), dimension(:,:), pointer :: displaceddensity
    real (kind=RKIND), dimension(:,:), pointer :: potentialdensity
+   real (kind=RKIND), dimension(:,:), pointer :: sfcParcelDensity
    real (kind=RKIND), dimension(:,:), pointer :: montgomeryPotential
    real (kind=RKIND), dimension(:,:), pointer :: pressure
    real (kind=RKIND), dimension(:,:), pointer :: thermExpCoeff
@@ -543,6 +544,8 @@ contains
                 displacedDensity)
       call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
                 potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'sfcParcelDensity', &
+                sfcParcelDensity)
       call mpas_pool_get_array(diagnosticsPool, &
                'inSituThermalExpansionCoeff', &
                 thermExpCoeff)
@@ -808,6 +811,7 @@ contains
       !$acc                   sfcFlxAttCoeff,                          &
       !$acc                   surfacePressure,                         &
       !$acc                   potentialDensity,                        &
+      !$acc                   sfcParcelDensity,                        &
       !$acc                   displacedDensity,                        &
       !$acc                   boundaryLayerDepth,                      &
       !$acc                   salineContractCoeff,                     &
@@ -1044,6 +1048,7 @@ contains
       !$acc                   sfcFlxAttCoeff,                          &
       !$acc                   surfacePressure,                         &
       !$acc                   potentialDensity,                        &
+      !$acc                   sfcParcelDensity,                        &
       !$acc                   displacedDensity,                        &
       !$acc                   boundaryLayerDepth,                      &
       !$acc                   salineContractCoeff,                     &
@@ -1229,6 +1234,7 @@ contains
               sfcFlxAttCoeff,                          &
               surfacePressure,                         &
               potentialDensity,                        &
+              sfcParcelDensity,                        &
               displacedDensity,                        &
               boundaryLayerDepth,                      &
               salineContractCoeff,                     &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -85,7 +85,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, tracersPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -97,6 +97,8 @@ contains
          meshPool          !< Input: mesh information
 
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
+
+      type (mpas_pool_type), intent(in) :: tracersPool
 
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
@@ -186,7 +188,7 @@ contains
       !$acc update host(vertViscTopOfEdge, vertDiffTopOfCell)
 #endif
 
-      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err1, timeLevel)
+      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, tracersPool, err1, timeLevel)
       call ocn_vmix_coefs_redi_build(meshPool, statePool, err2, timeLevel)
       call ocn_vmix_coefs_gotm_build(statePool, forcingPool, err3, timeLevel)
 
@@ -1117,7 +1119,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'bottomDrag', bottomDrag)
 
       call mpas_timer_start('vmix coefs', .false.)
-      call ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevel)
+      call ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, tracersPool, err, timeLevel)
       call mpas_timer_stop('vmix coefs')
 
       ! if using CVMix, then viscosity has to be averaged from cell centers to cell edges

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -19,6 +19,7 @@ module ocn_vmix_cvmix
    use mpas_constants
    use mpas_log
 
+   use ocn_equation_equation_of_state
    use ocn_constants
    use ocn_config
    use ocn_mesh
@@ -96,7 +97,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, tracersPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -105,7 +106,8 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
+         meshPool,          &!< Input: mesh information
+         tracersPool         !< Input: tracer information
 
       integer, intent(in), optional :: timeLevelIn !< Input: time level for state pool
 
@@ -152,19 +154,24 @@ contains
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, cellsOnCell, cellMask
 
       integer :: k, i, iCell, iNeighbor, timeLevel, kIndexOBL, kav, iEdge, nCells
-      integer :: edgeCount, nEdges, topIndex, nsmooth, kpp_stage
+      integer :: edgeCount, nEdges, topIndex, nsmooth, kpp_stage, iTracer
       integer, pointer :: nVertLevels, nVertLevelsP1
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), allocatable :: surfaceAverageIndex
+      integer, dimension(:,:), allocatable :: surfaceAverageIndex
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       real (kind=RKIND) :: x, bulkRichardsonNumberStop, sfc_layer_depth
       real (kind=RKIND) :: normalVelocityAv, delU2, areaSum, blTemp
       real (kind=RKIND) :: sigma
-      real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, turbulentScalarVelocityScale, &
+      real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, layerThicknessEdgeSum, &
                                                       deltaVelocitySquared, normalVelocitySum, &
                                                       potentialDensitySum, RiTemp,              &
-                                                      layerThicknessSum, layerThicknessEdgeSum
+                                                      layerThicknessSum, tracerTmp 
       real (kind=RKIND), dimension(:), allocatable, target :: RiSmoothed, BVFSmoothed, OBLDepths, interfaceForcings
+      real (kind=RKIND), dimension(:,:), allocatable :: turbulentScalarVelocityScale, zw_iface, &
+                                                        zt_cntr
+      real (kind=RKIND), dimension(:,:,:), allocatable :: tracersSum
       logical :: bulkRichardsonFlag
 
       real (kind=RKIND) :: langmuirEnhancementFactor, langmuirNumber
@@ -225,6 +232,7 @@ contains
       call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
@@ -271,12 +279,11 @@ contains
       allocate(cvmix_variables % Mdiff_iface(nVertLevels+1))
       allocate(cvmix_variables % Tdiff_iface(nVertLevels+1))
       allocate(cvmix_variables % Sdiff_iface(nVertLevels+1))
-      allocate(cvmix_variables % zw_iface(nVertLevels+1))
-      allocate(cvmix_variables % dzw(nVertLevels+1))
-      allocate(cvmix_variables % zt_cntr(nVertLevels))
-      allocate(cvmix_variables % dzt(nVertLevels))
       allocate(cvmix_variables % kpp_Tnonlocal_iface(nVertLevels+1))
       allocate(cvmix_variables % kpp_Snonlocal_iface(nVertLevels+1))
+
+      allocate(zw_iface(nVertLevels+1,nCells))
+      allocate(zt_cntr(nVertLevels,nCells))
 
       ! Initialize some of the cvmix variables that are not set later.
       cvmix_variables % Mdiff_iface(1:nVertLevels+1) = 0.0_RKIND
@@ -285,27 +292,108 @@ contains
 
       allocate(OBLDepths(nVertLevels))
       allocate(interfaceForcings(nVertLevels))
-
+      allocate(tracerTmp(nVertLevels))
       allocate(Nsqr_iface(nVertLevels+1))
-      allocate(turbulentScalarVelocityScale(nVertLevels))
+      allocate(turbulentScalarVelocityScale(nVertLevels,nCells))
       allocate(RiSmoothed(nVertLevels+1))
       allocate(BVFSmoothed(nVertLevels+1))
       allocate(RiTemp(nVertLevels+1))
 
       allocate(normalVelocitySum(nVertLevels))
-      allocate(potentialDensitySum(nVertLevels))
-      allocate(surfaceAverageIndex(nVertLevels))
+      allocate(tracersSum(2,nVertLevels,nCells)) 
+      allocate(surfaceAverageIndex(nVertLevels,nCells))
       allocate(deltaVelocitySquared(nVertLevels))
       allocate(layerThicknessSum(nVertLevels))
       allocate(layerThicknessEdgeSum(nVertLevels))
 
       do k = 1, nVertLevels
          Nsqr_iface(k) = 0.0_RKIND
-         turbulentScalarVelocityScale(k) = 0.0_RKIND
+         turbulentScalarVelocityScale(k,:) = 0.0_RKIND
       end do
       Nsqr_iface(nVertLevelsP1) = 0.0_RKIND
 
       call mpas_timer_start('cvmix cell loop', .false.)
+            do iCell=1,nCells                                                                                                                                                                                                                                               do k = 1, minLevelCell(iCell) - 1
+            zw_iface(k,iCell) = 0.0_RKIND
+            zt_cntr(k,iCell) = 0.0_RKIND
+         enddo
+         zw_iface(minLevelCell(iCell),iCell) = 0.0_RKIND
+         zt_cntr(minLevelCell(iCell),iCell) = -layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+         do k=minLevelCell(iCell)+1,maxLevelCell(iCell)
+            zw_iface(k,iCell) = zw_iface(k-1,iCell) - layerThickness(k-1,iCell)
+            zt_cntr(k,iCell) = zw_iface(k,iCell) - layerThickness(k,iCell)/2.0_RKIND
+         enddo
+         k = maxLevelCell(iCell)+1
+         zw_iface(k,iCell) = zw_iface(k-1,iCell) - layerThickness(k-1,iCell)
+         do k = maxLevelCell(iCell) + 1, nVertLevels
+            zw_iface(k+1,iCell) = zw_iface(maxLevelCell(iCell)+1,iCell)
+            zt_cntr(k,iCell) = zw_iface(maxLevelCell(iCell)+1,iCell)
+         enddo
+      enddo
+
+      do iCell=1,nCells
+      ! compute bulk Richardson number
+              ! assume boundary layer depth is at bottom of every kIndexOBL cell
+              topIndex = minLevelCell(iCell)
+!             call mpas_timer_start('Bulk Richardson kIndexOBL loops')
+              ! compute the index of the last cell in the KPP defined surface layer
+              ! this index is used for the necessary surface layer averages of buoyancy and momentum
+              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
+
+                 ! Reset deltaVelocitySquared and bulkRichardsonNumber at this layer for the later computation
+                 deltaVelocitySquared(kIndexOBL) = 0.0_RKIND
+                 bulkRichardsonNumber(kIndexOBL, iCell) = 0.0_RKIND
+
+                 ! set OBL at bottom of kIndexOBL cell for computation of bulk Richardson number
+                 OBLDepths(kIndexOBL) = abs(zw_iface(kIndexOBL+1,iCell))
+!                cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables % zw_iface(kIndexOBL+1))
+                 sigma = -zt_cntr(kIndexOBL,iCell) / OBLDepths(kIndexOBL)
+
+                 interfaceForcings(kIndexOBL) = surfaceBuoyancyForcing(iCell)
+
+                 ! initialize the surfaceAverageIndex for cases when the if statement below is not true
+                 surfaceAverageIndex(kIndexOBL,iCell) = minLevelCell(iCell)
+                 ! move progressively downward to find the bottom most layer within the surface layer
+                 sfc_layer_depth = OBLDepths(kIndexOBL) * config_cvmix_kpp_surface_layer_extent
+                 do kav=topIndex,kIndexOBL
+                    if(zw_iface(kav+1,iCell) < -sfc_layer_depth) then
+                       surfaceAverageIndex(kIndexOBL,iCell) = kav
+                       exit
+                    end if
+                 enddo
+                 topIndex = max(1, surfaceAverageIndex(kIndexOBL,iCell) - 1)
+              end do
+              stable = 0.5_RKIND + SIGN(0.5_RKIND,surfaceBuoyancyForcing(iCell))
+              sigma = stable + (1.0_RKIND - stable)*config_cvmix_kpp_surface_layer_extent
+              ! compute the turbulent scales in order to compute the bulk Richardson number
+              call cvmix_kpp_compute_turbulent_scales( &
+                   sigma_coord = sigma, &
+                   OBL_depth = OBLDepths(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_buoy_force = interfaceForcings(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_fric_vel = surfaceFrictionVelocity(iCell), &
+                   w_s = turbulentScalarVelocityScale(minLevelCell(iCell):maxLevelCell(iCell),iCell))
+
+                 !redo me for T&S
+                 !check all variale declarations
+              do iTracer=1,2
+                 tracerTmp(minLevelCell(iCell)) = activeTracers(iTracer,minLevelCell(iCell), iCell)* &
+                                                         layerThickness(minLevelCell(iCell), iCell)
+                 layerThicknessSum(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell), iCell)
+                 do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
+                    layerThicknessSum(kIndexOBL) = layerThicknessSum(kIndexOBL-1) + layerThickness(kIndexOBL, iCell)
+                    tracerTmp(kIndexOBL) = tracerTmp(kIndexOBL-1) + &
+                                   layerThickness(kIndexOBL, iCell)*activeTracers(iTracer, kIndexOBL, iCell)
+                 end do
+                 do kIndexOBL = minLevelCell(iCell),maxLevelCell(iCell)
+                    tracersSum(iTracer,kIndexOBL,iCell) = tracerTmp(surfaceAverageIndex(kIndexOBL,iCell)) &
+                                    / layerThicknessSum(surfaceAverageIndex(kIndexOBL,iCell))
+                 end do
+              end do
+
+      enddo
+      !with the tracerSum being the sfc average for each, call density eos
+       call ocn_equation_of_state_density(statePool, meshPool, tracersSum, tracersSurfaceValue, nCells, 0, &
+                          'relative', sfcParcelDensity, err, timeLevelIn=2)
       do kpp_stage = 1,2
       ! TODO, mdt: determine where the openmp data race is coming from in this loop
 !      !$omp parallel
@@ -318,39 +406,6 @@ contains
 !      !$omp         layerThicknessSum, blTemp) &
 !      !$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
       do iCell = 1, nCells
-
-         ! specify geometry/location
-         cvmix_variables % SeaSurfaceHeight = ssh(iCell)
-         cvmix_variables % Coriolis = fCell(iCell)
-         cvmix_variables % lat = latCell(iCell) * 180.0_RKIND / 3.14_RKIND
-         cvmix_variables % lon = lonCell(iCell) * 180.0_RKIND / 3.14_RKIND
-
-         ! fill vertical position of column
-         ! CVMix assume top of ocean is at z=0, so building all z-coordinate data based on layerThickness
-         do k = 1, minLevelCell(iCell) - 1
-            cvmix_variables % zw_iface(k) = 0.0_RKIND
-            cvmix_variables % zt_cntr(k) = 0.0_RKIND
-            cvmix_variables % dzw(k) = 0.0_RKIND
-            cvmix_variables % dzt(k) = 0.0_RKIND
-         enddo
-         cvmix_variables % zw_iface(minLevelCell(iCell)) = 0.0_RKIND
-         cvmix_variables % dzw(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
-         cvmix_variables % zt_cntr(minLevelCell(iCell)) = -layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
-         do k=minLevelCell(iCell)+1,maxLevelCell(iCell)
-            cvmix_variables % zw_iface(k) = cvmix_variables % zw_iface(k-1) - layerThickness(k-1,iCell)
-            cvmix_variables % zt_cntr(k) = cvmix_variables %  zw_iface(k) - layerThickness(k,iCell)/2.0_RKIND
-            cvmix_variables % dzw(k) = cvmix_variables % zt_cntr(k-1) - cvmix_variables % zt_cntr(k)
-            cvmix_variables % dzt(k) = layerThickness(k,iCell)
-         enddo
-         k = maxLevelCell(iCell)+1
-         cvmix_variables % zw_iface(k) = cvmix_variables % zw_iface(k-1) - layerThickness(k-1,iCell)
-         cvmix_variables % dzw(k) = cvmix_variables % zt_cntr(k-1) - cvmix_variables % zw_iface(k)
-         do k = maxLevelCell(iCell) + 1, nVertLevels
-            cvmix_variables % zw_iface(k+1) = cvmix_variables % zw_iface(maxLevelCell(iCell)+1)
-            cvmix_variables % zt_cntr(k) = cvmix_variables % zw_iface(maxLevelCell(iCell)+1)
-            cvmix_variables % dzw(k+1) = 0.0_RKIND
-            cvmix_variables % dzt(k) = 0.0_RKIND
-         enddo
 
          ! fill the intent(in) convective adjustment
          cvmix_variables % nlev = maxLevelCell(iCell)
@@ -402,8 +457,6 @@ contains
          cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed(minLevelCell(iCell):maxLevelCell(iCell)+1)
 
          ! fill the intent(in) KPP
-         cvmix_variables % SurfaceFriction = surfaceFrictionVelocity(iCell)
-         cvmix_variables % SurfaceBuoyancyForcing = surfaceBuoyancyForcing(iCell)
          cvmix_variables % BulkRichardson_cntr => bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell), iCell)
 
          if (kpp_stage == 2) then
@@ -417,16 +470,6 @@ contains
                  cvmix_variables, &
                  cvmix_shear_params)
             ! add shear mixing to vertical viscosity/diffusivity
-            ! at present, shear mixing adds in background values when using PP, but background is
-            ! accounted for seperately. so remove bac    kground from shear mixing values
-
-            if(cvmixShearMixingChoice==cvmixShearMixingTypePP) then
-               do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
-                  cvmix_variables % Mdiff_iface(k) = cvmix_variables % Mdiff_iface(k) - config_cvmix_background_viscosity
-                  cvmix_variables % Tdiff_iface(k) = cvmix_variables % Tdiff_iface(k) - config_cvmix_background_diffusion
-               end do
-            endif
-
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + cvmix_variables % Mdiff_iface(k)
                vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + cvmix_variables % Tdiff_iface(k)
@@ -439,11 +482,11 @@ contains
 
           if (kpp_stage==1) then
             if (config_use_cvmix_fixed_boundary_layer) then
-               cvmix_variables % BoundaryLayerDepth = config_cvmix_kpp_boundary_layer_depth
-               cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
-                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+               boundaryLayerDepth(iCell) = config_cvmix_kpp_boundary_layer_depth
+               indexBoundaryLayerDepth(iCell) = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell), &
+                          zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &
+                          OBL_depth = boundaryLayerDepth(iCell) )
 
             else
 
@@ -473,48 +516,6 @@ contains
                  langmuirEnhancementFactor = 1.0_RKIND
               end if
 
-              ! compute bulk Richardson number
-              ! assume boundary layer depth is at bottom of every kIndexOBL cell
-              bulkRichardsonNumberStop = config_cvmix_kpp_stop_OBL_search * config_cvmix_kpp_criticalBulkRichardsonNumber
-              bulkRichardsonFlag = .false.
-              topIndex = minLevelCell(iCell)
-!             call mpas_timer_start('Bulk Richardson kIndexOBL loops')
-              ! compute the index of the last cell in the KPP defined surface layer
-              ! this index is used for the necessary surface layer averages of buoyancy and momentum
-              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
-
-                 ! Reset deltaVelocitySquared and bulkRichardsonNumber at this layer for the later computation
-                 deltaVelocitySquared(kIndexOBL) = 0.0_RKIND
-                 bulkRichardsonNumber(kIndexOBL, iCell) = bulkRichardsonNumberStop - 1.0_RKIND
-
-                 ! set OBL at bottom of kIndexOBL cell for computation of bulk Richardson number
-                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables % zw_iface(kIndexOBL+1))
-                 sigma = -cvmix_variables % zt_cntr(kIndexOBL) / cvmix_variables % BoundaryLayerDepth
-
-                 OBLDepths(kIndexOBL) = abs(cvmix_variables % zw_iface(kIndexOBL+1))
-                 interfaceForcings(kIndexOBL) = cvmix_variables % SurfaceBuoyancyForcing
-
-                 ! initialize the surfaceAverageIndex for cases when the if statement below is not true
-                 surfaceAverageIndex(kIndexOBL) = minLevelCell(iCell)
-                 ! move progressively downward to find the bottom most layer within the surface layer
-                 sfc_layer_depth = cvmix_variables % BoundaryLayerDepth * config_cvmix_kpp_surface_layer_extent
-                 do kav=topIndex,kIndexOBL
-                    if(cvmix_variables%zw_iface(kav+1) < -sfc_layer_depth) then
-                       surfaceAverageIndex(kIndexOBL) = kav
-                       exit
-                    end if
-                 enddo
-                 topIndex = max(1, surfaceAverageIndex(kIndexOBL) - 1)
-              end do
-
-              ! compute the turbulent scales in order to compute the bulk Richardson number
-              call cvmix_kpp_compute_turbulent_scales( &
-                   sigma_coord = config_cvmix_kpp_surface_layer_extent, &
-                   OBL_depth = OBLDepths(minLevelCell(iCell):maxLevelCell(iCell)), &
-                   surf_buoy_force = interfaceForcings(minLevelCell(iCell):maxLevelCell(iCell)), &
-                   surf_fric_vel = cvmix_variables % SurfaceFriction, &
-                   w_s = turbulentScalarVelocityScale(minLevelCell(iCell):maxLevelCell(iCell)))
-
               ! averaging over a surface layer assuming that BLdepth is cell bottom
               ! Build deltaVelocitySquared
               do i = 1, nEdgesOnCell(iCell)
@@ -533,20 +534,11 @@ contains
                  end do
 
                  do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
-                    normalVelocityAv = normalVelocitySum(surfaceAverageIndex(kIndexOBL )) / &
-                        layerThicknessEdgeSum(surfaceAverageIndex(kIndexOBL))
+                    normalVelocityAv = normalVelocitySum(surfaceAverageIndex(kIndexOBL, iCell)) / &
+                        layerThicknessEdgeSum(surfaceAverageIndex(kIndexOBL, iCell))
                     delU2 = ( normalVelocityAv - normalVelocity(kIndexOBL, iEdge) )**2
                     deltaVelocitySquared(kIndexOBL) = deltaVelocitySquared(kIndexOBL) + edgeAreaFractionOfCell(i,iCell) * delU2
                  end do
-              end do
-
-              potentialDensitySum(minLevelCell(iCell)) = potentialDensity(minLevelCell(iCell), iCell)* &
-                                                         layerThickness(minLevelCell(iCell), iCell)
-              layerThicknessSum(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell), iCell)
-              do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
-                layerThicknessSum(kIndexOBL) = layerThicknessSum(kIndexOBL-1) + layerThickness(kIndexOBL, iCell)
-                potentialDensitySum(kIndexOBL) = potentialDensitySum(kIndexOBL-1) + &
-                    layerThickness(kIndexOBL, iCell)*potentialDensity(kIndexOBL, iCell)
               end do
 
               do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
@@ -554,52 +546,50 @@ contains
                 !Note that the factor of two is from averaging dot products to cell centers on a C-grid
                 bulkRichardsonNumberShear(kIndexOBL,iCell) = max(2.0_RKIND*deltaVelocitySquared(kIndexOBL), 1.0e-15_RKIND)
 
-                bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity * (potentialDensity(kIndexOBL, iCell) &
-                                  - potentialDensitySum(surfaceAverageIndex(kIndexOBL)) &
-                                  / layerThicknessSum(surfaceAverageIndex(kIndexOBL))) / rho_sw
+                bulkRichardsonNumberBuoy(kIndexOBL,iCell) = gravity*(density(kIndexOBL,iCell) - &
+                                                            sfcParcelDensity(kIndexOBL,iCell)) / rho_sw
               end do ! do kIndexOBL
 !             call mpas_timer_stop('Bulk Richardson kIndexOBL loops')
 
-              cvmix_variables % bulkRichardson_cntr(:) = cvmix_kpp_compute_bulk_Richardson( &
-                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
+              bulkRichardsonNumberBuoy(:,iCell) = cvmix_kpp_compute_bulk_Richardson( &
+                   zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
                    delta_buoy_cntr = bulkRichardsonNumberBuoy(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
                    delta_Vsqr_cntr = bulkRichardsonNumberShear(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
-                   ws_cntr = turbulentScalarVelocityScale(:), &
+                   ws_cntr = turbulentScalarVelocityScale(:,iCell), &
                    Nsqr_iface = Nsqr_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                    EFactor = langmuirEnhancementFactor, &
                    LaSL = langmuirNumber, &
-                   bfsfc = cvmix_variables%SurfaceBuoyancyForcing, &
-                   ustar = cvmix_variables%SurfaceFriction )
-              ! TODO: the surface buoyancy forcing here does not include penetrative solar radiation? <05-09-18, Qing Li> !
+                   bfsfc = surfaceBuoyancyForcing(iCell), &
+                   ustar = surfaceFriction(iCell) )
 
               ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
 
               call cvmix_kpp_compute_OBL_depth(  &
                    Ri_bulk = bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
-                   zw_iface = cvmix_variables % zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
-                   OBL_depth = cvmix_variables % BoundaryLayerDepth, &
+                   zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell), &
+                   OBL_depth = boundaryLayerDepth(iCell), &
                    kOBL_depth = cvmix_variables % kOBL_depth, &
-                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
-                   surf_fric = cvmix_variables % SurfaceFriction, &
-                   surf_buoy = cvmix_variables % SurfaceBuoyancyForcing, &
-                   Coriolis = cvmix_variables % Coriolis)
+                   zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   surf_fric = surfaceFriction(iCell), &
+                   surf_buoy = surfaceBuoyancyForcing(iCell), &
+                   Coriolis = fCell(iCell))
 
              endif  ! if (config_use_cvmix_fixed_boundary_layer) then
 
              ! apply minimum limit to OBL
-             if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND) then
-                cvmix_variables % BoundaryLayerDepth = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
-                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
-                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
-                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+             if(boundaryLayerDepth(iCell) .lt. layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND) then
+                boundaryLayerDepth(iCell) = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+                indexBoundaryLayerDepth(iCell) = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell),&
+                          zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &
+                          OBL_depth = boundaryLayerDepth(iCell) )
              endif
 
              ! apply minimum limit to OBL under sea-ice
              if(iceFraction(iCell).gt.0.15_RKIND) then
-             if(cvmix_variables % BoundaryLayerDepth .lt. configure_cvmix_kpp_minimum_OBL_under_sea_ice) then
-                cvmix_variables % BoundaryLayerDepth = configure_cvmix_kpp_minimum_OBL_under_sea_ice
-                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
+             if(boundaryLayerDepth(iCell) .lt. configure_cvmix_kpp_minimum_OBL_under_sea_ice) then
+                boundaryLayerDepth(iCell) = configure_cvmix_kpp_minimum_OBL_under_sea_ice
+                indexBoundaryLayerDepth(iCell) = cvmix_kpp_compute_kOBL_depth(  &
                           zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
                           zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = cvmix_variables % BoundaryLayerDepth )
@@ -607,16 +597,15 @@ contains
              endif
 
              ! apply maximum limit to OBL
-             if(cvmix_variables % BoundaryLayerDepth .gt. abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))) then
-                cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))
-                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
-                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+             if(boundaryLayerDepth .gt. abs(zt_cntr(maxLevelCell(iCell),iCell))) then
+                boundaryLayerDepth = abs(zt_cntr(maxLevelCell(iCell),iCell))
+                indexBoundaryLayerDepth = cvmix_kpp_compute_kOBL_depth(  &
+                          zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell), &
+                          zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &
+                          OBL_depth = boundaryLayerDepth(iCell) )
 
              endif
 
-             boundaryLayerDepth(iCell) = cvmix_variables % BoundaryLayerDepth
      endif !kpp stage 1 -- boundary layer compute
 
      if (kpp_stage == 2) then
@@ -628,11 +617,11 @@ contains
 
             !must reapply max and min limits to boundaryLayerDepth
             blTemp = max(boundaryLayerDepth(iCell), layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND)
-            boundaryLayerDepth(iCell) = min(blTemp, abs(cvmix_variables%zt_cntr(maxLevelCell(iCell))))
+            boundaryLayerDepth(iCell) = min(blTemp, abs(zt_cntr(maxLevelCell(iCell),iCell)))
 
             cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
+                          zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell), &
+                          zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &
                           OBL_depth = boundaryLayerDepth(iCell) )
 
             ! update Langmuir enhancement factor
@@ -652,8 +641,8 @@ contains
                           Mdiff_out = cvmix_variables % Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
                           Tdiff_out = cvmix_variables % Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
                           Sdiff_out = cvmix_variables % Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
-                          zw = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),            &
-                          zt = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),               &
+                          zw = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell),            &
+                          zt = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),               &
                           old_Mdiff = cvmix_variables%Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
                           old_Tdiff = cvmix_variables%Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
                           old_Sdiff = cvmix_variables%Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
@@ -661,8 +650,8 @@ contains
                           kOBL_depth = cvmix_variables%kOBL_depth,                           &
                           Tnonlocal = cvmix_variables%kpp_Tnonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                           Snonlocal = cvmix_variables%kpp_Snonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
-                          surf_fric = cvmix_variables%SurfaceFriction,                      &
-                          surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
+                          surf_fric = surfaceFrictionVelocity(iCell),                      &
+                          surf_buoy = surfaceBuoyancyForcing(iCell),               &
                           nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 1,             &
                           max_nlev = nVertLevels,         &
                           Langmuir_EFactor = langmuirEnhancementFactor )
@@ -682,6 +671,11 @@ contains
             ! both of these operations are done in ocn_tracer_nonlocalflux_tend routine
             vertNonLocalFlux(index_vertNonLocalFluxTemp,:,iCell) = cvmix_variables % kpp_Tnonlocal_iface(:)
 
+            ! overwrite with a parabolic non local flux formulation
+            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+               sigma = min(1.0_RKIND, abs(zw_iface(k,iCell)) / boundaryLayerDepth(iCell))
+               vertNonLocalFlux(index_vertNonLocalFluxTemp,k,iCell) = (1.0_RKIND - sigma)**2.0
+            end do
     endif ! kpp stage 2
          endif !if (config_use_cvmix_kpp)
 
@@ -775,20 +769,19 @@ contains
       deallocate(cvmix_variables % Mdiff_iface)
       deallocate(cvmix_variables % Tdiff_iface)
       deallocate(cvmix_variables % Sdiff_iface)
-      deallocate(cvmix_variables % zw_iface)
-      deallocate(cvmix_variables % dzw)
-      deallocate(cvmix_variables % zt_cntr)
-      deallocate(cvmix_variables % dzt)
       deallocate(cvmix_variables % kpp_Tnonlocal_iface)
       deallocate(cvmix_variables % kpp_Snonlocal_iface)
 
+      deallocate(zw_iface)
+      deallocate(zt_cntr)
+      deallocate(tracerTmp)
       deallocate(Nsqr_iface)
       deallocate(turbulentScalarVelocityScale)
       deallocate(RiSmoothed)
       deallocate(RiTemp)
       deallocate(BVFSmoothed)
       deallocate(normalVelocitySum)
-      deallocate(potentialDensitySum)
+      deallocate(tracersSum)
       deallocate(surfaceAverageIndex)
       deallocate(deltaVelocitySquared)
       deallocate(layerThicknessEdgeSum)
@@ -1033,7 +1026,8 @@ contains
                surf_layer_ext = config_cvmix_kpp_surface_layer_extent, &
                langmuir_mixing_str = config_cvmix_kpp_langmuir_mixing_opt, &
                langmuir_entrainment_str = config_cvmix_kpp_langmuir_entrainment_opt, &
-               lenhanced_diff = config_cvmix_kpp_use_enhanced_diff)
+               lenhanced_diff = config_cvmix_kpp_use_enhanced_diff, &
+               l_LMD_ws = .true.)
       endif
 
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -19,7 +19,7 @@ module ocn_vmix_cvmix
    use mpas_constants
    use mpas_log
 
-   use ocn_equation_equation_of_state
+   use ocn_equation_of_state
    use ocn_constants
    use ocn_config
    use ocn_mesh
@@ -163,7 +163,7 @@ contains
 
       real (kind=RKIND) :: x, bulkRichardsonNumberStop, sfc_layer_depth
       real (kind=RKIND) :: normalVelocityAv, delU2, areaSum, blTemp
-      real (kind=RKIND) :: sigma
+      real (kind=RKIND) :: sigma, stable
       real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, layerThicknessEdgeSum, &
                                                       deltaVelocitySquared, normalVelocitySum, &
                                                       potentialDensitySum, RiTemp,              &
@@ -313,7 +313,8 @@ contains
       Nsqr_iface(nVertLevelsP1) = 0.0_RKIND
 
       call mpas_timer_start('cvmix cell loop', .false.)
-            do iCell=1,nCells                                                                                                                                                                                                                                               do k = 1, minLevelCell(iCell) - 1
+      do iCell=1,nCells
+         do k = 1, minLevelCell(iCell) - 1
             zw_iface(k,iCell) = 0.0_RKIND
             zt_cntr(k,iCell) = 0.0_RKIND
          enddo
@@ -560,7 +561,7 @@ contains
                    EFactor = langmuirEnhancementFactor, &
                    LaSL = langmuirNumber, &
                    bfsfc = surfaceBuoyancyForcing(iCell), &
-                   ustar = surfaceFriction(iCell) )
+                   ustar = surfaceFrictionVelocity(iCell) )
 
               ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
 
@@ -570,7 +571,7 @@ contains
                    OBL_depth = boundaryLayerDepth(iCell), &
                    kOBL_depth = cvmix_variables % kOBL_depth, &
                    zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
-                   surf_fric = surfaceFriction(iCell), &
+                   surf_fric = surfaceFrictionVelocity(iCell), &
                    surf_buoy = surfaceBuoyancyForcing(iCell), &
                    Coriolis = fCell(iCell))
 
@@ -597,8 +598,8 @@ contains
              endif
 
              ! apply maximum limit to OBL
-             if(boundaryLayerDepth .gt. abs(zt_cntr(maxLevelCell(iCell),iCell))) then
-                boundaryLayerDepth = abs(zt_cntr(maxLevelCell(iCell),iCell))
+             if(boundaryLayerDepth(iCell) .gt. abs(zt_cntr(maxLevelCell(iCell),iCell))) then
+                boundaryLayerDepth(iCell) = abs(zt_cntr(maxLevelCell(iCell),iCell))
                 indexBoundaryLayerDepth = cvmix_kpp_compute_kOBL_depth(  &
                           zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell), &
                           zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -552,7 +552,7 @@ contains
               end do ! do kIndexOBL
 !             call mpas_timer_stop('Bulk Richardson kIndexOBL loops')
 
-              bulkRichardsonNumberBuoy(:,iCell) = cvmix_kpp_compute_bulk_Richardson( &
+              bulkRichardsonNumber(:,iCell) = cvmix_kpp_compute_bulk_Richardson( &
                    zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
                    delta_buoy_cntr = bulkRichardsonNumberBuoy(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
                    delta_Vsqr_cntr = bulkRichardsonNumberShear(minLevelCell(iCell):maxLevelCell(iCell),iCell), &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -591,9 +591,9 @@ contains
              if(boundaryLayerDepth(iCell) .lt. configure_cvmix_kpp_minimum_OBL_under_sea_ice) then
                 boundaryLayerDepth(iCell) = configure_cvmix_kpp_minimum_OBL_under_sea_ice
                 indexBoundaryLayerDepth(iCell) = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
-                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
-                          OBL_depth = cvmix_variables % BoundaryLayerDepth )
+                          zw_iface = zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1,iCell),&
+                          zt_cntr = zt_cntr(minLevelCell(iCell):maxLevelCell(iCell),iCell),    &
+                          OBL_depth = boundaryLayerDepth(iCell) )
              endif
              endif
 


### PR DESCRIPTION
KPP changes that were made by @vanroekel on the branch: https://github.com/E3SM-Project/E3SM/tree/vanroekel/ocean/kpp-updates/components/mpas-ocean/src/shared, rebased to master April 20 2022.

This will be non-BFB for all global runs using KPP (all standard runs). The changes are not protected by flag options, so this is not BFB backwards-compatible.