### PR TITLE
[FRAMEWORK] Add a new `name_in_output` registry attribute to variables

### DIFF
--- a/components/mpas-framework/src/framework/duplicate_field_array.inc
+++ b/components/mpas-framework/src/framework/duplicate_field_array.inc
@@ -7,7 +7,7 @@
             local_copy_only = .false.
          end if
 
-         
+
          src_cursor => src
          if (.not. local_copy_only) then
             nullify(dst_cursor)
@@ -41,6 +41,10 @@
                if ( associated( src_cursor % constituentNames ) ) then
                   allocate(dst_cursor % constituentNames(size(src_cursor % constituentNames, dim=1)))
                   dst_cursor % constituentNames(:) = src_cursor % constituentNames(:)
+               end if
+               if ( associated( src_cursor % outputConstituentNames ) ) then
+                  allocate(dst_cursor % outputConstituentNames(size(src_cursor % outputConstituentNames, dim=1)))
+                  dst_cursor % outputConstituentNames(:) = src_cursor % outputConstituentNames(:)
                end if
                dst_cursor % isPersistent = src_cursor % isPersistent
                dst_cursor % isActive = src_cursor % isActive

--- a/components/mpas-framework/src/framework/duplicate_field_scalar.inc
+++ b/components/mpas-framework/src/framework/duplicate_field_scalar.inc
@@ -6,17 +6,17 @@
          else
             local_copy_only = .false.
          end if
-   
-         
+
+
          src_cursor => src
          if (.not. local_copy_only) then
             nullify(dst_cursor)
          else
             dst_cursor => dst
          end if
-   
+
 !        do while (associated(src_cursor))
-   
+
             if (.not. local_copy_only) then
                if (associated(dst_cursor)) then
                   allocate(dst_cursor % next)
@@ -29,14 +29,15 @@
                end if
                nullify(dst_cursor % next)
             end if
-   
-   
+
+
             !
             ! Fill in members of dst_cursor from src_cursor
             !
             if (.not. local_copy_only) then
                dst_cursor % block => src_cursor % block
                dst_cursor % fieldName = src_cursor % fieldName
+               dst_cursor % outputFieldName = src_cursor % outputFieldName
                dst_cursor % isVarArray = src_cursor % isVarArray
                dst_cursor % isActive = src_cursor % isActive
                dst_cursor % isDecomposed = src_cursor % isDecomposed
@@ -63,6 +64,6 @@
 !           if (.not. local_copy_only) then
 !              dst_cursor => dst_cursor % next
 !           end if
-     
+
 !        end do
       end if

--- a/components/mpas-framework/src/framework/mpas_field_types.inc
+++ b/components/mpas-framework/src/framework/mpas_field_types.inc
@@ -18,6 +18,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(5) :: dimNames
       integer, dimension(5) :: dimSizes
       real (kind=RKIND) :: defaultValue
@@ -52,6 +54,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(4) :: dimNames
       integer, dimension(4) :: dimSizes
       real (kind=RKIND) :: defaultValue
@@ -87,6 +91,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
       integer, dimension(3) :: dimSizes
       real (kind=RKIND) :: defaultValue
@@ -121,6 +127,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
       integer, dimension(2) :: dimSizes
       real (kind=RKIND) :: defaultValue
@@ -155,6 +163,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
       integer, dimension(1) :: dimSizes
       real (kind=RKIND) :: defaultValue
@@ -189,6 +199,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -220,6 +232,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
       integer :: defaultValue
       integer :: missingValue
@@ -254,6 +268,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
       integer :: defaultValue
       integer :: missingValue
@@ -288,6 +304,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
       integer :: defaultValue
       integer :: missingValue
@@ -322,6 +340,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       integer :: defaultValue
       integer :: missingValue
       logical :: isDecomposed
@@ -353,6 +373,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
       integer, dimension(1) :: dimSizes
       character (len=StrKIND) :: defaultValue
@@ -387,6 +409,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       character (len=StrKIND) :: defaultValue
       character (len=StrKIND) :: missingValue
       logical :: isDecomposed
@@ -418,6 +442,8 @@
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+      character (len=StrKIND) :: outputFieldName
+      character (len=StrKIND), dimension(:), pointer :: outputConstituentNames => null()
       logical :: defaultValue
       logical :: missingValue
       logical :: isDecomposed

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -798,6 +798,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field0dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(:), pointer :: dimNames
       integer, dimension(:), pointer :: indices
       integer, dimension(:), pointer :: dimSizes
@@ -822,7 +823,13 @@ module mpas_io_streams
          local_precision = stream % defaultPrecision
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = 0
 
@@ -839,7 +846,7 @@ module mpas_io_streams
       globalDimSize = 0
       totalDimSize = 0
 
-      call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , dimNames, dimSizes, &
+      call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , dimNames, dimSizes, &
                                        field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
 
       deallocate(indices)
@@ -850,7 +857,7 @@ module mpas_io_streams
           return
       end if
 
