### PR TITLE
New implicit top drag feature

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1024,8 +1024,8 @@
 					description="The density of land ice."
 					possible_values="Any positive real number"
 		/>
-		<nml_option name="config_land_ice_flux_topDragCoeff" type="real" default_value="2.5e-3"
-					description="The top drag coefficient."
+		<nml_option name="config_land_ice_flux_explicit_topDragCoeff" type="real" default_value="2.5e-3"
+					description="The top drag coefficient if config_use_implicit_top_drag_coeff is false."
 					possible_values="Any positive real number"
 		/>
 		<nml_option name="config_land_ice_flux_ISOMIP_gammaT" type="real" default_value="1e-4" units="m s^-1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1089,6 +1089,14 @@
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>
+		<nml_option name="config_use_implicit_top_drag" type="logical" default_value=".false."
+					description="If true, implicit top drag is used on the momentum equation."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_implicit_top_drag_coeff" type="real" default_value="1.0e-3"
+					description="Dimensionless top drag coefficient, $c_{drag}$."
+					possible_values="any positive real, typically 1.0e-3"
+		/>
 		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false."
 					description="If true, depends on bottom roughness z0"
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -75,6 +75,7 @@ module ocn_diagnostics
 
    integer :: ke_cell_flag, ke_vertex_flag
    real (kind=RKIND) ::  fCoef
+   real (kind=RKIND) ::  landIceTopDragCoeff
    real (kind=RKIND), pointer ::  coef_3rd_order
 
    ! Methods for computing thickness at edges for flux calculations
@@ -3306,7 +3307,7 @@ contains
          velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell2),cell2))
          landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
-         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &
+         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * landIceTopDragCoeff &
                           * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
       end do
@@ -3324,11 +3325,11 @@ contains
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
-                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
+                           * 2.0_RKIND * landIceTopDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
 
          ! the friction velocity is the square root of the top drag + variance of tidal velocity
          ! (computed regardless of land-ice coverage)
-         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * &
+         landIceFrictionVelocity(iCell) = sqrt(landIceTopDragCoeff * &
                                    (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
                                    + config_land_ice_flux_rms_tidal_velocity**2))
       end do
@@ -4228,6 +4229,13 @@ contains
                  & 'is not known', MPAS_LOG_CRIT)
          end if
       end if
+
+      ! Initialize coefficient choice for computing land ice drag
+      if (config_use_implicit_top_drag) then
+         landIceTopDragCoeff = config_implicit_top_drag_coeff
+      else
+         landIceTopDragCoeff = config_land_ice_flux_explicit_topDragCoeff
+      endif
 
       call ocn_diagnostics_variables_init(domain, jenkinsOn, &
                                           hollandJenkinsOn, err)

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -188,6 +188,7 @@ contains
 
       err = 0
       if (.not.landIceFluxesOn) return
+      if (config_use_implicit_top_drag) return
 
       call mpas_timer_start("top_drag", .false.)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -34,6 +34,7 @@ module ocn_vmix
    use ocn_vmix_gotm
    use ocn_vmix_coefs_redi
    use ocn_diagnostics_variables
+   use ocn_surface_land_ice_fluxes
 
    implicit none
    private
@@ -64,7 +65,7 @@ module ocn_vmix
    !--------------------------------------------------------------------
 
    logical :: velVmixOn, tracerVmixOn
-   real (kind=RKIND) :: implicitBottomDragCoef
+   real (kind=RKIND) :: implicitBottomDragCoef, implicitTopDragCoef
    real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef, &
                         rayleighDepthVariable
 
@@ -384,7 +385,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                         layerThickEdgeMean, normalVelocity, err)
+                                         layerThickEdgeMean, landIceEdgeFraction, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -406,6 +407,9 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickEdgeMean !< Input: mean thickness at edge
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         landIceEdgeFraction !< Input: land ice fraction
 
       !-----------------------------------------------------------------
       !
@@ -446,7 +450,7 @@ contains
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
       !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell) &
+      !$acc    landIceEdgeFraction, kineticEnergyCell) &
       !$acc    private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
 #else
       !$omp parallel
@@ -463,7 +467,7 @@ contains
          ! one active layer
          if (N .eq. Nsurf) then
             normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
