### PR TITLE
Fix barotropic thickness on edge in split explicit subcycling

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -795,12 +795,10 @@ module ocn_time_integration_split
             !$omp end do
             !$omp end parallel
 
-!mrp note, not sure if I need nEdgesAll here, or nEdgesArray(3)?
-!mrp note, if I have bfb partition problems, it could be this section.
             !$omp parallel
             !$omp do schedule(runtime) &
-            !$omp private(k)
-            do iEdge = nEdgesOwned+1, nEdgesArray(3)
+            !$omp private(k, thicknessSum)
+            do iEdge = nEdgesOwned+1, nEdgesArray(4)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
@@ -1111,7 +1109,7 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(i, k, iEdge, cell1, cell2, sshEdge, &
+               !$omp private(i, iEdge, cell1, cell2, sshEdge, &
                !$omp         thicknessSum, flux)
                do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
@@ -1126,13 +1124,8 @@ module ocn_time_integration_split
                                           sshSubcycleCur(cell2))
 
                      ! Compute barotropic thickness at the edge. Note this
-                     ! must match the sum of baroclinic thicknesses at this
-                     ! edge.
-                     ! This version works with pbcs, but only for z-level and z-star
-                     k = maxLevelEdgeTop(iEdge)
-                     thicknessSum = sshEdge + 0.5_RKIND &
-                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
-                          + min(bottomDepth(cell2), refBottomDepth(k)) )
+                     ! matches the sum of baroclinic thicknesses at this edge.
+                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1170,7 +1163,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(k, cell1, cell2, sshEdge,thicknessSum,flux)
+                  !$omp private(cell1, cell2, sshEdge,thicknessSum,flux)
                   do iEdge = 1, nEdges
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
                      cell1 = cellsOnEdge(1,iEdge)
@@ -1179,14 +1172,7 @@ module ocn_time_integration_split
                      sshEdge = 0.5_RKIND*(sshSubcycleCur(cell1) + &
                                           sshSubcycleCur(cell2))
 