-      call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+      call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
 
 
       !
@@ -883,6 +890,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field1dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       character (len=StrKIND), dimension(0) :: dimNames0
@@ -922,7 +930,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -940,7 +954,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), REAL_IO_TYPE , dimNames0, &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , dimNames0, &
                                              dimSizes0, field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, precision=local_precision, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -950,7 +969,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -965,10 +984,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -1138,6 +1162,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field3dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -1175,7 +1200,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -1194,7 +1225,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), REAL_IO_TYPE , field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, precision=local_precision, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -1204,7 +1240,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -1219,10 +1255,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -1238,7 +1279,7 @@ module mpas_io_streams
       new_field_list_node % isAvailable => isAvailable
 
 !call mpas_log_write('... done adding field')
-!call mpas_log_write('DEBUGGING : Finished adding 3d real field '//trim(field % fieldName))
+!call mpas_log_write('DEBUGGING : Finished adding 3d real field '//trim(fieldName)
 
    end subroutine MPAS_streamAddField_3dReal
 
@@ -1258,6 +1299,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field4dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -1295,7 +1337,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -1314,7 +1362,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), REAL_IO_TYPE , field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, precision=local_precision, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -1324,7 +1377,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -1339,10 +1392,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -1358,7 +1416,7 @@ module mpas_io_streams
       new_field_list_node % isAvailable => isAvailable
 
 !call mpas_log_write('... done adding field')
-!call mpas_log_write('DEBUGGING : Finished adding 4d real field '//trim(field % fieldName))
+!call mpas_log_write('DEBUGGING : Finished adding 4d real field '//trim(fieldName)
 
    end subroutine MPAS_streamAddField_4dReal
 
@@ -1378,6 +1436,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field5dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -1415,7 +1474,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -1434,7 +1499,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), REAL_IO_TYPE , field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, precision=local_precision, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -1444,7 +1514,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -1459,10 +1529,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -1478,7 +1553,7 @@ module mpas_io_streams
       new_field_list_node % isAvailable => isAvailable
 
 !call mpas_log_write('... done adding field')
-!call mpas_log_write('DEBUGGING : Finished adding 5d real field '//trim(field % fieldName))
+!call mpas_log_write('DEBUGGING : Finished adding 5d real field '//trim(fieldName)
 
    end subroutine MPAS_streamAddField_5dReal
 
@@ -3555,7 +3630,7 @@ module mpas_io_streams
 
          else if (field_cursor % field_type == FIELD_0D_REAL) then
 
-!call mpas_log_write('Writing out field '//trim(field_cursor % real0dField % fieldName))
+!call mpas_log_write('Writing out field '//trim(field_cursor % real0dField % outputFieldName))
 !call mpas_log_write('   > is the field decomposed? $l', logicArgs=(/field_cursor % isDecomposed/))
 !call mpas_log_write('   > outer dimension size $i', intArgs=(/field_cursor % totalDimSize/))
 
@@ -3563,7 +3638,7 @@ module mpas_io_streams
             real0d_temp = field_cursor % real0dField % scalar
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
-            call MPAS_io_put_var(stream % fileHandle, field_cursor % real0dField % fieldName, real0d_temp, io_err)
+            call MPAS_io_put_var(stream % fileHandle, field_cursor % real0dField % outputFieldName, real0d_temp, io_err)
             call MPAS_io_err_mesg(io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -3617,9 +3692,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real1dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % constituentNames(j), real0d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % outputConstituentNames(j), real0d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % fieldName, real1d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % outputFieldName, real1d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
@@ -3747,9 +3822,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real3dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % constituentNames(j), real2d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % outputConstituentNames(j), real2d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % outputFieldName, real3d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
@@ -3816,9 +3891,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real4dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % constituentNames(j), real3d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % outputConstituentNames(j), real3d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % fieldName, real4d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % outputFieldName, real4d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
@@ -3887,9 +3962,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real5dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % constituentNames(j), real4d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % outputConstituentNames(j), real4d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % fieldName, real5d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % outputFieldName, real5d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -394,6 +394,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field0dInteger), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(:), pointer :: dimNames
       integer, dimension(:), pointer :: indices
       integer, dimension(:), pointer :: dimSizes
@@ -410,7 +411,13 @@ module mpas_io_streams
          return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = 0
 
@@ -427,7 +434,7 @@ module mpas_io_streams
       globalDimSize = 0
       totalDimSize = 0
 
-      call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_INT, dimNames, dimSizes, &
+      call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, dimNames, dimSizes, &
                                        field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
 
       deallocate(indices)
@@ -438,7 +445,7 @@ module mpas_io_streams
           return
       end if
 
-      call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+      call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
 
 
       !
@@ -470,6 +477,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field1dInteger), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       character (len=StrKIND), dimension(0) :: dimNames0
@@ -500,7 +508,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -518,7 +532,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_INT, dimNames0, &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, dimNames0, &
                                              dimSizes0, field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -528,7 +547,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -543,10 +562,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -580,6 +604,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field2dInteger), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -609,7 +634,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -627,7 +658,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_INT, field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -637,7 +673,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -652,10 +688,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -689,6 +730,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field3dInteger), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -718,7 +760,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -735,7 +783,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_INT, field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -745,7 +798,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_INT, field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -760,10 +813,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -3422,7 +3480,7 @@ module mpas_io_streams
 
          if (field_cursor % field_type == FIELD_0D_INT) then
 
-!call mpas_log_write('Writing out field '//trim(field_cursor % int0dField % fieldName))
+!call mpas_log_write('Writing out field '//trim(field_cursor % int0dField % outputFieldName))
 !call mpas_log_write('   > is the field decomposed? $l', logicArgs=(/field_cursor % isDecomposed/))
 !call mpas_log_write('   > outer dimension size $i', intArgs=(/field_cursor % totalDimSize/))
 
@@ -3430,7 +3488,7 @@ module mpas_io_streams
             int0d_temp = field_cursor % int0dField % scalar
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
-            call MPAS_io_put_var(stream % fileHandle, field_cursor % int0dField % fieldName, int0d_temp, io_err)
+            call MPAS_io_put_var(stream % fileHandle, field_cursor % int0dField % outputFieldName, int0d_temp, io_err)
             call MPAS_io_err_mesg(io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -3484,9 +3542,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % int1dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % constituentNames(j), int0d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % outputConstituentNames(j), int0d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % fieldName, int1d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % outputFieldName, int1d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
@@ -3547,9 +3605,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % int2dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % constituentNames(j), int1d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % outputConstituentNames(j), int1d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % fieldName, int2d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % outputFieldName, int2d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
@@ -3614,9 +3672,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % int3dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % constituentNames(j), int2d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % outputConstituentNames(j), int2d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % fieldName, int3d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % outputFieldName, int3d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -1003,6 +1003,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field2dReal), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: indices
@@ -1040,7 +1041,13 @@ module mpas_io_streams
         return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = size(field % dimSizes)
 
@@ -1058,7 +1065,12 @@ module mpas_io_streams
          allocate(isAvailable(size(field % constituentNames)))
          isAvailable(:) = .false.
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), REAL_IO_TYPE , field % dimNames(2:ndims), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames(2:ndims), &
                                              field % dimSizes(2:ndims), field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, precision=local_precision, ierr=io_err)
             if (io_err == MPAS_STREAM_NOERR) then
@@ -1068,7 +1080,7 @@ module mpas_io_streams
          end do
       else
          nullify(isAvailable)
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), REAL_IO_TYPE , field % dimNames, field % dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, precision=local_precision, ierr=io_err)
          if (io_err == MPAS_STREAM_NOERR) then
             any_success = .true.
@@ -1083,10 +1095,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -3663,9 +3680,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real2dField % isVarArray) then
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % constituentNames(j), real1d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % outputConstituentNames(j), real1d_temp, io_err)
                else
