### PR TITLE
New ocean drag feature: use harmonic mean edge layer thickness

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2772,6 +2772,11 @@
 			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
+		<var name="layerThicknessEdgeDrag" type="real" dimensions="nVertLevels nEdges Time" units="m"
+			 description="layer thickness to be used for drag terms"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="layerThicknessEdgeMean" type="real" dimensions="nVertLevels nEdges Time" units="m"
 			 description="layer thickness averaged from cell center to edges"
 			 missing_value="FILLVAL" missing_value_mask="edgeMask"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1117,6 +1117,10 @@
 					description="Dimensionless topographic wave drag coefficient, $c_{topo}$."
 					possible_values="any positive real, typically 5.0e-4"
 		/>
+		<nml_option name="config_thickness_drag_type" type="character" default_value="centered"
+					description="The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'."
+					possible_values="'harmonic-mean', 'centered'"
+		/>
 
 	</nml_record>
 	<nml_record name="wetting_drying" mode="init;forward">

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -226,7 +226,7 @@ contains
 #endif
 
       ! inputs: layerThickness, normalVelocity
-      ! output: layerThickEdgeMean, layerThickEdgeFlux
+      ! output: layerThickEdgeMean, layerThickEdgeDrag, layerThickEdgeFlux
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, &
                                                    layerThickness)
 
@@ -469,7 +469,8 @@ contains
 
 #ifdef MPAS_OPENACC
       !! Listing outputs by first routine that modifies variable
-      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdgeFlux, (diagnostics array)
+      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdgeDrag, (diagnostics array)
+      !!                                            layerThickEdgeFlux, (diagnostics array)
       !!                                            layerThickEdgeMean (diagnostics array)
       !! ocn_relativeVorticity_circulation       :: relativeVorticity, (diagnostics array)
       !!                                            circulation (diagnostics array)
@@ -507,7 +508,7 @@ contains
       !! ocn_diagnostic_solve_ssh                :: pressureAdjustedSSH, (diagnostics array)
       !!                                            gradSSH (diagnostics array)
 
