### PR TITLE
CF-compliant fill value for tracers in ocean

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -227,8 +227,8 @@ contains
             call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroup, 1)
             if ( associated(tracersGroup) ) then
                do iCell=1,nCells
-                  tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) =  -1.0e34_RKIND
-                  tracersGroup(:, 1:minLevelCell(iCell)-1,iCell) =  -1.0e34_RKIND
+                  tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) = MPAS_REAL_FILLVAL
+                  tracersGroup(:, 1:minLevelCell(iCell)-1,iCell) = MPAS_REAL_FILLVAL
                end do
             end if
          end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -26,6 +26,7 @@ module ocn_init_routines
    use mpas_pool_routines
    use mpas_timer
    use mpas_dmpar
+   use mpas_io
    use mpas_constants
 
    use mpas_rbf_interpolation

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -25,6 +25,7 @@ module ocn_vmix
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_timer
+   use mpas_io
    use ocn_mesh
 
    use mpas_constants
@@ -1042,8 +1043,8 @@ contains
                tracers(iTracer,k,iCell) = (rTemp(iTracer,k) - C(k)*tracers(iTracer,k+1,iCell)) / bTemp(k)
             enddo
          enddo
-         tracers(:,1:Nsurf-1,iCell) = -1e34
-         tracers(:,N+1:nVertLevels,iCell) = -1e34
+         tracers(:,1:Nsurf-1,iCell) = MPAS_REAL_FILLVAL
+         tracers(:,N+1:nVertLevels,iCell) = MPAS_REAL_FILLVAL
 
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real" packages="CFCTracersPKG"  default_value="0.0">
+			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="CFCTracersPKG"  default_value="0.0">
 				<!-- Add constituents of tracer group -->
 				<var name="CFC11" array_group="CFCGRP" units="mol m^{-3}"
 			description="CFC11"
@@ -63,7 +63,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersPKG">
+			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="CFC11Tend" array_group="CFCGRP" units="mol m^{-3} s^{-1}"
 			description="CFC11 Tendency"
@@ -77,7 +77,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="CFCTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+			<var_array name="CFCTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="CFC11SurfaceFlux" array_group="CFCSurfaceFluxGRP" units="mol m^{-3} m s^{-1}"
 			description="CFC11 Surface Flux"
@@ -86,7 +86,7 @@
 			description="CFC12 Surface Flux"
 				/>
 			</var_array>
-			<var_array name="CFCTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+			<var_array name="CFCTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="CFCSurfaceFluxRunoff" array_group="CFCSurfaceFluxRunoffGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC11 Surface Flux Due to Runoff"
@@ -95,7 +95,7 @@
 					description="CFC12 Surface Flux Due to Runoff"
 				/>
 			</var_array>
-			<var_array name="CFCTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="CFCTracersPKG">
+			<var_array name="CFCTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="CFCSurfaceFluxRemoved" array_group="CFCSurfaceFluxRemovedGRP" units="mol m^{-3} m s^{-1}"
 					description="CFC11 Surface Flux that is ignored"
@@ -106,7 +106,7 @@
 			</var_array>
 		</var_struct>
 
-		<var_struct name="CFC11FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+		<var_struct name="CFC11FluxDiagnostics" time_levs="1"  missing_value="FILLVAL" packages="CFCTracersPKG">
 			<var name="CFC11_flux_ifrac" type="real" dimensions="nCells Time" units="none"
 				description="Ice Fraction used in CFC11 flux calculation"
 			/>
@@ -132,7 +132,7 @@
 				description="Wind Speed used in CFC11 flux calculation"
 			/>
 		</var_struct>
-		<var_struct name="CFC12FluxDiagnostics" time_levs="1" packages="CFCTracersPKG">
+		<var_struct name="CFC12FluxDiagnostics" time_levs="1"  missing_value="FILLVAL" packages="CFCTracersPKG">
 			<var name="CFC12_flux_ifrac" type="real" dimensions="nCells Time" units="none"
 				description="Ice Fraction used in CFC12 flux calculation"
 			/>
@@ -160,7 +160,7 @@
 		</var_struct>
 
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="CFCTracersPistonVelocity" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
+			<var_array name="CFCTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersSurfaceRestoringPKG">
 				<var name="CFC11PistonVelocity" array_group="CFCPVGRP" units="m s^{-1}"
 				description="A non-negative field controlling the rate at which CFC11 is restored to CFC11SurfaceRestoringValue"
 				/>
@@ -168,7 +168,7 @@
 				description="A non-negative field controlling the rate at which CFC12 is restored to CFC12SurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="CFCTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="CFCTracersSurfaceRestoringPKG">
+			<var_array name="CFCTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersSurfaceRestoringPKG">
 				<var name="CFC11SurfaceRestoringValue" array_group="CFCSRVGRP" units="mol m^{3}"
 				description="Tracer is restored toward this field at a rate controlled by CFC11PistonVelocity."
 				/>
@@ -178,7 +178,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="CFCTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
+			<var_array name="CFCTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="CFCTracersInteriorRestoringPKG">
 				<var name="CFC11InteriorRestoringRate" array_group="CFCIRRGRP" units="{s}^-1"
 				description="A non-negative field controlling the rate at which CFC11 is restored to CFC11InteriorRestoringValue"
 				/>