-                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % fieldName, real2d_temp, io_err)
+                  call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % outputFieldName, real2d_temp, io_err)
                end if
                call MPAS_io_err_mesg(io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -1630,6 +1630,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field0dChar), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(5) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: dimSizes
@@ -1647,7 +1648,13 @@ module mpas_io_streams
          return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = 1
 
@@ -1668,12 +1675,17 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_CHAR, dimNames(1:1), &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_CHAR, dimNames(1:1), &
                                              dimSizes, field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, ierr=io_err)
          end do
       else
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_CHAR, dimNames(1:1), dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_CHAR, dimNames(1:1), dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
       end if
 
@@ -1686,10 +1698,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -1703,7 +1720,7 @@ module mpas_io_streams
       new_field_list_node % field_type = FIELD_0D_CHAR
       new_field_list_node % char0dField => field
 
-!call mpas_log_write('... done adding field'
+!call mpas_log_write('... done adding field')
 
    end subroutine MPAS_streamAddField_0dChar
 
@@ -1722,6 +1739,7 @@ module mpas_io_streams
       integer :: totalDimSize, globalDimSize
       integer :: ndims
       type (field1dChar), pointer :: field_ptr
+      character (len=StrKIND), pointer :: fieldName
       character (len=StrKIND), dimension(2) :: dimNames
       character (len=StrKIND), dimension(:), pointer :: dimNamesInq
       integer, dimension(:), pointer :: dimSizes
@@ -1739,7 +1757,13 @@ module mpas_io_streams
          return
       end if
 
-!call mpas_log_write('... Adding field '//trim(field % fieldName)//' to stream')
+      if (stream % ioDirection == MPAS_IO_WRITE) then
+         fieldName => field % outputFieldName
+      else
+         fieldName => field % fieldName
+      end if
+
+!call mpas_log_write('... Adding field '//trim(fieldName)//' to stream')
 
       ndims = 2
 
@@ -1761,12 +1785,17 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_CHAR, dimNames, &
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_CHAR, dimNames, &
                                              dimSizes, field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, &
                                              indices, ierr=io_err)
          end do
       else
-         call MPAS_streamAddField_generic(stream, trim(field % fieldName), MPAS_IO_CHAR, dimNames, dimSizes, &
+         call MPAS_streamAddField_generic(stream, trim(fieldName), MPAS_IO_CHAR, dimNames, dimSizes, &
                                           field % hasTimeDimension, field % isDecomposed, totalDimSize, globalDimSize, indices, ierr=io_err)
       end if
 
@@ -1779,10 +1808,15 @@ module mpas_io_streams
 
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
-            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % constituentNames(i)), field % attLists(i) % attList)
+            if (stream % ioDirection == MPAS_IO_WRITE) then
+               fieldName => field % outputConstituentNames(i)
+            else
+               fieldName => field % constituentNames(i)
+            end if
+            call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(i) % attList)
          end do
       else