-                     ! Compute barotropic thickness at the edge. Note this
-                     ! must match the sum of baroclinic thicknesses at this
-                     ! edge.
-                     ! This version works with pbcs, but only for z-level and z-star
-                     k = maxLevelEdgeTop(iEdge)
-                     thicknessSum = sshEdge + 0.5_RKIND &
-                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
-                          + min(bottomDepth(cell2), refBottomDepth(k)) )
+                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1392,7 +1378,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(i, k, iEdge, cell1, cell2, thicknessSum, &
+                  !$omp private(i, iEdge, cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
                   do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
@@ -1416,14 +1402,7 @@ module ocn_time_integration_split
 
                         sshEdge = 0.5_RKIND*(sshCell1 + sshCell2)
 
-                        ! Compute barotropic thickness at the edge. Note this
-                        ! must match the sum of baroclinic thicknesses at this
-                        ! edge.
-                        ! This version works with pbcs, but only for z-level and z-star
-                        k = maxLevelEdgeTop(iEdge)
-                        thicknessSum = sshEdge + 0.5_RKIND &
-                           *(  min(bottomDepth(cell1), refBottomDepth(k)) &
-                             + min(bottomDepth(cell2), refBottomDepth(k)) )
+                        thicknessSum = sshEdge + bottomDepthEdge(iEdge)
 
                         flux = ((1.0-config_btr_gam3_velWt2)* &
                            normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1446,7 +1425,7 @@ module ocn_time_integration_split
 
                   ! compute barotropic thickness flux on edges
                   !$omp do schedule(runtime) &
-                  !$omp private(k, cell1, cell2, thicknessSum, &
+                  !$omp private(cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
                   do iEdge = 1, nEdges
                      cell1 = cellsOnEdge(1,iEdge)
@@ -1463,14 +1442,7 @@ module ocn_time_integration_split
                                       sshSubcycleNew(cell2)
                      sshEdge = 0.5_RKIND * (sshCell1 + sshCell2)
 
-                     ! Compute barotropic thickness at the edge. Note this
-                     ! must match the sum of baroclinic thicknesses at this
-                     ! edge.
-                     ! This version works with pbcs, but only for z-level and z-star
-                     k = maxLevelEdgeTop(iEdge)
-                     thicknessSum = sshEdge + 0.5_RKIND &
-                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
-                          + min(bottomDepth(cell2), refBottomDepth(k)) )
+                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam3_velWt2) * &
                          normalBarotropicVelocitySubcycleCur(iEdge) &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -173,6 +173,8 @@ module ocn_time_integration_split
          edgeHaloComputeCounter, &! halo counters to reduce
          cellHaloComputeCounter   ! halo updates during cycling
 
+      integer, dimension(:), pointer :: nEdgesArray
+
       real (kind=RKIND) :: &
          normalThicknessFluxSum, &! sum of thickness flux in column
          thicknessSum,     &! sum of thicknesses in column
@@ -191,7 +193,8 @@ module ocn_time_integration_split
          uTemp
 
       real (kind=RKIND), dimension(:), allocatable :: &
-         btrvel_temp
+         btrvel_temp, &
+         bottomDepthEdge
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -381,6 +384,10 @@ module ocn_time_integration_split
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+
+      call mpas_pool_get_dimension(meshPool,'nEdgesArray', nEdgesArray)
+
+      allocate(bottomDepthEdge(nEdgesAll+1))
 
       if (config_transport_tests_flow_id > 0) then
         ! This is a transport test. Write advection velocity from prescribed
@@ -768,6 +775,8 @@ module ocn_time_integration_split
                enddo
                barotropicForcing(iEdge) = splitFact* &
                               normalThicknessFluxSum/thicknessSum/dt
+               bottomDepthEdge(iEdge) = thicknessSum &
+                  - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
 
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
@@ -782,6 +791,25 @@ module ocn_time_integration_split
 
                enddo
 
+            enddo ! iEdge
+            !$omp end do
+            !$omp end parallel
+
+!mrp note, not sure if I need nEdgesAll here, or nEdgesArray(3)?
+!mrp note, if I have bfb partition problems, it could be this section.
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k)
+            do iEdge = nEdgesOwned+1, nEdgesArray(3)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                  thicknessSum = thicknessSum + &
+                                 layerThickEdgeFlux(k,iEdge)
+               enddo
+               bottomDepthEdge(iEdge) = thicknessSum &
+                  - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
             !$omp end do
             !$omp end parallel
@@ -2682,6 +2710,7 @@ module ocn_time_integration_split
          call mpas_dmpar_exch_halo_field(effectiveDensityField)
          call mpas_timer_stop("se effective density halo")
       end if
+      deallocate(bottomDepthEdge)
 
       call mpas_timer_stop('se fini')
       call mpas_timer_stop("se timestep")

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1083,12 +1083,13 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(i, iEdge, cell1, cell2, sshEdge, &
+               !$omp private(i, k, iEdge, cell1, cell2, sshEdge, &
                !$omp         thicknessSum, flux)
                do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
+                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
                      cell1 = cellsOnEdge(1, iEdge)
                      cell2 = cellsOnEdge(2, iEdge)
@@ -1096,20 +1097,14 @@ module ocn_time_integration_split
                      sshEdge = 0.5_RKIND*(sshSubcycleCur(cell1) + &
                                           sshSubcycleCur(cell2))
 
-                     ! method 0: orig, works only without pbc:
-                     !thicknessSum = sshEdge + &
-                     ! refBottomDepthTopOfCell(maxLevelEdgeTop(iEdge)+1)
-
-                     ! method 1, matches method 0 without pbcs, works with pbcs.
-                     thicknessSum = sshEdge + min(bottomDepth(cell1), &
-                                                  bottomDepth(cell2))
-
-                     ! method 2: may be better than method 1.
-                     ! Take average  of full thickness at two
-                     ! neighboring cells.
-                     !thicknessSum = sshEdge + 0.5* &
-                     !      (bottomDepth(cell1) + bottomDepth(cell2))
-
+                     ! Compute barotropic thickness at the edge. Note this
+                     ! must match the sum of baroclinic thicknesses at this
+                     ! edge.
+                     ! This version works with pbcs, but only for z-level and z-star
+                     k = maxLevelEdgeTop(iEdge)
+                     thicknessSum = sshEdge + 0.5_RKIND &
+                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
+                          + min(bottomDepth(cell2), refBottomDepth(k)) )
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1147,18 +1142,23 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(cell1, cell2, sshEdge,thicknessSum,flux)
+                  !$omp private(k, cell1, cell2, sshEdge,thicknessSum,flux)
                   do iEdge = 1, nEdges
+                     if (maxLevelEdgeTop(iEdge).eq.0) cycle
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
 
                      sshEdge = 0.5_RKIND*(sshSubcycleCur(cell1) + &
                                           sshSubcycleCur(cell2))
 
-                     ! method 1, matches method 0 without pbcs,
-                     !    works with pbcs.
-                     thicknessSum = sshEdge + min(bottomDepth(cell1), &
-                                                  bottomDepth(cell2))
+                     ! Compute barotropic thickness at the edge. Note this
+                     ! must match the sum of baroclinic thicknesses at this
+                     ! edge.
+                     ! This version works with pbcs, but only for z-level and z-star
+                     k = maxLevelEdgeTop(iEdge)
+                     thicknessSum = sshEdge + 0.5_RKIND &
+                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
+                          + min(bottomDepth(cell2), refBottomDepth(k)) )
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1364,12 +1364,13 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(i, iEdge, cell1, cell2, thicknessSum, &
+                  !$omp private(i, k, iEdge, cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
                   do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
                         iEdge = edgesOnCell(i, iCell)
+                        if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
                         cell1 = cellsOnEdge(1,iEdge)
                         cell2 = cellsOnEdge(2,iEdge)
@@ -1387,21 +1388,14 @@ module ocn_time_integration_split
 
                         sshEdge = 0.5_RKIND*(sshCell1 + sshCell2)
 
-                        ! method 0: orig, works only without pbc:
-                        !thicknessSum = sshEdge + &
-                        !refBottomDepthTopOfCell(maxLevelEdgeTop(iEdge)+1)
-
-                        ! method 1, matches method 0 without pbcs,
-                        !    but works with pbcs.
-                        thicknessSum = sshEdge + &
-                                       min(bottomDepth(cell1), &
-                                           bottomDepth(cell2))
-
-                        ! method 2: may be better than method 1.
-                        ! take average of full thickness at two
-                        !    neighboring cells
-                        !thicknessSum = sshEdge + 0.5* &
-                        !   (bottomDepth(cell1) + bottomDepth (cell2))
+                        ! Compute barotropic thickness at the edge. Note this
+                        ! must match the sum of baroclinic thicknesses at this
+                        ! edge.
+                        ! This version works with pbcs, but only for z-level and z-star
+                        k = maxLevelEdgeTop(iEdge)
+                        thicknessSum = sshEdge + 0.5_RKIND &
+                           *(  min(bottomDepth(cell1), refBottomDepth(k)) &
+                             + min(bottomDepth(cell2), refBottomDepth(k)) )
 
                         flux = ((1.0-config_btr_gam3_velWt2)* &
                            normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1424,7 +1418,7 @@ module ocn_time_integration_split
 
                   ! compute barotropic thickness flux on edges
                   !$omp do schedule(runtime) &
-                  !$omp private(cell1, cell2, thicknessSum, &
+                  !$omp private(k, cell1, cell2, thicknessSum, &
                   !$omp         sshCell1, sshCell2, sshEdge, flux)
                   do iEdge = 1, nEdges
                      cell1 = cellsOnEdge(1,iEdge)
@@ -1441,21 +1435,14 @@ module ocn_time_integration_split
                                       sshSubcycleNew(cell2)
                      sshEdge = 0.5_RKIND * (sshCell1 + sshCell2)
 
-                     ! method 0: orig, works only without pbc:
-                     !thicknessSum = sshEdge + &
-                     !refBottomDepthTopOfCell(maxLevelEdgeTop(iEdge)+1)
-
-                     ! method 1, matches method 0 without pbcs,
-                     !           but works with pbcs.
-                     thicknessSum = sshEdge + min(bottomDepth(cell1),&
-                                                  bottomDepth(cell2))
-
-                     ! method 2, better, I think.
-                     !           take average of full thickness at two
-                     !           neighboring cells
-                     !thicknessSum = sshEdge + 0.5* &
-                     !               (bottomDepth(cell1) + &
-                     !                bottomDepth(cell2) )
+                     ! Compute barotropic thickness at the edge. Note this
+                     ! must match the sum of baroclinic thicknesses at this
+                     ! edge.
+                     ! This version works with pbcs, but only for z-level and z-star
+                     k = maxLevelEdgeTop(iEdge)
+                     thicknessSum = sshEdge + 0.5_RKIND &
+                        *(  min(bottomDepth(cell1), refBottomDepth(k)) &
+                          + min(bottomDepth(cell2), refBottomDepth(k)) )
 
                      flux = ((1.0-config_btr_gam3_velWt2) * &
                          normalBarotropicVelocitySubcycleCur(iEdge) &


### PR DESCRIPTION
Barotropic thickness at the edge must match the sum of baroclinic thicknesses at that edge. More notes soon...