@@ -186,7 +186,7 @@
 				description="A non-negative field controlling the rate at which CFC12 is restored to CFC12InteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="CFCTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersInteriorRestoringPKG">
+			<var_array name="CFCTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="CFCTracersInteriorRestoringPKG">
 				<var name="CFC11InteriorRestoringValue" array_group="CFCIRVGRP" units="mol m^{3}"
 				description="Tracer is restored toward this field at a rate controlled by CFC11InteriorRestoringRate."
 				/>
@@ -196,7 +196,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="CFCTracersExponentialDecayRate" type="real" dimensions="Time" packages="CFCTracersExponentialDecayPKG">
+			<var_array name="CFCTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="CFCTracersExponentialDecayPKG">
 				<var name="CFC11ExponentialDecayRate" array_group="CFCGRP" units="s^{-1}"
 				description="A non-negative field controlling the exponential decay of CFC11"
 				/>
@@ -206,7 +206,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="CFCTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="CFCTracersIdealAgePKG">
+			<var_array name="CFCTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersIdealAgePKG">
 				<var name="CFC11IdealAgeMask" array_group="CFCGRP" units="unitless"
 				description="In top layer, CFC11 is reset to CFC11 * CFC11IdealAgeMask, valid values of CFC11IdealAgeMask or 0 and 1"
 				/>
@@ -216,7 +216,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="CFC11TracersTTDMask" type="real" dimensions="nCells Time" packages="CFCTracersTTDPKG">
+			<var_array name="CFC11TracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="CFCTracersTTDPKG">
 				<var name="CFC11TTDMask" array_group="CFCGRP" units="unitless"
 				description="In top layer, CFC11 is reset to TTDMask, valid values of CFC11TTDMask or 0 and 1"
 				/>
@@ -225,7 +225,7 @@
 				/>
 			</var_array>
 		</var_struct>
-		<var_struct name="CFCAuxiliary" time_levs="1" packages="CFCTracersPKG">
+		<var_struct name="CFCAuxiliary" time_levs="1"  missing_value="FILLVAL" packages="CFCTracersPKG">
 			<var name="pCFC11" type="real" dimensions="nCells Time" units="mole fraction"
 				description="Mole Fraction of Atmospheric CFC11"
 			/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_DMS.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_DMS.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="DMSTracers" dimensions="nVertLevels nCells Time" type="real" packages="DMSTracersPKG" >
+			<var_array name="DMSTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="DMSTracersPKG" >
 				<!-- Add constituents of tracer group -->
 				<var name="DMS" array_group="DMSGRP" units="mmol m^{-3}"
 			description="Dimethyl Sulfide"
@@ -63,7 +63,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="DMSTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="DMSTracersPKG">
+			<var_array name="DMSTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="DMSTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="DMSTend" array_group="DMSGRP" units="mmol m^{-3} s^{-1}"
 			description="Dimethyl Sulfide Tendency"
@@ -77,7 +77,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="DMSTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="DMSTracersPKG">
+			<var_array name="DMSTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="DMSSurfaceFlux" array_group="DMSSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
 			description="Dimethyl Sulfide Surface Flux"
@@ -86,7 +86,7 @@
 			description="Dimethyl Sulfoniopropionate Surface Flux"
 				/>
 			</var_array>
-			<var_array name="DMSTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="DMSTracersPKG">
+			<var_array name="DMSTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="DMSSurfaceFluxRunoff" array_group="DMSSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
 					description="Dimethyl Sulfide Surface Flux Due to Runoff"
@@ -95,7 +95,7 @@
 					description="Dimethyl Sulfoniopropionate Surface Flux Due to Runoff"
 				/>
 			</var_array>
-			<var_array name="DMSTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="DMSTracersPKG">
+			<var_array name="DMSTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="DMSSurfaceFluxRemoved" array_group="DMSSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
 					description="Dimethyl Sulfide Surface Flux that is ignored"
@@ -105,7 +105,7 @@
 				/>
 			</var_array>
 		</var_struct>
-		<var_struct name="DMSSeaIceCoupling" time_levs="1" packages="DMSTracersPKG">
+		<var_struct name="DMSSeaIceCoupling" time_levs="1"  missing_value="FILLVAL" packages="DMSTracersPKG">
 			<var name="avgOceanSurfaceDMS" type="real" dimensions="nCells Time" units="mmolS m^{-3}"
 				description="Ocean Surface DMS concentration"
 			/>
@@ -119,7 +119,7 @@
 				description="Surface DMSP flux from sea ice"
 			/>
 		</var_struct>
-		<var_struct name="DMSFluxDiagnostics" time_levs="1" packages="DMSTracersPKG">
+		<var_struct name="DMSFluxDiagnostics" time_levs="1"  missing_value="FILLVAL" packages="DMSTracersPKG">
 			<var name="dms_flux_diag_ifrac" type="real" dimensions="nCells Time" units="none"
 				description="Ice Fraction used in DMS flux calculation"
 			/>
@@ -146,7 +146,7 @@
 			/>
 		</var_struct>
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="DMSTracersPistonVelocity" type="real" dimensions="nCells Time" packages="DMSTracersSurfaceRestoringPKG">
+			<var_array name="DMSTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersSurfaceRestoringPKG">
 				<var name="DMSPistonVelocity" array_group="DMSPVGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which DMS is restored to DMSSurfaceRestoringValue"
 				/>