-                / (1.0_RKIND + dt*implicitBottomDragCoef &
+                / (1.0_RKIND + dt*(implicitTopDragCoef * landIceEdgeFraction(iEdge) + implicitBottomDragCoef) &
                    * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
          else
 
@@ -471,7 +475,10 @@ contains
            C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
                       / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
                       / layerThickEdgeMean(Nsurf,iEdge)
-           bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
+           bTemp(Nsurf) = 1.0_RKIND - C(Nsurf) &
+              + dt * implicitTopDragCoef * landIceEdgeFraction(iEdge) &
+                * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / &
+                layerThickEdgeMean(N,iEdge)
            rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
            ! first pass: set the coefficients
@@ -1122,7 +1129,8 @@ contains
       type (mpas_pool_type), pointer :: tracersPool, tracersSurfaceFluxPool
 
       integer :: iCell, timeLevel, k, cell1, cell2, iEdge, iTracer, num_tracers, nCells, nEdges, N, Nsurf
-      real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh
+      real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh, landIceFraction
+      real (kind=RKIND), dimension(:), allocatable :: landIceEdgeFraction
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
@@ -1144,6 +1152,33 @@ contains
       end if
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
+
+      allocate(landIceEdgeFraction(nEdgesOwned))
+      landIceEdgeFraction(:) = 0.0_RKIND
+      if (landIcePressureOn) then
+         call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(landIceFraction)
+
+         !$acc parallel loop present(landIceEdgeFraction) &
+         !$acc    private(cell1, cell2, k)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, k)
+#endif
+         do iEdge = 1, nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            landIceEdgeFraction(iEdge) = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
+         end do
+#ifdef MPAS_OPENACC
+         !$acc exit data copyout(landIceFraction)
+#else
+         !$omp end do
+         !$omp end parallel
+#endif
+      end if
+
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
@@ -1245,7 +1280,8 @@ contains
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, &
+          landIceEdgeFraction, normalVelocity, err)
       end if
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)
@@ -1405,9 +1441,13 @@ contains
       if(config_disable_tr_vmix.or.config_disable_tr_all_tend) tracerVmixOn = .false.
 
       implicitBottomDragCoef = 0.0_RKIND
+      implicitTopDragCoef = 0.0_RKIND
 
       if (config_use_implicit_bottom_drag) then
           implicitBottomDragCoef = config_implicit_bottom_drag_coeff
+      endif
+      if (config_use_implicit_top_drag) then
+          implicitTopDragCoef = config_implicit_top_drag_coeff
       endif
 
       call ocn_vmix_cvmix_init(domain,err_tmp)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -477,8 +477,8 @@ contains
                       / layerThickEdgeMean(Nsurf,iEdge)
            bTemp(Nsurf) = 1.0_RKIND - C(Nsurf) &
               + dt * implicitTopDragCoef * landIceEdgeFraction(iEdge) &
-                * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / &
-                layerThickEdgeMean(N,iEdge)
+                * sqrt(kineticEnergyCell(Nsurf,cell1) + kineticEnergyCell(Nsurf,cell2)) / &
+                layerThickEdgeMean(Nsurf,iEdge)
            rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
            ! first pass: set the coefficients

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1443,6 +1443,12 @@ contains
       implicitBottomDragCoef = 0.0_RKIND
       implicitTopDragCoef = 0.0_RKIND
 
+      if (config_use_implicit_top_drag .and. &
+          .not. config_use_implicit_bottom_drag) then
+         call mpas_log_write('Implicit top drag can only be used with ' //&
+              & 'implicit bottom drag', MPAS_LOG_CRIT)
+      endif
+
       if (config_use_implicit_bottom_drag) then
           implicitBottomDragCoef = config_implicit_bottom_drag_coeff
       endif


### PR DESCRIPTION
This PR creates a new option to use implicit top drag in the same manner as implicit bottom drag. It assumes that the only setting in which top drag will be used is in land ice-covered regions. 

Implicit top drag is activated by setting `config_use_implicit_top_drag = .true.` and `config_implicit_top_drag_coeff` > 0 and `config_land_ice_flux_mode = 'standalone'` (while also ensuring that at least part of the domain has `landIceFraction` > 0).

[BFB]