-         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(field % fieldname), field % attLists(1) % attList)
+         call put_get_field_atts(stream % fileHandle, stream % ioDirection, trim(fieldName), field % attLists(1) % attList)
       end if
 
 
@@ -4036,25 +4070,25 @@ module mpas_io_streams
 
          else if (field_cursor % field_type == FIELD_0D_CHAR) then
 
-!call mpas_log_write('Writing out field '//trim(field_cursor % char0dField % fieldName))
+!call mpas_log_write('Writing out field '//trim(field_cursor % char0dField % outputFieldName))
 !call mpas_log_write('   > is the field decomposed? $l', logicArgs=(/field_cursor % isDecomposed/))
 !call mpas_log_write('   > outer dimension size $i', intArgs=(/field_cursor % totalDimSize/))
 
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
-            call MPAS_io_put_var(stream % fileHandle, field_cursor % char0dField % fieldName, field_cursor % char0dField % scalar, io_err)
+            call MPAS_io_put_var(stream % fileHandle, field_cursor % char0dField % outputFieldName, field_cursor % char0dField % scalar, io_err)
             call MPAS_io_err_mesg(io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_CHAR) then
 
-!call mpas_log_write('Writing out field '//trim(field_cursor % char1dField % fieldName))
+!call mpas_log_write('Writing out field '//trim(field_cursor % char1dField % outputFieldName))
 !call mpas_log_write('   > is the field decomposed? $l', logicArgs=(/field_cursor % isDecomposed/))
 !call mpas_log_write('   > outer dimension size $i', intArgs=(/field_cursor % totalDimSize/))
 
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
-            call MPAS_io_put_var(stream % fileHandle, field_cursor % char1dField % fieldName, field_cursor % char1dField % array, io_err)
+            call MPAS_io_put_var(stream % fileHandle, field_cursor % char1dField % outputFieldName, field_cursor % char1dField % array, io_err)
             call MPAS_io_err_mesg(io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -99,7 +99,7 @@ module mpas_io_streams
 
 
       stream % fileHandle = MPAS_io_open(fileName, ioDirection, ioFormat, ioContext, clobber_file=clobberFiles, truncate_file=truncateFiles, &
-                                         ierr=io_err) 
+                                         ierr=io_err)
       !
       ! Catch a few special errors
       !
@@ -144,7 +144,7 @@ module mpas_io_streams
       character (len=*), intent(out) :: actualTime
       integer, intent(out), optional :: maxRecords
       integer, intent(out), optional :: ierr
-      
+
       integer :: io_err
       integer :: i
       integer :: timeDim
@@ -342,7 +342,7 @@ module mpas_io_streams
       integer, intent(in) :: frame
       character (len=*), intent(out) :: frameValidTime
       integer, intent(out), optional :: ierr
-      
+
       integer :: io_err
       integer :: timeDim
 
@@ -416,10 +416,10 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
       idim = ndims
       allocate(indices(0))
       allocate(dimSizes(0))
@@ -506,13 +506,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
          allocate(isAvailable(size(field % constituentNames)))
@@ -615,13 +615,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
          allocate(isAvailable(size(field % constituentNames)))
@@ -724,12 +724,12 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
-      
+
       any_success = .false.
       if (field % isVarArray) then
          allocate(isAvailable(size(field % constituentNames)))
@@ -815,7 +815,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -828,10 +828,10 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
       idim = ndims
       allocate(indices(0))
       allocate(dimSizes(0))
@@ -911,7 +911,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -928,13 +928,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
          allocate(isAvailable(size(field % constituentNames)))
@@ -1029,7 +1029,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -1046,13 +1046,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
          allocate(isAvailable(size(field % constituentNames)))
@@ -1147,7 +1147,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -1164,13 +1164,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
 !call mpas_log_write('^^^^^^^^^^^^^^^^^^^^^^^^^^^ we are adding a var-array')
@@ -1267,7 +1267,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -1284,13 +1284,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
 !call mpas_log_write('^^^^^^^^^^^^^^^^^^^^^^^^^^^ we are adding a var-array')
@@ -1387,7 +1387,7 @@ module mpas_io_streams
          return
       end if
 
-     
+
       if (present(precision)) then
          local_precision = precision
       else
@@ -1404,13 +1404,13 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
 #include "add_field_indices.inc"
 
-      
+
       any_success = .false.
       if (field % isVarArray) then
 !call mpas_log_write('^^^^^^^^^^^^^^^^^^^^^^^^^^^ we are adding a var-array')
@@ -1503,10 +1503,10 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
       idim = ndims
       allocate(indices(0))
       allocate(dimSizes(1))
@@ -1515,7 +1515,7 @@ module mpas_io_streams
       globalDimSize = ShortStrKIND
       totalDimSize = ShortStrKIND
 
-      
+
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
             call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_CHAR, dimNames(1:1), &
@@ -1595,10 +1595,10 @@ module mpas_io_streams
 
 !call mpas_log_write('... field has $i dimensions', intArgs=(/ndims/))
 
-      ! 
+      !
       ! Determine whether the field is decomposed, the indices that are owned by this task's blocks,
       !    and the total number of outer-indices owned by this task
-      ! 
+      !
       idim = ndims
       allocate(indices(1))
       allocate(dimSizes(2))
@@ -1608,7 +1608,7 @@ module mpas_io_streams
       dimNames(2) = field % dimNames(1)
       globalDimSize = dimSizes(2)
       totalDimSize = dimSizes(2)
-      
+
       if (field % isVarArray) then
          do i=1,size(field % constituentNames)
             call MPAS_streamAddField_generic(stream, trim(field % constituentNames(i)), MPAS_IO_CHAR, dimNames, &
@@ -1720,7 +1720,7 @@ module mpas_io_streams
          end if
 
          new_field_list_node % isDecomposed = isDecomposed
-  
+
          if (ndims > 0) then
 !call mpas_log_write('... defining dimension '// trim(dimNames(idim))//" $i", intArgs=(/ globalDimSize/))
             call MPAS_io_def_dim(stream % fileHandle, trim(dimNames(idim)), globalDimSize, io_err)
@@ -1760,7 +1760,7 @@ module mpas_io_streams
             deallocate(new_field_list_node)
             return
          end if
-        
+
       else if (stream % ioDirection == MPAS_IO_READ) then
 !call mpas_log_write('... inquiring about')
 
@@ -1803,7 +1803,7 @@ module mpas_io_streams
                deallocate(dimSizesInq)
                return
             end if
-         end do 
+         end do
 
          ! Set outer dimension sizes depending on whether the field is decomposed
          if (isDecomposed) then
@@ -1819,7 +1819,7 @@ module mpas_io_streams
 
       end if
 
-      
+
       !
       ! Set variable indices
       !
@@ -2473,7 +2473,7 @@ module mpas_io_streams
       !
       ! Set time frame to real
       !
-      call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
+      call MPAS_io_set_frame(stream % fileHandle, frame, io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
@@ -2535,7 +2535,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_1dint_ptr => field_cursor % int1dField
@@ -2561,7 +2561,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % int1dField % isVarArray) then
                      call mpas_dmpar_bcast_int( mpas_io_handle_dminfo(stream % fileHandle), int0d_temp)
                      field_1dint_ptr => field_cursor % int1dField
@@ -2613,7 +2613,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_2dint_ptr => field_cursor % int2dField
@@ -2639,7 +2639,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % int2dField % isVarArray) then
                      call mpas_dmpar_bcast_ints( mpas_io_handle_dminfo(stream % fileHandle), size(int1d_temp), int1d_temp(:))
                      field_2dint_ptr => field_cursor % int2dField
@@ -2695,7 +2695,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_3dint_ptr => field_cursor % int3dField
@@ -2721,7 +2721,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % int3dField % isVarArray) then
                      call mpas_dmpar_bcast_ints( mpas_io_handle_dminfo(stream % fileHandle), size(int2d_temp), int2d_temp(:,1))
                      field_3dint_ptr => field_cursor % int3dField
@@ -2795,7 +2795,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_1dreal_ptr => field_cursor % real1dField
@@ -2822,7 +2822,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % real1dField % isVarArray) then
                      call mpas_dmpar_bcast_real( mpas_io_handle_dminfo(stream % fileHandle), real0d_temp)
                      field_1dreal_ptr => field_cursor % real1dField
@@ -2874,7 +2874,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_2dreal_ptr => field_cursor % real2dField
@@ -2900,7 +2900,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % real2dField % isVarArray) then
                      call mpas_dmpar_bcast_reals( mpas_io_handle_dminfo(stream % fileHandle), size(real1d_temp), real1d_temp(:))
                      field_2dreal_ptr => field_cursor % real2dField
@@ -2959,7 +2959,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_3dreal_ptr => field_cursor % real3dField
@@ -2986,7 +2986,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % real3dField % isVarArray) then
                      call mpas_dmpar_bcast_reals( mpas_io_handle_dminfo(stream % fileHandle), size(real2d_temp), real2d_temp(:,1))
                      field_3dreal_ptr => field_cursor % real3dField
@@ -3046,7 +3046,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_4dreal_ptr => field_cursor % real4dField
@@ -3073,7 +3073,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % real4dField % isVarArray) then
                      call mpas_dmpar_bcast_reals( mpas_io_handle_dminfo(stream % fileHandle), size(real3d_temp), real3d_temp(:,1,1))
                      field_4dreal_ptr => field_cursor % real4dField