@@ -154,7 +154,7 @@
 			 description="A non-negative field controlling the rate at which DMSP is restored to DMSPSurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="DMSTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="DMSTracersSurfaceRestoringPKG">
+			<var_array name="DMSTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersSurfaceRestoringPKG">
 				<var name="DMSSurfaceRestoringValue" array_group="DMSSRVGRP" units="mmol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by DMSPistonVelocity."
 				/>
@@ -164,7 +164,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="DMSTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="DMSTracersInteriorRestoringPKG">
+			<var_array name="DMSTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="DMSTracersInteriorRestoringPKG">
 				<var name="DMSInteriorRestoringRate" array_group="DMSIRRGRP" units="{s}^-1"
 			 description="A non-negative field controlling the rate at which DMS is restored to DMSInteriorRestoringValue"
 				/>
@@ -172,7 +172,7 @@
 			 description="A non-negative field controlling the rate at which DMSP is restored to DMSPInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="DMSTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="DMSTracersInteriorRestoringPKG">
+			<var_array name="DMSTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="DMSTracersInteriorRestoringPKG">
 				<var name="DMSInteriorRestoringValue" array_group="DMSIRVGRP" units="mmol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by DMSInteriorRestoringRate."
 				/>
@@ -182,7 +182,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="DMSTracersExponentialDecayRate" type="real" dimensions="Time" packages="DMSTracersExponentialDecayPKG">
+			<var_array name="DMSTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="DMSTracersExponentialDecayPKG">
 				<var name="DMSExponentialDecayRate" array_group="DMSGRP" units="s^{-1}"
 			 description="A non-negative field controlling the exponential decay of DMS"
 				/>
@@ -192,7 +192,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="DMSTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="DMSTracersIdealAgePKG">
+			<var_array name="DMSTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersIdealAgePKG">
 				<var name="DMSIdealAgeMask" array_group="DMSGRP" units="unitless"
 			 description="In top layer, DMS is reset to DMS * DMSIdealAgeMask, valid values of DMSIdealAgeMask or 0 and 1"
 				/>
@@ -202,7 +202,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="DMSTracersTTDMask" type="real" dimensions="nCells Time" packages="DMSTracersTTDPKG">
+			<var_array name="DMSTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="DMSTracersTTDPKG">
 				<var name="DMSTTDMask" array_group="DMSGRP" units="unitless"
 			 description="In top layer, DMS is reset to TTDMask, valid values of DMSTTDMask or 0 and 1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="MacroMoleculesTracers" dimensions="nVertLevels nCells Time" type="real" packages="MacroMoleculesTracersPKG" >
+			<var_array name="MacroMoleculesTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG" >
 				<!-- Add constituents of tracer group -->
 			<var name="PROT" array_group="MacroMoleculesGRP" units="mmol m^{-3}"
 				description="Proteins"
@@ -66,7 +66,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="MacroMoleculesTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="MacroMoleculesTracersPKG">
+			<var_array name="MacroMoleculesTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG">
 				<!-- Add constituents of tracer group -->
 			<var name="PROTTend" array_group="MacroMoleculesGRP" units="mmol m^{-3} s^{-1}"
 				description="Proteins Tendency"
@@ -83,7 +83,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="MacroMoleculesTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersPKG">
+			<var_array name="MacroMoleculesTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PROTSurfaceFlux" array_group="MacroMoleculesSurfaceFluxGRP" units="mmol m^{-3} m s^{-1}"
 			description="Proteins Surface Flux"
@@ -95,7 +95,7 @@
 			description="Lipids Surface Flux"
 				/>
 			</var_array>
-			<var_array name="MacroMoleculesTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersPKG">
+			<var_array name="MacroMoleculesTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PROTSurfaceFluxRunoff" array_group="MacroMoleculesSurfaceFluxRunoffGRP" units="mmol m^{-3} m s^{-1}"
 					description="Proteins Surface Flux Due to Runoff"
@@ -107,7 +107,7 @@
 					description="Lipids Surface Flux Due to Runoff"
 				/>
 			</var_array>
-			<var_array name="MacroMoleculesTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersPKG">
+			<var_array name="MacroMoleculesTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PROTSurfaceFluxRemoved" array_group="MacroMoleculesSurfaceFluxRemovedGRP" units="mmol m^{-3} m s^{-1}"
 					description="Proteins Surface Flux that is ignored"
@@ -120,7 +120,7 @@
 				/>
 			</var_array>
 		</var_struct>
-		<var_struct name="MacroMoleculesSeaIceCoupling" time_levs="1" packages="MacroMoleculesTracersPKG">
+		<var_struct name="MacroMoleculesSeaIceCoupling" time_levs="1"  missing_value="FILLVAL" packages="MacroMoleculesTracersPKG">
 			<var name="avgOceanSurfaceDOC" type="real" dimensions="R3 nCells Time" units="mmolC m^{-3}"
 				description="Ocean Surface Organics concentration: (1,2,3)=>(polysaccharides,lipids,proteins)"
 			/>
