### PR TITLE
New floating land ice variables

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1996,6 +1996,7 @@
 				immutable="true">
 			<var name="landIcePressureForcing"/>
 			<var name="landIceFractionForcing"/>
+			<var name="landIceFloatingFractionForcing"/>
 			<var name="landIceDraftForcing"/>
 		</stream>
 
@@ -3823,6 +3824,10 @@
 			packages="timeVaryingAtmosphericForcingPKG"
 		/>
 		<var name="landIceFractionForcing" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by land ice"
+			packages="timeVaryingLandIceForcingPKG"
+		/>
+		<var name="landIceFloatingFractionForcing" type="real" dimensions="nCells Time" units="1"
 			description="The fraction of each cell covered by land ice"
 			packages="timeVaryingLandIceForcingPKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3626,7 +3626,7 @@
 			description="The fraction of each cell covered by an ice shelf"
 			packages="landIcePressurePKG"
 		/>
-		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time"
+		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time" default_value="-1"
 			description="Mask indicating where an ice shelf is present (1) or absent (0)"
 			packages="landIcePressurePKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1640,6 +1640,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -1749,6 +1751,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 		<stream name="block_debug_output"
 				type="output"
@@ -1848,6 +1852,8 @@
 			<var name="landIceDraft"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var name="seaIcePressure"/>
 			<var name="atmosphericPressure"/>
 			<var_array name="tracersSurfaceValue"/>
@@ -2106,6 +2112,8 @@
 			<var name="nAccumulatedCoupled"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var_array name="landIceInterfaceTracers"/>
 			<var_array name="landIceBoundaryLayerTracers"/>
 			<var name="landIceFrictionVelocity"/>
@@ -3611,6 +3619,14 @@
 		/>
 		<var name="landIceMask" type="integer" dimensions="nCells Time"
 			description="Mask indicating where land-ice is present (1) or absent (0)"
+			packages="landIcePressurePKG"
+		/>
+		<var name="landIceFloatingFraction" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by an ice shelf"
+			packages="landIcePressurePKG"
+		/>
+		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time"
+			description="Mask indicating where an ice shelf is present (1) or absent (0)"
 			packages="landIcePressurePKG"
 		/>
 		<var name="landIcePressure" type="real" dimensions="nCells Time" units="Pa"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -234,7 +234,7 @@ contains
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
       integer, dimension(:), pointer :: minLevelCell, minLevelEdgeBot, minLevelVertexTop, maxLevelCell, &
-          maxLevelEdgeTop, maxLevelVertexBot, landiceMask
+          maxLevelEdgeTop, maxLevelVertexBot, landIceFloatingMask
 
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
@@ -364,7 +364,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
          call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
          call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
          call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
          call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersPistonVelocity', &
@@ -381,8 +381,8 @@ contains
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
 
          allocate(landIceFloatingArea(1:nCellsSolve))