@@ -3136,7 +3136,7 @@ module mpas_io_streams
                    end if
                    return
                end if
-   
+
                if (field_cursor % isDecomposed) then
                   ! Distribute field to multiple blocks
                   field_5dreal_ptr => field_cursor % real5dField
@@ -3163,7 +3163,7 @@ module mpas_io_streams
                   end do
 
                else
-   
+
                   if (field_cursor % real5dField % isVarArray) then
                      call mpas_dmpar_bcast_reals( mpas_io_handle_dminfo(stream % fileHandle), size(real4d_temp), real4d_temp(:,1,1,1))
                      field_5dreal_ptr => field_cursor % real5dField
@@ -3296,7 +3296,7 @@ module mpas_io_streams
       !
       ! Set time frame to write
       !
-      call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
+      call MPAS_io_set_frame(stream % fileHandle, frame, io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
@@ -3943,7 +3943,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -3971,7 +3971,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -4071,7 +4071,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
+      call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -4100,7 +4100,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -4129,7 +4129,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -4232,7 +4232,7 @@ module mpas_io_streams
          return
       end if
 
-      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
+      call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err)
       call MPAS_io_err_mesg(io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
@@ -4334,7 +4334,7 @@ module mpas_io_streams
                   call MPAS_io_put_att(handle, trim(att_cursor % attName), att_cursor % attValueRealA, fieldname)
                case (MPAS_ATT_TEXT)
                   call MPAS_io_put_att(handle, trim(att_cursor % attName), att_cursor % attValueText, fieldname)
-            end select 
+            end select
             att_cursor => att_cursor % next
          end do
       ! For MPAS_IO_READ the commented out code would overwrite any attributes, such as "units", defined in the

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1280,7 +1280,9 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 		}
 		fortprintf(fd, "! Defining time level %d\n", time_lev);
 		fortprintf(fd, "      allocate( %s %% constituentNames(numConstituents) )\n", pointer_name_arr);