-!     !$acc update host(layerThickEdgeFlux, layerThickEdgeCenter)
+!     !$acc update host(layerThickEdgeDrag, layerThickEdgeFlux, layerThickEdgeCenter)
 !     !$acc update host(relativeVorticity, circulation)
 !     !$acc update host(vertTransportVelocityTop, &
 !     !$acc             vertGMBolusVelocityTop, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -508,7 +508,9 @@ contains
       !! ocn_diagnostic_solve_ssh                :: pressureAdjustedSSH, (diagnostics array)
       !!                                            gradSSH (diagnostics array)
 
-!     !$acc update host(layerThickEdgeDrag, layerThickEdgeFlux, layerThickEdgeCenter)
+!     !$acc update host(layerThickEdgeDrag, &
+!     !$acc             layerThickEdgeFlux, &
+!     !$acc             layerThickEdgeMean)
 !     !$acc update host(relativeVorticity, circulation)
 !     !$acc update host(vertTransportVelocityTop, &
 !     !$acc             vertGMBolusVelocityTop, &
@@ -660,10 +662,10 @@ contains
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
-!>  This routine computes the diagnostic variables layerThickEdgeFlux
-!>  and layerThickEdgeMean. The Mean is a simple mean across the edge
-!>  but the Flux value can either be the mean or an upwind value,
-!>  depending on user input.
+!>  This routine computes the diagnostic variables layerThickEdgeDrag,
+!>  layerThickEdgeFlux, and layerThickEdgeMean. The Mean is a simple
+!>  mean across the edge but the Flux value can either be the mean or
+!>  an upwind value, depending on user input.
 !
 !-----------------------------------------------------------------------
 
@@ -684,6 +686,7 @@ contains
 
       ! Outputs are the shared variables from diagnostic_variables:
       !real (kind=RKIND), dimension(:,:), intent(out) :: &
+      !   layerThickEdgeDrag, & !< [out] layer thickness on edge for drag
       !   layerThickEdgeMean, & !< [out] centered layer thickness on edge
       !   layerThickEdgeFlux    !< [out] flux-related thickness on edge
 
@@ -802,6 +805,25 @@ contains
                              MPAS_LOG_CRIT)
 
       end select
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop collapse(2) &
+      !$acc    present(layerThickEdgeDrag, layerThickEdgeMean)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+#endif
+      do iEdge = 1, nEdgesAll
+      do k = 1,nVertLevels
+         layerThickEdgeDrag(k,iEdge) = &
+         layerThickEdgeMean(k,iEdge)
+      end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -857,9 +857,9 @@ contains
             end do
             do k = kmin,kmax
                ! central differenced
-               layerThickEdgeDrag(k,iEdge) = 2.0_RKIND / &
-                                            (1/max(layerThickness(k,cell1), 1e-9_RKIND) + &
-                                             1/max(layerThickness(k,cell2), 1e-9_RKIND))
+               layerThickEdgeDrag(k,iEdge) = &
+                   2.0_RKIND * layerThickness(k,cell1) * layerThickness(k,cell2)/ &
+                   (max(layerThickness(k,cell1)+layerThickness(k,cell2), 1e-9_RKIND))
             end do
          end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -78,11 +78,17 @@ module ocn_diagnostics
    real (kind=RKIND), pointer ::  coef_3rd_order
 
    ! Methods for computing thickness at edges for flux calculations
-   integer :: thickEdgeFluxChoice  ! choice of thickness flux type
+   integer :: &
+      thickEdgeFluxChoice, &! choice of thickness flux type
+      thickEdgeDragChoice   ! choice of thickness drag type
    integer, parameter :: &
       thickEdgeFluxUnknown = 0, &! type unknown or unset
       thickEdgeFluxCenter  = 1, &! use mean thickness of cell neighbors
       thickEdgeFluxUpwind  = 2   ! use upwind cell thickness at edge
+   integer, parameter :: &
+      thickEdgeDragUnknown = 0, &! type unknown or unset
+      thickEdgeDragCenter  = 1, &! use mean thickness of cell neighbors
+      thickEdgeDragHarMean = 2   ! use harmonic mean cell thickness at edge
 
 !***********************************************************************
 
@@ -686,9 +692,9 @@ contains
 
       ! Outputs are the shared variables from diagnostic_variables:
       !real (kind=RKIND), dimension(:,:), intent(out) :: &
-      !   layerThickEdgeDrag, & !< [out] layer thickness on edge for drag
-      !   layerThickEdgeMean, & !< [out] centered layer thickness on edge
-      !   layerThickEdgeFlux    !< [out] flux-related thickness on edge
+      !   layerThickEdgeDrag,    & !< [out] layer thickness on edge for drag
+      !   layerThickEdgeMean,    & !< [out] centered layer thickness on edge
+      !   layerThickEdgeFlux       !< [out] flux-related thickness on edge
 
       !-----------------------------------------------------------------
       ! local variables
@@ -806,23 +812,67 @@ contains
 
       end select
 
+      ! Compute edge flux based on option set on init
+      select case (thickEdgeDragChoice)
+
+      case (thickEdgeDragCenter)
 #ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) &
-      !$acc    present(layerThickEdgeDrag, layerThickEdgeMean)
+         !$acc parallel loop collapse(2) &
+         !$acc    present(layerThickEdgeDrag, layerThickEdgeMean)
 #else
-      !$omp parallel
-      !$omp do schedule(runtime) private(k)
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
 #endif
-      do iEdge = 1, nEdgesAll
-      do k = 1,nVertLevels
-         layerThickEdgeDrag(k,iEdge) = &
-         layerThickEdgeMean(k,iEdge)
-      end do
-      end do
+         do iEdge = 1, nEdgesAll
+         do k = 1,nVertLevels
+            layerThickEdgeDrag(k,iEdge) = &
+            layerThickEdgeMean(k,iEdge)
+         end do
+         end do
 #ifndef MPAS_OPENACC
-      !$omp end do
-      !$omp end parallel
+        !$omp end do
+        !$omp end parallel
 #endif
+
+      case (thickEdgeDragHarMean)
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(layerThickness, layerThickEdgeDrag, &
+         !$acc            minLevelEdgeBot, maxLevelEdgeTop, cellsOnEdge) &
+         !$acc    private(k, kmin, kmax, cell1, cell2)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+#endif
+         do iEdge = 1, nEdgesAll
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k = 1,nVertLevels
+               ! initialize layerThicknessEdgeMean to avoid divide by
+               ! zero and NaN problems.
+               layerThickEdgeDrag(k,iEdge) = -1.0e34_RKIND
+            end do
+            do k = kmin,kmax
+               ! central differenced
+               layerThickEdgeDrag(k,iEdge) = 2.0_RKIND / &
+                                            (1/max(layerThickness(k,cell1), 1e-9_RKIND) + &
+                                             1/max(layerThickness(k,cell2), 1e-9_RKIND))
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+
+      case default
+         ! Should have been caught on init
+         call mpas_log_write('Thickness flux option unknown', &
+                             MPAS_LOG_CRIT)
+
+      end select
 
 
    !--------------------------------------------------------------------
@@ -4250,6 +4300,23 @@ contains
                  & trim(config_thickness_flux_type) // &
                  & 'is not known', MPAS_LOG_CRIT)
          end if