-         if ( associated(landIceMask) ) then
-            landIceFloatingArea = landIceMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
+         if ( associated(landIceFloatingMask) ) then
+            landIceFloatingArea = landIceFloatingMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
          else
             landIceFloatingArea = 0.
          end if

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -176,7 +176,7 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceFloatingMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
@@ -214,7 +214,7 @@ contains
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -286,11 +286,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceMask) ) then
+               if (associated(landIceFloatingMask) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -352,11 +352,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceMask) ) then
+         if (associated(landIceFloatingMask) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
            end do
            !$omp end do
            !$omp end parallel
@@ -417,11 +417,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceMask) ) then
+         if (associated(landIceFloatingMask) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -176,7 +176,6 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceFloatingMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
@@ -214,7 +213,6 @@ contains
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -286,11 +284,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceFloatingMask) ) then
+               if (associated(landIceDraft) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -352,11 +350,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceFloatingMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel
@@ -417,11 +415,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceFloatingMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1192,6 +1192,10 @@ contains
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
           call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
+          if (landIceFloatingMask(1) == -1) then
+             call mpas_log_write('landIceFloatingMask contains the default value which is invalid.', &
+                                 MPAS_LOG_CRIT)
+          endif
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
           modifyLandIcePressureMask(:) = 0

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1193,7 +1193,7 @@ contains
           call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
           if (landIceFloatingMask(1) == -1) then
-             call mpas_log_write('landIceFloatingMask contains the default value which is invalid.', &
+             call mpas_log_write('landIceFloatingMask contains the default value which likely indicates that this field is missing in the initial condition file (e.g. because it is meant for an older E3SM version).', &
                                  MPAS_LOG_CRIT)
           endif
           ssh(:) = 0.0_RKIND

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1096,7 +1096,7 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceFloatingFracObserved', landIceFloatingFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFloatingFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
 
           if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
@@ -1187,8 +1187,10 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
           call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1069,13 +1069,16 @@ contains
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
        real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, landIceDraftObserved, &
-                                                   landIceFracObserved, landIceGroundedFracObserved
+                                                   landIceFracObserved, &
+                                                   landIceFloatingFracObserved, &
+                                                   landIceGroundedFracObserved
 
-       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, ssh, &
+       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+                                                   landIceFloatingFraction, ssh, &
                                                    bottomDepth
 
        integer, pointer :: nCells
-       integer, dimension(:), pointer :: maxLevelCell, landIceMask
+       integer, dimension(:), pointer :: maxLevelCell, landIceMask, landIceFloatingMask
 
        integer :: iCell
 
@@ -1093,6 +1096,7 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFloatingFracObserved', landIceFloatingFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
 
           if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
@@ -1194,6 +1198,9 @@ contains
 
              if(landIceMask(iCell) == 1) then
                 landIceFraction(iCell) = landIceFracObserved(iCell)
+             end if
+             if(landIceFloatingMask(iCell) == 1) then
+                landIceFloatingFraction(iCell) = landIceFloatingFracObserved(iCell)
              end if
 
              ! nothing to do here if the cell is land

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -166,6 +166,10 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+         if (landIceFloatingMask(1) == -1) then
+            call mpas_log_write('landIceFloatingMask contains the default value which is invalid.', &
+                                MPAS_LOG_CRIT)
+         endif
       end if
 
       nEdges = nEdgesAll

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -133,7 +133,7 @@ contains
         frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
 
       integer, dimension(:), pointer :: &
-        landIceMask
+        landIceFloatingMask
 
       call mpas_timer_start('diagnostic solve')
 
@@ -164,7 +164,7 @@ contains
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       end if
 
@@ -440,11 +440,11 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       !
-      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceMask
+      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceFloatingMask
       ! outputs: 
       if (landIcePressureOn) then
          call ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, activeTracers, &
-                landIceFraction, landIceMask, timeLevel, indexTemperature, indexSalinity)
+                landIceFraction, landIceFloatingMask, timeLevel, indexTemperature, indexSalinity)
       end if
 
       if ( full_compute ) then
@@ -3224,7 +3224,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, &
-      activeTracers, landIceFraction, landIceMask, &
+      activeTracers, landIceFraction, landIceFloatingMask, &
       timeLevel, indexTval, indexSval)!{{{
 
       !-----------------------------------------------------------------
@@ -3245,7 +3245,7 @@ contains
          activeTracers
 
       integer, dimension(:), intent(in) :: &
-         landIceMask
+         landIceFloatingMask
 
       !-----------------------------------------------------------------
       !
@@ -3288,7 +3288,7 @@ contains
                blSaltScratch(nCellsAll))
       !$acc enter data create(blTempScratch, blSaltScratch)
 
-      ! Compute top drag
+      ! Compute top drag everywhere there is grounded or floating land ice
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(landIceFraction)
 
@@ -3449,15 +3449,15 @@ contains
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceMask)
+      !$acc enter data copyin(landIceFloatingMask)
 
-      !$acc parallel loop present(landIceMask, sfcFlxAttCoeff)
+      !$acc parallel loop present(landIceFloatingMask, sfcFlxAttCoeff)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if(landIceMask(iCell) == 1) then
+         if(landIceFloatingMask(iCell) == 1) then
             sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -167,7 +167,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
          if (landIceFloatingMask(1) == -1) then
-            call mpas_log_write('landIceFloatingMask contains the default value which is invalid.', &
+            call mpas_log_write('landIceFloatingMask contains the default value which likely indicates that this field is missing in the initial condition file (e.g. because it is meant for an older E3SM version).', &
                                 MPAS_LOG_CRIT)
          endif
       end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -200,7 +200,6 @@ module ocn_eddy_parameterization_helpers
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
-     integer, dimension(:), pointer :: landIceFloatingMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
      real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
@@ -212,7 +211,6 @@ module ocn_eddy_parameterization_helpers
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -284,11 +282,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceFloatingMask) ) then
+        if (associated(landIceDraft) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -200,7 +200,7 @@ module ocn_eddy_parameterization_helpers
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
-     integer, dimension(:), pointer :: landIceMask
+     integer, dimension(:), pointer :: landIceFloatingMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
      real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
@@ -212,7 +212,7 @@ module ocn_eddy_parameterization_helpers
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -284,11 +284,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceMask) ) then
+        if (associated(landIceFloatingMask) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -113,7 +113,7 @@ contains
          effectiveDensityNew   ! effective density at new time level
                                                   
       integer, dimension(:), pointer :: &
-         landIceMask           ! mask for land ice presence on cell
+         landIceFloatingMask   ! mask for land ice presence on cell
 
       ! Scratch Arrays
       ! effectiveDensityScratch: effective seawater density in land
@@ -130,8 +130,8 @@ contains
       if ( (trim(config_land_ice_flux_mode) /= 'coupled') ) return
 
       ! Retrieve forcing and state variables
-      call mpas_pool_get_array(forcingPool, 'landIceMask', &
-                                             landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', &
+                                             landIceFloatingMask)
       call mpas_pool_get_array(forcingPool, 'landIcePressure', &
                                              landIcePressure)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
@@ -139,7 +139,7 @@ contains
                                            effectiveDensityCur, 1)
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
                                            effectiveDensityNew, 2)