+		fortprintf(fd, "      allocate( %s %% outputConstituentNames(numConstituents) )\n", pointer_name_arr);
 		fortprintf(fd, "      %s %% fieldName = '%s'\n", pointer_name_arr , vararrname);
+		fortprintf(fd, "      %s %% outputFieldName = '%s'\n", pointer_name_arr , vararrname);
 		if (decomp != -1) {
 			fortprintf(fd, "      %s %% isDecomposed = .true.\n", pointer_name_arr);
 		} else {
@@ -1315,6 +1317,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 			fortprintf(fd, "      end if\n");
 			fortprintf(fd, "      if (const_index > 0) then\n", spacing);
 			fortprintf(fd, "         %s %% constituentNames(const_index) = '%s'\n", pointer_name_arr, varname);
+			fortprintf(fd, "         %s %% outputConstituentNames(const_index) = '%s'\n", pointer_name_arr, varname);
 			fortprintf(fd, "      end if\n", spacing);
 		}
 
@@ -1554,6 +1557,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		fortprintf(fd, "\n");
 		fortprintf(fd, "! Setting up time level %d\n", time_lev);
 		fortprintf(fd, "      %s %% fieldName = '%s'\n", pointer_name_arr, varname);
+		fortprintf(fd, "      %s %% outputFieldName = '%s'\n", pointer_name_arr, varname);
 		fortprintf(fd, "      %s %% isVarArray = .false.\n", pointer_name_arr);
 		if (decomp != -1) {
 			fortprintf(fd, "      %s %% isDecomposed = .true.\n", pointer_name_arr);

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1017,6 +1017,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages;
 	const char *varname2, *vararrgroup2, *vararrname_in_code;
 	const char *varname_in_code;
+	const char *varname_in_output;
 	const char *streamname, *streamname2;
 	const char *packagename;
 	const char *vararrtimelevs;
@@ -1114,6 +1115,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 		varpackages = ezxml_attr(var_xml, "packages");
 		vararrgroup = ezxml_attr(var_xml, "array_group");
 		varname_in_code = ezxml_attr(var_xml, "name_in_code");
+		varname_in_output = ezxml_attr(var_xml, "name_in_output");
 		skip_var = 0;
 
 		if(!varname_in_code){
@@ -1312,12 +1314,17 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				varname_in_code = ezxml_attr(var_xml, "name");
 			}
 
+			varname_in_output = ezxml_attr(var_xml, "name_in_output");
+			if(!varname_in_output){
+				varname_in_output = ezxml_attr(var_xml, "name");
+			}
+
 			fortprintf(fd, "      if (associated(newSubPool)) then\n");
 			fortprintf(fd, "         call mpas_pool_get_dimension(newSubPool, 'index_%s', const_index)\n", varname_in_code);
 			fortprintf(fd, "      end if\n");
 			fortprintf(fd, "      if (const_index > 0) then\n", spacing);
 			fortprintf(fd, "         %s %% constituentNames(const_index) = '%s'\n", pointer_name_arr, varname);
-			fortprintf(fd, "         %s %% outputConstituentNames(const_index) = '%s'\n", pointer_name_arr, varname);
+			fortprintf(fd, "         %s %% outputConstituentNames(const_index) = '%s'\n", pointer_name_arr, varname_in_output);
 			fortprintf(fd, "      end if\n", spacing);
 		}
 