@@ -129,7 +129,7 @@
 			/>
 		</var_struct>
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="MacroMoleculesTracersPistonVelocity" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersSurfaceRestoringPKG">
+			<var_array name="MacroMoleculesTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersSurfaceRestoringPKG">
 				<var name="PROTPistonVelocity" array_group="MacroMoleculesPVGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which PROT is restored to PROTSurfaceRestoringValue"
 				/>
@@ -140,7 +140,7 @@
 			 description="A non-negative field controlling the rate at which LIP is restored to LIPSurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="MacroMoleculesTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersSurfaceRestoringPKG">
+			<var_array name="MacroMoleculesTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersSurfaceRestoringPKG">
 				<var name="PROTSurfaceRestoringValue" array_group="MacroMoleculesSRVGRP" units="mmol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by PROTPistonVelocity."
 				/>
@@ -153,7 +153,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="MacroMoleculesTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="MacroMoleculesTracersInteriorRestoringPKG">
+			<var_array name="MacroMoleculesTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersInteriorRestoringPKG">
 				<var name="PROTInteriorRestoringRate" array_group="MacroMoleculesIRRGRP" units="{s}^-1"
 			 description="A non-negative field controlling the rate at which PROT is restored to PROTInteriorRestoringValue"
 				/>
@@ -164,7 +164,7 @@
 			 description="A non-negative field controlling the rate at which LIP is restored to LIPInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="MacroMoleculesTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="MacroMoleculesTracersInteriorRestoringPKG">
+			<var_array name="MacroMoleculesTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersInteriorRestoringPKG">
 				<var name="PROTInteriorRestoringValue" array_group="MacroMoleculesIRVGRP" units="mmol m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by PROTInteriorRestoringRate."
 				/>
@@ -177,7 +177,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="MacroMoleculesTracersExponentialDecayRate" type="real" dimensions="Time" packages="MacroMoleculesTracersExponentialDecayPKG">
+			<var_array name="MacroMoleculesTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersExponentialDecayPKG">
 				<var name="PROTExponentialDecayRate" array_group="MacroMoleculesGRP" units="s^{-1}"
 			 description="A non-negative field controlling the exponential decay of PROT"
 				/>
@@ -190,7 +190,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="MacroMoleculesTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersIdealAgePKG">
+			<var_array name="MacroMoleculesTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersIdealAgePKG">
 				<var name="PROTIdealAgeMask" array_group="MacroMoleculesGRP" units="unitless"
 			 description="In top layer, PROT is reset to PROT * PROTIdealAgeMask, valid values of PROTIdealAgeMask or 0 and 1"
 				/>
@@ -203,7 +203,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="MacroMoleculesTracersTTDMask" type="real" dimensions="nCells Time" packages="MacroMoleculesTracersTTDPKG">
+			<var_array name="MacroMoleculesTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="MacroMoleculesTracersTTDPKG">
 				<var name="PROTTTDMask" array_group="MacroMoleculesGRP" units="unitless"
 			 description="In top layer, PROT is reset to TTDMask, valid values of PROTTTDMask or 0 and 1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_TEMPLATEGRP.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_TEMPLATEGRP.xml
@@ -45,7 +45,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="TEMPLATEGRP" dimensions="nVertLevels nCells Time" type="real" packages="TEMPLATEGRPPKG" >
+			<var_array name="TEMPLATEGRP" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="TEMPLATEGRPPKG" >
 				<!-- Add constituents of tracer group -->
 			</var_array>
 		</var_struct>
@@ -53,7 +53,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="TEMPLATEGRPTend" type="real" dimensions="nVertLevels nCells Time" packages="TEMPLATEGRPPKG">
+			<var_array name="TEMPLATEGRPTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="TEMPLATEGRPPKG">
 				<!-- Add constituents of tracer group -->
 			</var_array>
 		</var_struct>
@@ -61,7 +61,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="TEMPLATEGRPSurfaceFlux" type="real" dimensions="nCells Time" packages="TEMPLATEGRPPKG">
+			<var_array name="TEMPLATEGRPSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="TEMPLATEGRPPKG">
 				<!-- Add constituents of tracer group -->
 			</var_array>
 		</var_struct>

--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -61,7 +61,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" >
+			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="temperature" array_group="activeGRP" units="degrees Celsius"
 			 description="potential temperature"
 				/>
@@ -74,7 +74,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="temperatureTend" array_group="activeGRP" units="^\circ C s^{-1}"
 			 description="time tendency of potential temperature"
 				/>
@@ -87,7 +87,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="activeTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="temperatureSurfaceFlux" array_group="activeTracerFluxGRP" units="^\circ C m s^{-1}"
 			 description="Flux of temperature through the ocean surface. Positive into ocean."
 				/>
@@ -95,7 +95,7 @@
 			 description="Flux of salinity through the ocean surface. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="activeTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="temperatureSurfaceFluxRunoff" array_group="activeRunoffFluxGRP" units="^\circ C m s^{-1}"
 			 description="Flux of temperature through the ocean surface due to river runoff. Positive into ocean."
 				/>
@@ -103,7 +103,7 @@
 			 description="Flux of salinity through the ocean surface due to river runoff. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="activeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="temperatureSurfaceFluxRemoved" array_group="activeRemovedFluxGRP" units="^\circ C m s^{-1}"
 			 description="Flux of temperature that is ignored coming into the ocean. Positive into ocean."
 				/>