+      end if
+
+      if (trim(config_thickness_drag_type) == 'centered') then
+         thickEdgeDragChoice = thickEdgeDragCenter
+         call mpas_log_write('Thickness drag option of ' //&
+              & trim(config_thickness_drag_type) // &
+              & 'is assigned')
+      elseif (trim(config_thickness_drag_type) == 'harmonic-mean') then
+         thickEdgeDragChoice = thickEdgeDragHarMean
+         call mpas_log_write('Thickness drag option of ' //&
+              & trim(config_thickness_drag_type) // &
+              & 'is assigned')
+      else
+         thickEdgeFluxChoice = thickEdgeFluxUnknown
+         call mpas_log_write('Thickness drag option of ' //&
+              & trim(config_thickness_drag_type) // &
+              & 'is not known', MPAS_LOG_CRIT)
       end if
 
       call ocn_diagnostics_variables_init(domain, jenkinsOn, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -56,6 +56,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: salineContractCoeff
    real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
    real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeDrag
    real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeFlux
    real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeMean
    real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
@@ -458,6 +459,8 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'vertMLEBolusVelocityTop', &
                    vertMLEBolusVelocityTop)
 
+         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeDrag', &
+                   layerThickEdgeDrag)
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeFlux', &
                    layerThickEdgeFlux)
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeMean', &
@@ -722,6 +725,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
          !$acc                   slopeTriadDown,                  &
@@ -963,6 +967,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
          !$acc                   slopeTriadDown,                  &
@@ -1162,6 +1167,7 @@ contains
                  GMStreamFuncX,                   &
                  GMStreamFuncY,                   &
                  GMStreamFuncZ,                   &
+                 layerThickEdgeDrag,              &
                  layerThickEdgeFlux,              &
                  layerThickEdgeMean,              &
                  slopeTriadDown,                  &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -445,6 +445,7 @@ contains
       ! Add forcing and bottom drag
       call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                 sfcStress, kineticEnergyCell, &
+                                layerThickEdgeDrag, &
                                 layerThickEdgeMean, tendVel, err)
 
       ! vertical mixing treated implicitly in a later routine

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -77,7 +77,8 @@ contains
 
    subroutine ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                    surfaceStress, kineticEnergyCell, &
-                                   layerThickEdgeMean, tend, err)!{{{
+                                   layerThickEdgeDrag, layerThickEdgeMean, &
+                                   tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -86,6 +87,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,    &!< [in] Normal velocity at edges
          kineticEnergyCell, &!< [in] kinetic energy at cell
+         layerThickEdgeDrag,&!< [in] mean thickness at edge to use for drag
          layerThickEdgeMean  !< [in] mean thickness at edge
 
       real (kind=RKIND), dimension(:), intent(in) :: &
@@ -124,7 +126,7 @@ contains
       err = ior(err, err1)
 
       call ocn_vel_forcing_explicit_bottom_drag_tend(normalVelocity, &
-                   kineticEnergyCell, layerThickEdgeMean, tend, err1)
+                   kineticEnergyCell, layerThickEdgeDrag, tend, err1)
       err = ior(err, err1)
 
       call ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -76,7 +76,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_forcing_explicit_bottom_drag_tend(normVelocity, &
-                                 KECell, layerThickEdgeMean, tend, err) !{{{
+                                 KECell, layerThickEdgeDrag, tend, err) !{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -85,7 +85,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normVelocity,      &!< [in] normal velocity
          KECell,            &!< [in] kinetic energy at cell
-         layerThickEdgeMean  !< [in] mean layer thickness at edge
+         layerThickEdgeDrag  !< [in] mean layer thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -130,7 +130,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, maxLevelEdgeTop, KECell, &
-      !$acc            tend, normVelocity, layerThickEdgeMean) &
+      !$acc            tend, normVelocity, layerThickEdgeDrag) &
       !$acc    private(k, cell1, cell2)
 #else
       !$omp parallel
@@ -144,7 +144,7 @@ contains
         if (k > 0) then
            tend(k,iEdge) = tend(k,iEdge) - dragCoeff* &
                            sqrt(KECell(k,cell1) + KECell(k,cell2))* &
-                           normVelocity(k,iEdge)/layerThickEdgeMean(k,iEdge)
+                           normVelocity(k,iEdge)/layerThickEdgeDrag(k,iEdge)
         end if
 
       enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -384,7 +384,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                         layerThickEdgeMean, normalVelocity, err)
+                                         layerThickEdgeDrag, layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -405,7 +405,8 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeMean !< Input: mean thickness at edge
+         layerThickEdgeDrag, &!< Input: mean thickness at edge
+         layerThickEdgeMean   !< Input: mean thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -445,7 +446,7 @@ contains
       !$acc enter data create(bTemp, C, rTemp)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeDrag, layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell) &
       !$acc    private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
 #else
@@ -464,7 +465,7 @@ contains
          if (N .eq. Nsurf) then
             normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
                 / (1.0_RKIND + dt*implicitBottomDragCoef &
-                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
+                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) )
          else
 
            ! tridiagonal matrix algorithm