@@ -1471,6 +1478,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages, *varmissingval;
 	const char *varname2, *vararrgroup2;
 	const char *varname_in_code;
+	const char *varname_in_output;
 	const char *streamname, *streamname2;
 	const char *packagename;
 
@@ -1510,6 +1518,11 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	if(!varname_in_code){
 		varname_in_code = ezxml_attr(var_xml, "name");
 	}
+
+    varname_in_output = ezxml_attr(var_xml, "name_in_output");
+    if(!varname_in_output){
+        varname_in_output = ezxml_attr(var_xml, "name");
+    }
 
 	if(!vartimelevs){
 		vartimelevs = ezxml_attr(superStruct, "time_levs");
@@ -1557,7 +1570,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		fortprintf(fd, "\n");
 		fortprintf(fd, "! Setting up time level %d\n", time_lev);
 		fortprintf(fd, "      %s %% fieldName = '%s'\n", pointer_name_arr, varname);
-		fortprintf(fd, "      %s %% outputFieldName = '%s'\n", pointer_name_arr, varname);
+		fortprintf(fd, "      %s %% outputFieldName = '%s'\n", pointer_name_arr, varname_in_output);
 		fortprintf(fd, "      %s %% isVarArray = .false.\n", pointer_name_arr);
 		if (decomp != -1) {
 			fortprintf(fd, "      %s %% isDecomposed = .true.\n", pointer_name_arr);
@@ -1718,7 +1731,7 @@ int parse_struct(FILE *fd, ezxml_t registry, ezxml_t superStruct, int subpool, c
 
 	structname = ezxml_attr(superStruct, "name");
 	structnameincode = ezxml_attr(superStruct, "name_in_code");
-	
+
 	if(!structnameincode){
 		structnameincode = ezxml_attr(superStruct, "name");
 	}
@@ -1964,7 +1977,7 @@ int generate_immutable_streams(ezxml_t registry){/*{{{*/
 											fortprintf(fd, "   call MPAS_stream_mgr_add_field(manager, \'%s\', \'%s\', packages=packages, ierr=ierr)\n", optname, optvarname);
 										else
 											fortprintf(fd, "   call MPAS_stream_mgr_add_field(manager, \'%s\', \'%s\', ierr=ierr)\n", optname, optvarname);
-										
+
 									}
 
 									/* Loop over arrays of fields listed within the stream */

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -490,6 +490,7 @@ subroutine add_new_string(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_STRING_MEMORY, srcString, 1)
   call mpas_duplicate_field(srcString, dstString)
   dstString % fieldName = field_name
+  dstString % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstString % fieldName, dstString)
   call mpas_pool_add_field(all_fields, dstString % fieldName, dstString)
   if (present(target_ptr)) then
@@ -524,6 +525,7 @@ subroutine add_new_integer(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_INTEGER_MEMORY, srcInteger, 1)
   call mpas_duplicate_field(srcInteger, dstInteger)
   dstInteger % fieldName = field_name
+  dstInteger % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstInteger % fieldName, dstInteger)
   call mpas_pool_add_field(all_fields, dstInteger % fieldName, dstInteger)
   if (present(target_ptr)) then
@@ -558,6 +560,7 @@ subroutine add_new_real(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_REAL_MEMORY, srcReal, 1)
   call mpas_duplicate_field(srcReal, dstReal)
   dstReal % fieldName = field_name
+  dstReal % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstReal % fieldName, dstReal)
   call mpas_pool_add_field(all_fields, dstReal % fieldName, dstReal)
   if (present(target_ptr)) then
@@ -1091,7 +1094,7 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
        streamID=restart_stream_name, fieldName=fieldName) .and. emptyRestartStream)
        emptyRestartStream = .false.
      end do