@@ -111,7 +111,7 @@
 			 description="Flux of salinity that is ignored coming into the ocean. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="nonLocalSurfaceTracerFlux" type="real" dimensions="nCells Time" packages="activeTracersPKG">
+			<var_array name="nonLocalSurfaceTracerFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersPKG">
 				<var name="nonLocalTemperatureSurfaceFlux" array_group="activeNonLocalGRP" units="^\circ C m s^{-1}"
 			description="total flux of temperature (including thickness contributions) through ocean surface"
 				/>
@@ -121,7 +121,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="activeTracersPistonVelocity" type="real" dimensions="nCells Time" packages="activeTracersSurfaceRestoringPKG">
+			<var_array name="activeTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersSurfaceRestoringPKG">
 				<var name="temperaturePistonVelocity" array_group="activeGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which temperature is restored to temperatureSurfaceRestoringValue"
 				/>
@@ -129,7 +129,7 @@
 			 description="A non-negative field controlling the rate at which salinity is restored to salinitySurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="activeTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="activeTracersSurfaceRestoringPKG">
+			<var_array name="activeTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersSurfaceRestoringPKG">
 				<var name="temperatureSurfaceRestoringValue" array_group="activeGRP" units="^\circ C"
 			 description="Temperature is restored toward this field at a rate controlled by temperaturePistonVelocity."
 				/>
@@ -139,7 +139,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="activeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG">
+			<var_array name="activeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="activeTracersInteriorRestoringPKG">
 				<var name="temperatureInteriorRestoringRate" array_group="activeGRP" units="{s}^-1"
 			 description="A non-negative field controlling the rate at which temperature is restored to temperatureInteriorRestoringValue"
 				/>
@@ -147,7 +147,7 @@
 			 description="A non-negative field controlling the rate at which salinity is restored to salinityInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="activeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG">
+			<var_array name="activeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="activeTracersInteriorRestoringPKG">
 				<var name="temperatureInteriorRestoringValue" array_group="activeGRP" units="^\circ C"
 			 description="Temperature is restored toward this field at a rate controlled by temperatureInteriorRestoringRate."
 				/>
@@ -157,7 +157,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="activeTracersExponentialDecayRate" type="real" dimensions="Time" packages="activeTracersExponentialDecayPKG">
+			<var_array name="activeTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="activeTracersExponentialDecayPKG">
 				<var name="temperatureExponentialDecayRate" array_group="activeGRP" units="s^{-1}"
 			 description="A non-negative field controlling the exponential decay of temperature"
 				/>
@@ -167,7 +167,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="activeTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="activeTracersIdealAgePKG">
+			<var_array name="activeTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersIdealAgePKG">
 				<var name="temperatureIdealAgeMask" array_group="activeGRP" units="unitless"
 			 description="In top layer, temperature is reset to temperature * temperatureIdealAgeMask, valid values of temperatureIdealAgeMask or 0 and 1"
 				/>
@@ -177,7 +177,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="activeTracersTTDMask" type="real" dimensions="nCells Time" packages="activeTracersTTDPKG">
+			<var_array name="activeTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="activeTracersTTDPKG">
 				<var name="temperatureTTDMask" array_group="activeGRP" units="unitless"
 			 description="In top layer, temperature is reset to TTDMask, valid values of temperatureTTDMask or 0 and 1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0">
+			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="debugTracersPKG" default_value="1.0">
 				<var name="tracer1" array_group="debugGRP" units="tracer1"
 			 description="tracer for debugging purposes"
 				/>
@@ -65,7 +65,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="debugTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG">
+			<var_array name="debugTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="debugTracersPKG">
 				<var name="tracer1Tend" array_group="debugGRP" units="tracer1"
 			 description="Tendency for tracer1"
 				/>
@@ -81,7 +81,7 @@
 
    	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="debugTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="debugTracersPKG">
+			<var_array name="debugTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersPKG">
 				<var name="tracer1SurfaceFlux" array_group="debugTracerFluxGRP" units="tracer1 m s^{-1}"
 			 description="Flux of tracer1 through the ocean surface. Positive into ocean."
 				/>
@@ -92,7 +92,7 @@
 			 description="Flux of tracer3 through the ocean surface. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="debugTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="debugTracersPKG">
+			<var_array name="debugTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersPKG">
 				<var name="tracer1SurfaceFluxRunoff" array_group="debugRunoffFluxGRP" units="tracer1 m s^{-1}"
 			 description="Flux of tracer1 through the ocean surface due to river runoff. Positive into ocean."
 				/>
@@ -103,7 +103,7 @@
 			 description="Flux of tracer3 through the ocean surface due to river runoff. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="debugTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="debugTracersPKG">
+			<var_array name="debugTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersPKG">
 				<var name="tracer1SurfaceFluxRemoved" array_group="debugRemovedFluxGRP" units="tracer1 m s^{-1}"
 			 description="Flux of tracer1 that is ignored coming into the ocean. Positive into ocean."
 				/>