-      !$acc enter data copyin(landIceMask, landIcePressure, ssh, &
+      !$acc enter data copyin(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                   effectiveDensityCur, effectiveDensityNew)
 
       allocate(effectiveDensityScratch(nCellsAll))
@@ -151,13 +151,13 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(effectiveDensityScratch, effectiveDensityCur, &
-      !$acc            landIcePressure, landIceMask, ssh)
+      !$acc            landIcePressure, landIceFloatingMask, ssh)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if (landIceMask(iCell) == 1) then
+         if (landIceFloatingMask(iCell) == 1) then
             ! land ice is present to update the effective density
             effectiveDensityScratch(iCell) = -landIcePressure(iCell)/ &
                                               (ssh(iCell)*gravity)
@@ -198,7 +198,7 @@ contains
 #endif
 
       !$acc exit data delete(effectiveDensityScratch)
-      !$acc exit data delete(landIceMask, landIcePressure, ssh, &
+      !$acc exit data delete(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                  effectiveDensityCur, effectiveDensityNew)
       deallocate(effectiveDensityScratch)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -354,7 +354,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
       real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
       real (kind=RKIND), dimension(:), pointer :: frazilSurfacePressure
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceMask, landIceFloatingMask
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
@@ -383,7 +383,7 @@ contains
       integer, pointer :: indexSalinity !< index in tracers array for salinity
       integer :: kBottomFrazil  ! k index where testing for frazil begins
 
-      logical :: underLandIce ! indicates if we are under land ice
+      logical :: underFloatingLandIce, underLandIce ! indicates if we are under land ice
 
       real (kind=RKIND) :: potential  ! scalar holding freezing/melt potential
       real (kind=RKIND) :: freezingEnergy  ! energy available for freezing, positive definite
@@ -423,6 +423,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       ! get time step in units of seconds
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err)
@@ -439,7 +440,7 @@ contains
       ! loop over all columns
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
+      !$omp private(underFloatingLandIce, underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
       !$omp         sumNewThicknessWeightedSaltContent, oceanFreezingTemperature, potential, &
       !$omp         freezingEnergy, meltingEnergy, frazilSalinity, newFrazilIceThickness, &
       !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, &
@@ -451,13 +452,23 @@ contains
            underLandIce = (landIceMask(iCell) == 1)
         end if
 
-        if (underLandIce .and. .not. config_frazil_under_land_ice) then
-          ! skip this cell because we're not doing frazil under land ice
+        underFloatingLandIce = .false.
+        if ( associated(landIceFloatingMask) ) then
+           underFloatingLandIce = (landIceFloatingMask(iCell) == 1)
+        end if
+
+        if (underFloatingLandIce .and. .not. config_frazil_under_land_ice) then
+          ! skip this cell because we're not doing frazil under floating land ice
           cycle
         end if
 
         if (.not. underLandIce .and. .not. config_frazil_in_open_ocean) then
           ! skip this cell because we're not doing frazil in the open ocean
+          cycle
+        end if
+
+        if (underLandIce .and. .not. underFloatingLandIce) then
+          ! skip this cell because we're not doing frazil under grounded land ice
           cycle
         end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -429,7 +429,7 @@ contains
 
       real (kind=RKIND) :: freshwaterFlux, heatFlux
 
-      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFloatingFraction, &
                                                   landIceSurfaceTemperature, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce
@@ -438,7 +438,7 @@ contains
                                                   accumulatedLandIceHeatOld, &
                                                   accumulatedLandIceHeatNew
 
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceFloatingMask
 
       real (kind=RKIND), dimension(:,:), pointer :: &
                                                     landIceInterfaceTracers
@@ -467,8 +467,8 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
-      call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
       call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
@@ -499,7 +499,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
             ! linearized equaiton for the S and p dependent potential freezing temperature
             landIceInterfaceTracers(indexIT,iCell) = ocn_freezing_temperature( &
@@ -514,14 +514,14 @@ contains
             freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*freshwaterFlux
 
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
             heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
                               + rho_sw*ISOMIPgammaT &
                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*heatFlux
 
             heatFluxToLandIce(iCell) = 0.0_RKIND
 
@@ -534,7 +534,7 @@ contains
          if(useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -556,7 +556,7 @@ contains
 
             ! freezing solution
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -576,7 +576,7 @@ contains
             end if
 
             do iCell = 1, nCells
-               if ((landIceMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
+               if ((landIceFloatingMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
 
                landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
                landIceInterfaceTracers(indexIT,iCell) = freezeInterfaceTemperature(iCell)
@@ -586,7 +586,7 @@ contains
             end do
          else ! not using Holland and Jenkins advection/diffusion
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -606,13 +606,13 @@ contains
             end if
          end if
 
-         ! modulate the fluxes by the landIceFraction
+         ! modulate the fluxes by the landIceFloatingFraction
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*landIceFreshwaterFlux(iCell)
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*landIceHeatFlux(iCell)
-            heatFluxToLandIce(iCell) = landIceFraction(iCell)*heatFluxToLandIce(iCell)
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*landIceFreshwaterFlux(iCell)
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*landIceHeatFlux(iCell)
+            heatFluxToLandIce(iCell) = landIceFloatingFraction(iCell)*heatFluxToLandIce(iCell)
          end do
 
       endif ! jenkinsOn or hollandJenkinsOn

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -443,6 +443,10 @@ contains
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
     call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIceFloatingFraction", "land_ice_forcing", "timeVaryingForcing", "landIceFloatingFractionForcing", "linear", &
+         config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
          "landIceDraft", "land_ice_forcing", "timeVaryingForcing", "landIceDraftForcing", "linear", &
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
@@ -495,6 +499,8 @@ contains
     real(kind=RKIND), dimension(:), pointer :: &
          landIceFractionForcing, &
          landIceFraction, &
+         landIceFloatingFractionForcing, &
+         landIceFloatingFraction, &
          landIcePressureForcing, &
          landIcePressure, &
          landIceDraftForcing, &
@@ -525,15 +531,18 @@ contains
        call MPAS_pool_get_dimension(mesh, "nCells", nCells)
    
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFractionForcing", landIceFractionForcing)
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFloatingFractionForcing", landIceFloatingFractionForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIcePressureForcing", landIcePressureForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceDraftForcing", landIceDraftForcing)
        call MPAS_pool_get_array(forcingPool, "landIceFraction", landIceFraction)
+       call MPAS_pool_get_array(forcingPool, "landIceFloatingFraction", landIceFloatingFraction)
        call MPAS_pool_get_array(forcingPool, "landIcePressure", landIcePressure)
        call MPAS_pool_get_array(forcingPool, "landIceDraft", landIceDraft)
    
        do iCell = 1, nCells
    
           landIceFraction(iCell) = landIceFractionForcing(iCell)
+          landIceFloatingFraction(iCell) = landIceFloatingFractionForcing(iCell)
           landIcePressure(iCell) = landIcePressureForcing(iCell)
           landIceDraft(iCell) = landIceDraftForcing(iCell)
    

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -189,7 +189,7 @@ contains
 
       if (config_use_idealAgeTracers_idealAge_forcing) then
          ! set mask = 0 for open ocean
-         ! set mask = 1 under ice shelves
+         ! set mask = 1 under land ice
          idealAgeMask = 0.0_RKIND
          if (associated(landIceMask)) then
             where (landIceMask /= 0) idealAgeMask(1,:) = 1.0_RKIND


### PR DESCRIPTION
This PR adds new variables to represent floating land ice. 

- `landIceMask` and `landIceFraction` (existing variables) now represent both grounded and floating land ice.
- `landIceFloatingMask` and `landIceFloatingFraction (new variables)` represent only floating land ice.

The `landIceFloating*` variables are used to modulate land ice fluxes, whereas the `landIce*` variables modulate the land ice pressure. `landIce*` variables also modulate top drag, as we want to include the effect of top drag on thin film regions to slow flow.