-   
+
      if (.not. emptyRestartStream) then
        call mpas_log_write( 'Stream named ''' &
          // trim(restart_stream_name) // ''' is not empty, but is used in ' // &

--- a/components/mpas-ocean/src/analysis_members/time_series_inc/copy_field.F
+++ b/components/mpas-ocean/src/analysis_members/time_series_inc/copy_field.F
@@ -8,11 +8,19 @@
   call mpas_duplicate_field(src, dst)
 
   dst % fieldName = outname
+  dst % outputFieldName = outname
 
   if (associated(dst % constituentNames)) then
     do i = 1, size(dst % constituentNames, dim=1)
       dst % constituentNames(i) = trim(outname) // '_' // &
         trim(dst % constituentNames(i))
+    end do
+  end if
+
+  if (associated(dst % outputConstituentNames)) then
+    do i = 1, size(dst % outputConstituentNames, dim=1)
+      dst % outputConstituentNames(i) = trim(outname) // '_' // &
+        trim(dst % outputConstituentNames(i))
     end do
   end if
 

--- a/components/mpas-ocean/src/analysis_members/time_series_inc/copy_field_2.inc
+++ b/components/mpas-ocean/src/analysis_members/time_series_inc/copy_field_2.inc
@@ -4,11 +4,19 @@
   call mpas_duplicate_field(src, dst)
 
   dst % fieldName = outname
+  dst % outputFieldName = outname
 
   if (associated(dst % constituentNames)) then
     do i = 1, size(dst % constituentNames, dim=1)
       dst % constituentNames(i) = trim(outname) // '_' // &
         trim(dst % constituentNames(i))
+    end do
+  end if
+
+  if (associated(dst % outputConstituentNames)) then
+    do i = 1, size(dst % outputConstituentNames, dim=1)
+      dst % outputConstituentNames(i) = trim(outname) // '_' // &
+        trim(dst % outputConstituentNames(i))
     end do
   end if
 

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_time_series_stats.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_time_series_stats.F
@@ -481,6 +481,7 @@ subroutine add_new_string(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_STRING_MEMORY, srcString, 1)
   call mpas_duplicate_field(srcString, dstString)
   dstString % fieldName = field_name
+  dstString % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstString % fieldName, dstString)
   call mpas_pool_add_field(all_fields, dstString % fieldName, dstString)
   if (present(target_ptr)) then
@@ -515,6 +516,7 @@ subroutine add_new_integer(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_INTEGER_MEMORY, srcInteger, 1)
   call mpas_duplicate_field(srcInteger, dstInteger)
   dstInteger % fieldName = field_name
+  dstInteger % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstInteger % fieldName, dstInteger)
   call mpas_pool_add_field(all_fields, dstInteger % fieldName, dstInteger)
   if (present(target_ptr)) then
@@ -549,6 +551,7 @@ subroutine add_new_real(all_fields, inpool, outpool, field_name, target_ptr)
   call mpas_pool_get_field(inpool, ONE_REAL_MEMORY, srcReal, 1)
   call mpas_duplicate_field(srcReal, dstReal)
   dstReal % fieldName = field_name
+  dstReal % outputFieldName = field_name
   call mpas_pool_add_field(outpool, dstReal % fieldName, dstReal)
   call mpas_pool_add_field(all_fields, dstReal % fieldName, dstReal)
   if (present(target_ptr)) then

--- a/components/mpas-seaice/src/analysis_members/time_series_inc/copy_field.F
+++ b/components/mpas-seaice/src/analysis_members/time_series_inc/copy_field.F
@@ -8,11 +8,19 @@
   call mpas_duplicate_field(src, dst)
 
   dst % fieldName = outname
+  dst % outputFieldName = outname
 
   if (associated(dst % constituentNames)) then
     do i = 1, size(dst % constituentNames, dim=1)
       dst % constituentNames(i) = trim(outname) // '_' // &
         trim(dst % constituentNames(i))
+    end do
+  end if
+
+  if (associated(dst % outputConstituentNames)) then
+    do i = 1, size(dst % outputConstituentNames, dim=1)
+      dst % outputConstituentNames(i) = trim(outname) // '_' // &
+        trim(dst % outputConstituentNames(i))
     end do
   end if
 

--- a/components/mpas-seaice/src/analysis_members/time_series_inc/copy_field_2.inc
+++ b/components/mpas-seaice/src/analysis_members/time_series_inc/copy_field_2.inc
@@ -4,11 +4,19 @@
   call mpas_duplicate_field(src, dst)
 
   dst % fieldName = outname
+  dst % outputFieldName = outname
 
   if (associated(dst % constituentNames)) then
     do i = 1, size(dst % constituentNames, dim=1)
       dst % constituentNames(i) = trim(outname) // '_' // &
         trim(dst % constituentNames(i))
+    end do
+  end if
+
+  if (associated(dst % outputConstituentNames)) then
+    do i = 1, size(dst % outputConstituentNames, dim=1)
+      dst % outputConstituentNames(i) = trim(outname) // '_' // &
+        trim(dst % outputConstituentNames(i))
     end do
   end if
 


### PR DESCRIPTION
This can be used to set a different name in output streams than the name in code or the unique name required for input.

This merge also adds corresponding `outputFieldName` and `outputConstituentNames` to each field. These new attributes will be used to allow different names in output than in the code.  Currently, the output name must be unique, but this causes trouble in time mean output, particularly for coordinate variables.