@@ -116,7 +116,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="debugTracersPistonVelocity" type="real" dimensions="nCells Time" packages="debugTracersSurfaceRestoringPKG">
+			<var_array name="debugTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersSurfaceRestoringPKG">
 				<var name="tracer1PistonVelocity" array_group="debugGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which tracer1 is restored to tracer1SurfaceRestoringValue"
 				/>
@@ -127,7 +127,7 @@
 			 description="A non-negative field controlling the rate at which tracer3 is restored to tracer3SurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="debugTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="debugTracersSurfaceRestoringPKG">
+			<var_array name="debugTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersSurfaceRestoringPKG">
 				<var name="tracer1SurfaceRestoringValue" array_group="debugGRP" units="^\circ C"
 			 description="tracer1 is restored toward this field at a rate controlled by tracer1PistonVelocity."
 				/>
@@ -140,7 +140,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="debugTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersInteriorRestoringPKG">
+			<var_array name="debugTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="debugTracersInteriorRestoringPKG">
 				<var name="tracer1InteriorRestoringRate" array_group="debugGRP" units="{s}^-1"
 				 description="A non-negative field controlling the rate at which tracer1 is restored to tracer1InteriorRestoringValue"
 				/>
@@ -151,7 +151,7 @@
 				 description="A non-negative field controlling the rate at which tracer3 is restored to tracer3InteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="debugTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersInteriorRestoringPKG">
+			<var_array name="debugTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="debugTracersInteriorRestoringPKG">
 				<var name="tracer1InteriorRestoringValue" array_group="debugGRP" units="^\circ C"
 				 description="tracer1 is restored toward this field at a rate controlled by tracer1InteriorRestoringRate."
 				/>
@@ -164,7 +164,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="debugTracersExponentialDecayRate" type="real" dimensions="Time" packages="debugTracersExponentialDecayPKG">
+			<var_array name="debugTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="debugTracersExponentialDecayPKG">
 				<var name="tracer1ExponentialDecayRate" array_group="debugGRP" units="s^{-1}"
 			 description="A non-negative field controlling the exponential decay of tracer1"
 				/>
@@ -177,7 +177,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="debugTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="debugTracersIdealAgePKG">
+			<var_array name="debugTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersIdealAgePKG">
 				<var name="tracer1IdealAgeMask" array_group="debugGRP" units="unitless"
 			 description="In top layer, tracer1 is reset to tracer1 * tracer1IdealAgeMask, valid values of tracer1IdealAgeMask or 0 and 1"
 				/>
@@ -190,7 +190,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="debugTracersTTDMask" type="real" dimensions="nCells Time" packages="debugTracersTTDPKG">
+			<var_array name="debugTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="debugTracersTTDPKG">
 				<var name="tracer1TTDMask" array_group="debugGRP" units="unitless"
 			 description="In top layer, tracer1 is reset to TTDMask, valid values of tracer1TTDMask or 0 and 1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
@@ -89,7 +89,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="ecosysTracers" dimensions="nVertLevels nCells Time" type="real" packages="ecosysTracersPKG" >
+			<var_array name="ecosysTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="ecosysTracersPKG" >
 				<!-- Add constituents of tracer group -->
 				<var name="PO4" array_group="ecosysGRP" units="mmol P m^{-3}"
 					description="Dissolved Inorganic Phosphate"
@@ -193,7 +193,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="ecosysTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="ecosysTracersPKG">
+			<var_array name="ecosysTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4Tend" array_group="ecosysGRP" units="mmol P m^{-3} s^{-1}"
 					description="Dissolved Inorganic Phosphate Tendency"
@@ -297,7 +297,7 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="ecosysTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="ecosysTracersPKG">
+			<var_array name="ecosysTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4SurfaceFlux" array_group="ecosysSurfaceFluxGRP" units="mmol P m^{-3} m s^{-1}"
 					description="Dissolved Inorganic Phosphate Surface Flux"
@@ -396,7 +396,7 @@
 					description="Diazotroph Phosphorus Surface Flux"
 				/>
 			</var_array>
-			<var_array name="ecosysTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="ecosysTracersPKG">
+			<var_array name="ecosysTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4SurfaceFluxRunoff" array_group="ecosysSurfaceFluxRunoffGRP" units="mmol P m^{-3} m s^{-1}"
 					description="Dissolved Inorganic Phosphate Surface Flux Due to Runoff"
@@ -495,7 +495,7 @@
 					description="Diazotroph Phosphorus Surface Flux Due to Runoff"
 				/>
 			</var_array>
-			<var_array name="ecosysTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="ecosysTracersPKG">
+			<var_array name="ecosysTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4SurfaceFluxRemoved" array_group="ecosysSurfaceFluxRemovedGRP" units="mmol P m^{-3} m s^{-1}"
 					description="Dissolved Inorganic Phosphate Surface Flux that is ignored"
@@ -596,7 +596,7 @@
 			</var_array>
 		</var_struct>
 
-		<var_struct name="ecosysAuxiliary" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysAuxiliary" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="PH_PREV_3D" type="real" dimensions="nVertLevels nCells Time" units="pH"
 				description="pH (3D) from previous timestep"
 			/>