@@ -497,7 +498,7 @@ contains
            ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
            normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
                / (1.0_RKIND - A + dt*implicitBottomDragCoef &
-               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) &
                - m*C(N-1))
            ! second pass: back substitution
            do k = N-1, Nsurf, -1
@@ -1245,7 +1246,8 @@ contains
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeDrag, &
+          layerThickEdgeMean, normalVelocity, err)
       end if
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -765,7 +765,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iEdge, k, cell1, cell2, N, Nsurf
-      real (kind=RKIND) :: implicitCd
+      real (kind=RKIND) :: implicitCd, bottomDepthDrag, columnThicknessDrag
 
       real (kind=RKIND), dimension(:), allocatable :: bTemp, C, rTemp
       real (kind=RKIND) :: A, m
@@ -835,7 +835,8 @@ contains
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
       !$acc    layerThickEdgeDrag, layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell, bottomDrag, vegetationManning, ssh, bottomDepth) &
-      !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
+      !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k, &
+      !$acc    bottomDepthDrag, columnThicknessDrag)
 #else
       !$omp do schedule(runtime)
 #endif
@@ -848,6 +849,16 @@ contains
          cell2 = cellsOnEdge(2,iEdge)
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
+         if (trim(config_thickness_drag_type) == 'harmonic-mean') then
+           bottomDepthDrag = 2.0_RKIND * bottomDepth(cell1) * bottomDepth(cell2) / &
+                                 (bottomDepth(cell1) + bottomDepth(cell2))
+           columnThicknessDrag = 2.0_RKIND * (ssh(cell1) + bottomDepth(cell1)) * &
+                                             (ssh(cell2) + bottomDepth(cell2)) / &
+                                 (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2))
+         else
+           bottomDepthDrag = 0.5_RKIND * (bottomDepth(cell1) + bottomDepth(cell2))
+           columnThicknessDrag = 0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2))
+         endif
          if (config_use_implicit_bottom_roughness) then
            ! NCOM's formula for bottom drag coefficient
            ! The original formula is cb(i,j) = max(cbmin, (vonk/log(0.5*depth(i,j)/z0))**2 ))
@@ -856,13 +867,13 @@ contains
            ! averaging the two bottomDepth cells.
            implicitCd = max(0.0025_RKIND, &
                         min(0.1_RKIND, &
-                          0.16_RKIND/(log(250.0_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))))**2 ))
+                          0.16_RKIND/(log(500.0_RKIND*bottomDepthDrag))**2 ))
          elseif (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
            implicitCd = gravity*(0.5_RKIND*(vegetationManning(cell1) + vegetationManning(cell2)))**2 * &
-            (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
+                        columnThicknessDrag**(-1.0_RKIND/3.0_RKIND)
          else
            implicitCd = gravity*(0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2)))**2 * &
-            (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
+                        columnThicknessDrag**(-1.0_RKIND/3.0_RKIND)
          endif
 
          ! one active layer

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -213,7 +213,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                                  layerThickEdgeMean, normalVelocity, err)
+                                                  layerThickEdgeDrag, layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -234,7 +234,8 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeMean !< Input: mean thickness at edge
+         layerThickEdgeDrag, &!< Input: thickness at edge for drag
+         layerThickEdgeMean   !< Input: mean thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -292,14 +293,14 @@ contains
          cell2 = cellsOnEdge(2,iEdge)
          edgeThicknessTotal = 0.0_RKIND
          do k = Nsurf, N