@@ -680,7 +680,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysSeaIceCoupling" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysSeaIceCoupling" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="avgOceanSurfacePhytoC" type="real" dimensions="R3 nCells Time" units="mmol C m^{-3}"
 				description="Ocean Surface phytoplankton carbon concentration: (1,2,3) corresponds to (diat,sp,phaeo)"
 			/>
@@ -743,7 +743,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysDiagFieldsLevel1" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysDiagFieldsLevel1" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="ecosys_diag_photoC_TOT_zint" type="real" dimensions="nCells Time" units="mmol C m^{-3} m s^{-1}"
 				description="Total C Fixation Vertical Integral"
 			/>
@@ -854,7 +854,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysDiagFieldsLevel2" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysDiagFieldsLevel2" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="ecosys_diag_O2_PRODUCTION" type="real" dimensions="nVertLevels nCells Time" units="mmol O2 m^{-3} s^{-1}"
 				description="O2 Production"
 			/>
@@ -1016,7 +1016,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysDiagFieldsLevel3" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysDiagFieldsLevel3" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="ecosys_diag_tot_bSi_form" type="real" dimensions="nVertLevels nCells Time" units="mmol Si m^{-3} s^{-1}"
 				description="Si Uptake"
 			/>
@@ -1115,7 +1115,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysDiagFieldsLevel4" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysDiagFieldsLevel4" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="ecosys_diag_tot_CaCO3_form_zint" type="real" dimensions="nCells Time" units="mmol C m^{-3} m s^{-1}"
 				description="Total CaCO3 Formation Vertical Integral"
 			/>
@@ -1175,7 +1175,7 @@
 			/>
 		</var_struct>
 
-		<var_struct name="ecosysDiagFieldsLevel5" time_levs="1" packages="ecosysTracersPKG">
+		<var_struct name="ecosysDiagFieldsLevel5" time_levs="1"  missing_value="FILLVAL" packages="ecosysTracersPKG">
 			<var name="ecosys_diag_PO4_RESTORE" type="real" dimensions="nVertLevels nCells Time" units="mmol P m^{-3} s^{-1}"
 				description="PO4 Restoring"
 			/>
@@ -1188,7 +1188,7 @@
 		</var_struct>
 
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="ecosysTracersPistonVelocity" type="real" dimensions="nCells Time" packages="ecosysTracersSurfaceRestoringPKG">
+			<var_array name="ecosysTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersSurfaceRestoringPKG">
 				<var name="PO4PistonVelocity" array_group="ecosysPVGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which PO4 is restored to PO4SurfaceRestoringValue"
 				/>
@@ -1286,7 +1286,7 @@
 			 description="A non-negative field controlling the rate at which diazP is restored to diazPSurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="ecosysTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="ecosysTracersSurfaceRestoringPKG">
+			<var_array name="ecosysTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersSurfaceRestoringPKG">
 				<var name="PO4SurfaceRestoringValue" array_group="ecosysSRVGRP" units="m s^{-1}"
 			 description="A non-negative field controlling the rate at which PO4 is restored to PO4SurfaceRestoringValue"
 				/>
@@ -1386,7 +1386,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="ecosysTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="ecosysTracersInteriorRestoringPKG">
+			<var_array name="ecosysTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="ecosysTracersInteriorRestoringPKG">
 				<var name="PO4InteriorRestoringRate" array_group="ecosysIRRGRP" units="{s}^-1"
 			 description="A non-negative field controlling the rate at which PO4 is restored to PO4InteriorRestoringValue"
 				/>
@@ -1484,7 +1484,7 @@
 			 description="A non-negative field controlling the rate at which diazP is restored to diazPInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="ecosysTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="ecosysTracersInteriorRestoringPKG">
+			<var_array name="ecosysTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="ecosysTracersInteriorRestoringPKG">
 				<var name="PO4InteriorRestoringValue" array_group="ecosysIRVGRP" units="mmol P m^{3}"
 			 description="Tracer is restored toward this field at a rate controlled by PO4InteriorRestoringRate."
 				/>
@@ -1584,7 +1584,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="ecosysTracersExponentialDecayRate" type="real" dimensions="Time" packages="ecosysTracersExponentialDecayPKG">
+			<var_array name="ecosysTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="ecosysTracersExponentialDecayPKG">
 				<var name="PO4ExponentialDecayRate" array_group="ecosysGRP" units="s^{-1}"
 			 description="A non-negative field controlling the exponential decay of PO4"
 				/>
@@ -1683,7 +1683,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="ecosysTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="ecosysTracersIdealAgePKG">
+			<var_array name="ecosysTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersIdealAgePKG">
 				<var name="PO4IdealAgeMask" array_group="ecosysGRP" units="unitless"
 			 description="In top layer, PO4 is reset to PO4 * PO4IdealAgeMask, valid values of PO4IdealAgeMask or 0 and 1"
 				/>
@@ -1783,7 +1783,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="ecosysTracersTTDMask" type="real" dimensions="nCells Time" packages="ecosysTracersTTDPKG">
+			<var_array name="ecosysTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="ecosysTracersTTDPKG">
 				<var name="PO4TTDMask" array_group="ecosysGRP" units="unitless"
 			 description="In top layer, PO4 is reset to TTDMask, valid values of PO4TTDMask or 0 and 1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