-            edgeThicknessTotal = edgeThicknessTotal + layerThickEdgeMean(k,iEdge)
+            edgeThicknessTotal = edgeThicknessTotal + layerThickEdgeDrag(k,iEdge)
          enddo
 
          ! one active layer
          if (N .eq. Nsurf) then
            normalVelocity(N,iEdge) = normalVelocity(N,iEdge) &
                / (1.0_RKIND + dt*implicitBottomDragCoef &
-               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) &
                ! added Rayleigh terms
                + dt*(rayleighBottomDampingCoef + rayleighDampingCoef &
                / ((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)))
@@ -340,7 +341,7 @@ contains
            ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
            normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
                / (1.0_RKIND - A + dt*implicitBottomDragCoef &
-               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) &
                ! added Rayleigh terms
                + dt*(rayleighBottomDampingCoef + rayleighDampingCoef &
                / ((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)) &
@@ -543,7 +544,7 @@ contains
 
    subroutine ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, & !{{{
                                          vertViscTopOfEdge, layerThickness, &
-                                         layerThickEdgeMean, normalVelocity, err)
+                                         layerThickEdgeDrag, layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -564,7 +565,8 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeMean !< Input: mean thickness at edge
+         layerThickEdgeDrag, &!< Input: thickness at edge for drag
+         layerThickEdgeMean   !< Input: mean thickness at edge
 
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
@@ -629,7 +631,7 @@ contains
          if (N .eq. Nsurf) then
             normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
                 / (1.0_RKIND + dt*implicitCD &
-                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
+                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) )
          else
 
            ! tridiagonal matrix algorithm
@@ -662,7 +664,7 @@ contains
            ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
            normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
                / (1.0_RKIND - A + dt*implicitCD &
-               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) &
                - m*C(N-1))
            ! second pass: back substitution
            do k = N-1, Nsurf, -1
@@ -707,7 +709,7 @@ contains
 
    subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, dt, & !{{{
                                          kineticEnergyCell, vertViscTopOfEdge, layerThickness, &
-                                         layerThickEdgeMean, normalVelocity, ssh, err)
+                                         layerThickEdgeDrag, layerThickEdgeMean, normalVelocity, ssh, err)
 
       !-----------------------------------------------------------------
       !
@@ -731,7 +733,8 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeMean !< Input: mean thickness at edge
+         layerThickEdgeDrag, &!< Input: thickness at edge for drag
+         layerThickEdgeMean   !< Input: mean thickness at edge
 
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
@@ -830,7 +833,7 @@ contains
       !$acc enter data create(vegetationManning)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeDrag, layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell, bottomDrag, vegetationManning, ssh, bottomDepth) &
       !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
 #else
@@ -866,7 +869,7 @@ contains
          if (N .eq. Nsurf) then
            normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
                 / (1.0_RKIND + dt*implicitCD &
-                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
+                   * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) )
          else
 
            ! tridiagonal matrix algorithm
@@ -899,7 +902,7 @@ contains
            ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
            normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
                / (1.0_RKIND - A + dt*implicitCD &
-               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
+               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeDrag(N,iEdge) &
                - m*C(N-1))
            ! second pass: back substitution
            do k = N-1, Nsurf, -1
@@ -1231,19 +1234,20 @@ contains
 #endif
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeDrag, layerThickEdgeMean, normalVelocity, err)
       else if (config_use_implicit_bottom_drag_variable_mannings.or. &
                config_use_implicit_bottom_roughness) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, &
-          ssh, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeDrag, &
+          layerThickEdgeMean, normalVelocity, ssh, err)
       else if (config_Rayleigh_friction.or. &
                config_Rayleigh_bottom_friction.or. &
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeDrag, &
+          layerThickEdgeMean, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeDrag, &


### PR DESCRIPTION
Here we add a new drag feature to MPAS-Ocean. The namelist option `config_thickness_drag_type` indicates what method is to be used for computing the layer thickness at edges used in the implicit drag term. The default option, `'centered'`, is bit-for-bit and retains the arithmetic mean computation. The new option, `'harmonic-mean'`, uses the harmonic mean of the neighboring cell layer thickness, thus increasing the drag anywhere there are horizontal gradients in layer thickness. When used, this change improves the performance of MPAS-Ocean in wetting-and-drying simulations relative to the analytical solution in the test case from Warner et al. (2013) shown below.

`config_thickness_drag_type = 'centered'`
<img src="https://user-images.githubusercontent.com/12041014/211853192-2ac21a1f-bbc4-4079-a7c2-f013f33a19a1.png" width="300">

`config_thickness_drag_type = 'harmonic-mean'`
<img src="https://user-images.githubusercontent.com/12041014/211853415-b12e0e1e-e913-400b-ad5f-d98067e78e00.png" width="300">