@@ -41,7 +41,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="idealAgeTracers" dimensions="nVertLevels nCells Time" type="real" packages="idealAgeTracersPKG"  default_value="0.0">
+			<var_array name="idealAgeTracers" dimensions="nVertLevels nCells Time" type="real"  missing_value="FILLVAL" packages="idealAgeTracersPKG"  default_value="0.0">
 				<var name="iAge" array_group="iAgeGRP" units="seconds" description="tracer for ideal age"
 				/>
 			</var_array>
@@ -50,7 +50,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="idealAgeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersPKG">
+			<var_array name="idealAgeTracersTend" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersPKG">
 				<var name="iAgeTend" array_group="iAgeGRP" units="seconds/second" description="Tendency for iAge"
 				/>
 			</var_array>
@@ -59,62 +59,62 @@
 
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
-			<var_array name="idealAgeTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+			<var_array name="idealAgeTracersSurfaceFlux" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersPKG">
 				<var name="iAgeSurfaceFlux" array_group="idealAgeluxGRP" units="none"
 				description="Flux of iAge through the ocean surface. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="idealAgeTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+			<var_array name="idealAgeTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersPKG">
 				<var name="iAgeSurfaceFluxRunoff" array_group="iAgeRunoffFluxGRP" units="none"
 				description="Flux of iAge through the ocean surface due to river runoff. Positive into ocean."
 				/>
 			</var_array>
-			<var_array name="idealAgeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="idealAgeTracersPKG">
+			<var_array name="idealAgeTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersPKG">
 				<var name="iAgeSurfaceFluxRemoved" array_group="iAgeRemovedFluxGRP" units="none"
 				description="Flux of iAge that is ignored coming into the ocean. Positive into ocean."
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
-			<var_array name="idealAgeTracersPistonVelocity" type="real" dimensions="nCells Time" packages="idealAgeTracersSurfaceRestoringPKG">
+			<var_array name="idealAgeTracersPistonVelocity" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersSurfaceRestoringPKG">
 				<var name="iAgePistonVelocity" array_group="iAgeRestoringGRP" units="none"
 				description="A non-negative field controlling the rate at which iAge is restored to iAgeSurfaceRestoringValue"
 				/>
 			</var_array>
-			<var_array name="idealAgeTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="idealAgeTracersSurfaceRestoringPKG">
+			<var_array name="idealAgeTracersSurfaceRestoringValue" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersSurfaceRestoringPKG">
 				<var name="iAgeSurfaceRestoringValue" array_group="iAgeRestoringGRP" units="none"
 				description="iAge is restored toward this field at a rate controlled by iAgePistonVelocity."
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="idealAgeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersInteriorRestoringPKG">
+			<var_array name="idealAgeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersInteriorRestoringPKG">
 				<var name="iAgeInteriorRestoringRate" array_group="iAgeRestoringGRP" units="none"
 					description="A non-negative field controlling the rate at which iAge is restored to iAgeInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="idealAgeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersInteriorRestoringPKG">
+			<var_array name="idealAgeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersInteriorRestoringPKG">
 				<var name="iAgeInteriorRestoringValue" array_group="iAgeRestoringGRP" units="none"
 					description="iAge is restored toward this field at a rate controlled by iAgeInteriorRestoringRate."
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersExponentialDecayFields" time_levs="1">
-			<var_array name="idealAgeTracersExponentialDecayRate" type="real" dimensions="Time" packages="idealAgeTracersExponentialDecayPKG">
+			<var_array name="idealAgeTracersExponentialDecayRate" type="real" dimensions="Time"  missing_value="FILLVAL" packages="idealAgeTracersExponentialDecayPKG">
 				<var name="iAgeExponentialDecayRate" array_group="iAgeRestoringGRP" units="none"
 				description="A non-negative field controlling the exponential decay of iAge"
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersIdealAgeFields" time_levs="1">
-			<var_array name="idealAgeTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="idealAgeTracersIdealAgePKG">
+			<var_array name="idealAgeTracersIdealAgeMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersIdealAgePKG">
 				<var name="iAgeIdealAgeMask" array_group="iAgeRestoringGRP" units="none"
 				description="In top layer, iAge is reset to iAge * iAgeIdealAgeMask, valid values of iAgeIdealAgeMask or 0 and 1"
 				/>
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersTTDFields" time_levs="1">
-			<var_array name="idealAgeTracersTTDMask" type="real" dimensions="nCells Time" packages="idealAgeTracersTTDPKG">
+			<var_array name="idealAgeTracersTTDMask" type="real" dimensions="nCells Time"  missing_value="FILLVAL" packages="idealAgeTracersTTDPKG">
 				<var name="iAgeTTDMask" array_group="iAgeRestoringGRP" units="none"
 				description="In top layer, iAge is reset to TTDMask, valid values of iAgeTTDMask or 0 and 1"
 				/>


### PR DESCRIPTION
Currently, land cells in 3D fields are filled with zeros or values of -1e34 in netcdf files. Both netcdf tools and paraview show the stored value, rather than understanding it as a missing value.

This PR corrects this for all tracer variables. Two items are required:
1. Set `missing_value="FILLVAL"` for that array in the Registry file
2. Set the value of land cells to `MPAS_REAL_FILLVAL` in the code, either on init and during the computation.