### PR TITLE
add data assimilation capability to mpas-ocean

### DIFF
--- a/components/mpas-ocean/driver/ECDA_mpaso_obs_mod.F
+++ b/components/mpas-ocean/driver/ECDA_mpaso_obs_mod.F
@@ -1,0 +1,636 @@
+!BOP
+!   !MODULE: ecda_mpaso_obs_mod
+!   !INTERFACE:
+module ECDA_mpaso_obs_mod
+!   !DESCRIPTION:
+!   ! Define the obs variable type and corresponding obsope
+!   !
+!   !REVISION HISTORY:
+!    Jul  2019 Y. Liu <liu6@tamu.edu> initial release
+!   !USES:
+
+  use shr_kind_mod, only : r8=> shr_kind_r8
+  use ecda_shr_type_mod
+  use ECDA_mpaso_state_mod 
+  use seq_comm_mct,  only : logunit
+  use shr_file_mod,      only : shr_file_getUnit,     &
+                                  shr_file_freeUnit,    &
+                                  shr_file_setIO,       &
+                                  shr_file_getLogUnit,  &
+                                  shr_file_setLogUnit,  &
+                                  shr_file_getLogLevel, &
+                                  shr_file_setLogLevel
+
+  implicit none
+  public :: ocn_obs_init, set_obs_type_value, ocn_obs_type_register, &
+            observation_deallocate, phys2ij_mercator
+  
+  integer, parameter, public :: max_OCN_obs_type =  10    ! Currently using T,S,U,V,zeta 
+  
+  integer, parameter, public :: O_rea_TEMP_ID = 1     ! index of reanalysis ocn temperature
+  integer, parameter, public :: O_rea_SALT_ID = 2     ! index of reanalysis ocn salinity
+  integer, parameter, public :: O_rea_VEL_ID = 3     ! index of reanalysis ocn velocity
+  integer, parameter, public :: O_rea_SSH_ID = 4     ! index of reanalysis ocn surface height
+
+
+  integer, parameter, public :: O_GRID_MODEL     = 1        ! instrument type for reanalysis with the same grids as ocean model 
+  integer, parameter, public :: O_GRID_NONMODEL =  2         ! grid observation but not the model grid
+  integer, parameter, public :: O_profile =  3         ! grid observation but not the model grid
+
+  integer, public :: NUM_OCN_obs_type
+!  type(ECDA_obs_type),public         ::  OCN_obs_data(max_OCN_obs_type) 
+  type(ECDA_obs_type),allocatable,public         ::  OCN_obs_data(:) 
+
+contains
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_obs_init
+!   initialize the OCN obs for DA
+!   define the observations
+!   !INTERFACE:
+
+    subroutine ocn_obs_init()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_obs_init) '
+        integer :: iob,i,j,k,ierr
+        integer :: inst_type
+!        logical :: update_states(n_OCN_state),required_states(n_OCN_state)
+!        allocate (OCN_obs_data(max_OCN_obs_type)        
+        do iob=1,NUM_OCN_obs_type
+           OCN_obs_data(iob)%assimilate=.False.    
+           allocate (OCN_obs_data(iob)%required_states(n_OCN_state), stat=ierr)
+           allocate (OCN_obs_data(iob)%update_states(n_OCN_state), stat=ierr)
+           OCN_obs_data(iob)%required_states = .FALSE.
+           OCN_obs_data(iob)%update_states   = .FALSE.
+           OCN_obs_data(iob)%grid_type    = O_GRID_MODEL       ! set model grid as default
+        enddo
+
+     end subroutine ocn_obs_init
+    
+!==============================================================================
+!BOP
+! ! Rountine set_obs_type_value(obs_data,...)
+! ! set the obs configures
+ 
+    subroutine set_obs_type_value(ID,obs_name,filename,dm_name,inst_type,assimilate, required_states, update_states)
+      
+! EOP 
+       integer, intent(in)                                    ::      ID
+       character(*),optional,intent(in)                       ::      obs_name
+       character(*),optional,intent(in)                       ::      filename
+       character(*),optional,intent(in)                       ::      dm_name
+       integer, optional,intent(in)                           ::      inst_type
+       logical, optional,intent(in)                           ::      assimilate, &
+                                                                      required_states(n_OCN_state), &
+                                                                      update_states(n_OCN_state)
+                                                       
+      if(present(obs_name)) OCN_obs_data(ID)%obs_name    = obs_name
+      if(present(filename)) OCN_obs_data(ID)%filename = filename
+      if(present(dm_name)) OCN_obs_data(ID)%dm_name = dm_name
+      if(present(inst_type)) OCN_obs_data(ID)%inst_type = inst_type
+      if(present(assimilate)) OCN_obs_data(ID)%assimilate = assimilate
+      if(present(required_states)) OCN_obs_data(ID)%required_states = required_states
+      if(present(update_states)) OCN_obs_data(ID)%update_states = update_states
+
+    end subroutine set_obs_type_value
+    
+!==============================================================================
+
+!BOP
+!   !ROUTINE: ocn_obs_type_register
+!   register the ocean observation type  for DA
+!
+!   !INTERFACE:
+
+  subroutine ocn_obs_type_register()
+!EOP
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_obs_type_register) '
+        character(len = filename_len) :: nml_inpfile = 'ocean_da.namelist'
+        integer :: i,j,k,iob,iunit,rc,ierr
+        logical :: exists
+        logical :: obs_avalaible(max_OCN_obs_type)=.False.
+        character(len = type_name_len) ::  assim_obs_types(max_OCN_obs_type) = 'null'
+        namelist /obs_kind_nml/assim_obs_types
+        
+        NUM_OCN_obs_type=0
+        ! -read namelist for observation type        
+        inquire(file=trim(nml_inpfile), exist=exists)
+        if (.not. exists) return
+        iunit = shr_file_getUnit()
+        open(unit = iunit, file = trim(nml_inpfile), action = 'read')
+        read(unit = iunit, nml = obs_kind_nml, iostat = ierr)
+        close(unit = iunit)
+        call shr_file_freeUnit( iunit )
+        !- loop to get total number of assim. obs type
+        do i = 1, max_OCN_obs_type      
+           if(assim_obs_types(i) == 'null' .or. len_trim(assim_obs_types(i)) == 0 ) exit
+           NUM_OCN_obs_type = i
+        end do
+        if(NUM_OCN_obs_type == 0) return
+
+        !- initialize the observation variabel
+        allocate(OCN_obs_data(NUM_OCN_obs_type),stat=ierr)
+        call ocn_obs_init()
+
+        !- specific obs type  to assim, read the coresponding namelist file for
+        !assim. setting
+        do i= 1, NUM_OCN_obs_type  
+              OCN_obs_data(i)%obs_name=assim_obs_types(i)   
+              OCN_obs_data(i)%assimilate= .true.
+              call read_obs_assim_namelist(i,exists)   ! if ierr is not true, error, need revisit @ YL
+               RR=max(RR,OCN_obs_data(i)%RR_xy)         ! find maxium localization cutoff for  grid setting
+                ! active related state variable for DA
+              do k=1,n_OCN_state
+                 if( OCN_obs_data(i)%required_states(k).or. OCN_obs_data(i)%update_states(k)) &
+                     OCN_DAstate_data(k)%required = .true.
+              end do
+        end do
+        ! Falling off the end is an error
+         write(logunit,*) trim(subname), 'finish','NUM_OCN_obs_type',NUM_OCN_obs_type
+
+     end subroutine ocn_obs_type_register
+
+
+!==============================================================================
+!BOP
+    !ROUTINe: read_obs_assim_namelist
+    !real namelist for assimilation setting of a observation
+!   !INTERFACE:
+!  subroutine read_obs_assim_namelist(ID,exists)
+  subroutine read_obs_assim_namelist(ID,exists)
+! @YL need refine for define all values
+!EOP
+    integer, intent(in)   :: ID
+    logical, intent(out) :: exists
+!EOC
+    character(*), parameter :: subName =   '(read_obs_assim_namelist) '
+    character(len=type_name_len)         ::   obs_name              ! state variable  name,ex : ocn_temp,ocn_salt...
+    integer                              ::   obs_type            ! observation ID  name,ex : e.g. O_rea_TEMP_ID...
+    character(len=filename_len)          ::   filename='null'          ! the obs file name or part
+    character(len=var_name_len)          ::   varname='varname'           ! the obs variable name in ncfile 
+    character(len=var_name_len)          ::   uncert_name='null'    ! the obs variable name in ncfile 
+    character(len=var_name_len)          ::   lonname='longitude'           ! the lon coordinator name in ncfile 
+    character(len=var_name_len)          ::   latname='latitude'            ! the lat coordinator name in ncfile 
+    character(len=var_name_len)          ::   vertical_name= 'depth'         ! vertical
+    character(len=var_name_len)          ::   dm_name= 'records'
+    character(len=10)                    ::   init_obs_YMDH='2010010112'     ! the inital time to observations
+    integer                              ::   uncert_type = 1       ! variance 0 ,std 1 default, not valid when err_var0 >0 applies
+    integer                              ::   grid_type = 1      !  netcdf file, 1,2 are grid file, 1: model grid, 2 other resolution, need read coordinator information, 3: station data, (lon,lat,lev, value,error) 
+    integer                              ::   obs_dm = 2                                ! data dimension in file, only used for grid file
+    integer                              ::   start_layer = 1                           ! data start  from (vertical layer) for 3D,only used for grid file
+    integer                              ::   nlayer                                 ! total vertical layer for 3D,only used for grid file
+    integer                              ::   ilayer                                 ! pick vertical layer ,only used for grid file
+    integer                              ::   inst_type =0                             ! instrument types are defined by platform class (e.g. MOORING, DROP) and instrument type (XBT, CTD, ...), not active now @YL
+    logical                              ::   required_states(n_OCN_state)=.false.   ! the required state variables for obsope 
+    logical                              ::   update_states(n_OCN_state)=.false.     ! the updated  state variables for current variable 
+    real(r8)                             ::   skip_sfc(n_OCN_state)=0                ! skip surface for ssh lik observation 
+    real(r8)                             ::   RR_xy=10.0, RR_z=200.0                 !
+    real(r8)                             ::   Mx_PO_dist=10.0                        ! maxium distance allowed between observation and forecast
+    real(r8)                             ::   Mx_misfit=25                           ! maxium rate allowed for inflate  observation uncertainty
+    real(r8)                             ::   err_var0 = -1.0                          ! specify constant observation error variance (>0). When <=0, input from observation file, default.
+    real(r8)                             ::   adj_scale= 1.0               !some variable need adjust scale
+
+    integer :: ierr
+    integer :: iunit
+    real(r8):: obs_err_var0
+    namelist /obs_assim_nml/obs_name,obs_type,filename,inst_type,varname,lonname,latname,vertical_name,&
+                           grid_type, obs_dm,uncert_name, start_layer, nlayer, ilayer,&
+                           required_states,update_states,skip_sfc,RR_xy,RR_z,Mx_PO_dist,Mx_misfit,err_var0, &
+                           init_obs_YMDH,dm_name,uncert_type,adj_scale
+
+  !  write(logunit,*) trim(subname),' obs namelist: ',trim(filename),',',trim(lonname),',',trim(varname),',',trim(vertical_name),',',trim(latname) &
+  !                    ,',', trim(uncert_name)
+    inquire(file=trim(OCN_obs_data(ID)%obs_name)//'.nml', exist=exists)
+    if (.not. exists) then 
+        write(logunit,*) trim(subname),'error: can not find mamelist file: ',trim(OCN_obs_data(ID)%obs_name)//'.nml'
+       return
+    endif
+    iunit = shr_file_getUnit()
+    open(unit = iunit, file=trim(OCN_obs_data(ID)%obs_name)//'.nml', action = 'read')
+    read(unit = iunit, nml = obs_assim_nml, iostat = ierr)
+    close(unit = iunit)
+    call shr_file_freeUnit(iunit)
+    if(trim(obs_name) .ne. trim(OCN_obs_data(ID)%obs_name))then
+        write(logunit,*) trim(subname),'obs_name do name match ',trim(obs_name),trim(OCN_obs_data(ID)%obs_name)
+        return    
+    endif
+   ! write(logunit,*) trim(subname),' obs namelist: ',trim(filename),',',trim(lonname),',',trim(varname),',',trim(vertical_name),',',trim(latname) &
+   !                   ,',', trim(uncert_name)
+        
+
+    allocate (OCN_obs_data(ID)%required_states(n_OCN_state), stat=ierr)
+    allocate (OCN_obs_data(ID)%update_states(n_OCN_state), stat=ierr)
+    allocate (OCN_obs_data(ID)%skip_sfc(n_OCN_state), stat=ierr)
+
+    OCN_obs_data(ID)%obs_type  = obs_type
+    OCN_obs_data(ID)%filename  = filename
+    OCN_obs_data(ID)%inst_type  = inst_type
+    OCN_obs_data(ID)%dm_name   = dm_name 
+    OCN_obs_data(ID)%varname   = varname
+    OCN_obs_data(ID)%uncert_name   = uncert_name
+    OCN_obs_data(ID)%init_obs_YMDH   = init_obs_YMDH
+    
+    OCN_obs_data(ID)%required_states = required_states
+    OCN_obs_data(ID)%update_states = update_states
+    OCN_obs_data(ID)%grid_type = grid_type
+    OCN_obs_data(ID)%obs_dm = obs_dm
+    OCN_obs_data(ID)%lonname = lonname
+    OCN_obs_data(ID)%latname = latname
+    OCN_obs_data(ID)%vertical_name = vertical_name
+    OCN_obs_data(ID)%dm_name = dm_name
+    OCN_obs_data(ID)%skip_sfc = skip_sfc
+    OCN_obs_data(ID)%RR_xy=RR_xy
+    OCN_obs_data(ID)%RR_z=RR_z
+    OCN_obs_data(ID)%err_var0=err_var0 
+    OCN_obs_data(ID)%Mx_PO_dist=Mx_PO_dist
+    OCN_obs_data(ID)%Mx_misfit=Mx_misfit
+    OCN_obs_data(ID)%uncert_type=uncert_type
+    OCN_obs_data(ID)%adj_scale=adj_scale
+    if(grid_type .ne. 3) then
+        read(init_obs_YMDH(1:4),'(i)') OCN_obs_data(ID)%init_obs_YR
+        read(init_obs_YMDH(5:6),'(i)') OCN_obs_data(ID)%init_obs_MO
+        read(init_obs_YMDH(7:8),'(i)') OCN_obs_data(ID)%init_obs_DY
+        read(init_obs_YMDH(9:10),'(i)') OCN_obs_data(ID)%init_obs_HR
+    endif
+   if(iamroot_da_all)then
+      write(logunit,*) trim(subname),' request/update states: ',required_states,update_states
+      write(logunit,*) trim(subname),' obs namelist: ',trim( OCN_obs_data(ID)%filename),',',trim( OCN_obs_data(ID)%lonname),',',trim( OCN_obs_data(ID)%varname),',',trim( OCN_obs_data(ID)%vertical_name)
+      write(logunit,*) trim(subname),'finsh obs namelist: ',trim(OCN_obs_data(ID)%obs_name)//'.nml'
+    end if 
+  end subroutine read_obs_assim_namelist
+!==============================================================================
+!BOP
+!   !ROUTINE: mpaso_obs_operator
+!   register the ocean observation type  for DA
+!
+!   !INTERFACE:
+  subroutine mpaso_obs_operator(ID,iob,fobs,obs,obs_var, icell_edge)
+
+!EOP
+    integer, intent(in)   :: ID,iob
+    real(r8),intent(out)  :: obs,obs_var
+    real(r8),intent(out)  :: fobs(ensemble_size)
+    integer, intent(out)  ::  icell_edge     ! use for localization @YL
+
+!BOC
+    character(*), parameter :: subName =   '(mpaso_obs_operator) '
+    integer :: da_nbs,da_nbe
+    real(r8),allocatable :: diff_lon(:),diff_lat(:),distance(:)
+    integer  :: state_ID
+    integer  :: ierr, ilocation(1)
+    
+
+
+    ! only for cell elements now @YL
+    da_nbs=da_Cell_nbs
+    da_nbe=da_Cell_nbe
+
+    allocate(diff_lon(da_nbs:da_nbe),diff_lat(da_nbs:da_nbe),distance(da_nbs:da_nbe), stat=ierr)
+
+
+    obs      =   OCN_obs_data(ID)%values(iob)
+    obs_var  =   OCN_obs_data(ID)%err_var(iob)    
+
+    ! assume all the grid is profile, first to find the nearest grid, no interptation @YL
+    ! when use EAKF sequential, obs operateor works on updated model state ( here posterior), the prior do not change during analysis step
+    ! and use to calculate analysis increment and inflation
+
+!= select corresponding state ID
+    select case(OCN_obs_data(ID)%obs_type)
+      case(O_rea_TEMP_ID)
+         state_ID=OCN_TEMP_index
+      case(O_rea_SALT_ID)
+         state_ID=OCN_SALT_index
+      case(O_rea_VEL_ID)
+         state_ID=OCN_VEL_index
+      case(O_rea_SSH_ID)
+         state_ID=OCN_SSH_index
+      CASE DEFAULT
+         write(logunit,*) trim(subname),'observation type:', OCN_obs_data(ID)%obs_type,'not support now'
+    end select
+    
+!=find the closest cell ( only for cell now)   @YL 
+    diff_lon =  abs(OCN_obs_data(ID)%lon(iob)- DA_lonCell)
+    diff_lat =  abs(OCN_obs_data(ID)%lat(iob)- DA_latCell)
+    distance = diff_lon + diff_lat     ! quick fix @YL
+    ilocation=minloc(distance)+ da_nbs-1   ! system think  minloc return with a array. Define an arry  
+    icell_edge= ilocation(1)
+    ! write(logunit,*) trim(subname),'min distance',minval(distance), distance(icell_edge)
+    ! write(logunit,*) trim(subname), &
+    ! OCN_obs_data(ID)%lon(iob),OCN_obs_data(ID)%lat(iob),DA_lonCell(icell_edge),DA_latCell(icell_edge)
+
+    ! assume the surface observation for now 
+    if(OCN_DAstate_data(state_ID)%state_dim==2)  fobs= OCN_DAstate_data(state_ID)%prior2d(icell_edge,1,:)
+    if(OCN_DAstate_data(state_ID)%state_dim==1)  fobs= OCN_DAstate_data(state_ID)%prior1d(icell_edge,:)
+!= spatail anf vertical intep need @YL
+    
+    deallocate(diff_lon,diff_lat,distance)
+
+ 
+  end subroutine mpaso_obs_operator
+
+
+!==============================================================================
+!BOP
+!   !ROUTINE: OCN_obs_operator
+!   register the ocean observation type  for DA
+!
+!   !INTERFACE:
+
+  subroutine OCN_obs_operator(ID,iob,fobs,obs,obs_var)
+!EOP
+    integer, intent(in)   :: ID,iob
+    real(r8),intent(out)  :: obs,obs_var
+    real(r8),intent(out)  :: fobs(ensemble_size)
+
+!BOC
+    character(*), parameter :: subName =   '(OCN_obs_operator) '
+   
+    obs      =   OCN_obs_data(ID)%values(iob)
+    obs_var  =   OCN_obs_data(ID)%err_var(iob)    
+    select case(OCN_obs_data(ID)%grid_type)
+      case(1)
+         call obs_operator_O_reanalysis(ID,iob,fobs)
+      case(2)
+         call obs_operator_O_profile(ID,iob,fobs)
+      case(3)
+         call obs_operator_O_profile(ID,iob,fobs)   
+      CASE DEFAULT
+         write(logunit,*) trim(subname),'grid type:', OCN_obs_data(ID)%grid_type,'not support now'   
+    end select
+!   write(logunit,*) trim(subname),'obs:',obs,obs_var,' forec obs: ',fobs   
+
+  end subroutine OCN_obs_operator
+!==============================================================================
+!BOP
+!   !ROUTINE: obs_operator_O_profile
+!   obs operator for obs with on model grid. no interpotation need 
+!
+!   !INTERFACE:
+
+  subroutine obs_operator_O_profile(ID,iob,fobs)
+!EOP
+    integer, intent(in)   :: ID,iob
+    real(r8),intent(out)  :: fobs(ensemble_size)
+
+!BOC
+    character(*), parameter :: subName =   '(obs_operator_O_profile) '
+    integer  :: state_ID
+    integer  :: i , j, k
+    integer  :: i0 , j0, k0 , i1,j1,k1
+    real(r8) :: ri,rj,rk,ai,aj,ak,depth_diff
+    integer  :: kk(1)
+! here, analysis grid is consistent with model grids, so values of rx,ry,rz are integer. otherwise, intepotation need. 
+! when use EAKF sequential, obs operateor works on updated model state ( here posterior), the prior do not change during analysis step
+! and use to calculate analysis increment and inflation
+
+!= select corresponding state ID
+
+    select case(OCN_obs_data(ID)%obs_type)
+      case(O_rea_TEMP_ID)
+         state_ID=OCN_TEMP_index
+      case(O_rea_SALT_ID)
+         state_ID=OCN_SALT_index
+!      case(O_rea_UVEL_ID)
+!         state_ID=OCN_UVEL_index
+!      case(O_rea_VVEL_ID)
+!         state_ID=OCN_VVEL_index
+!      case(O_rea_SSH_ID)
+!         state_ID=OCN_SSH_index
+      CASE DEFAULT
+         write(logunit,*) trim(subname),'observation type:', OCN_obs_data(ID)%obs_type,'not support now'   
+    end select
+
+!=   for spatial interpotation, implement for 2 D variable ( zeta here @YL) 
+   if(OCN_DAstate_data(state_ID)%state_dim==2) then 
+      i=floor(OCN_obs_data(ID)%rx(iob))       !i,j should within the range of current grids
+      j=floor(OCN_obs_data(ID)%ry(iob))
+      if ( i< da_ibs .or. i>=da_ibe .or. j< da_jbs .or. j>= da_jbe) then
+        write(logunit,*) trim(subname), " terror out of range",da_ibs,da_ibe,i, da_jbs,da_jbe,j
+        fobs=0.0
+        return
+      endif 
+    !k0=floor(OCN_obs_data(ID)%rz(iob))
+      ri= OCN_obs_data(ID)%rx(iob)-i
+      rj= OCN_obs_data(ID)%ry(iob)-j
+      ai=1-ri
+      aj=1-rj
+      fobs= OCN_DAstate_data(state_ID)%posterior2d(i,j,:)*ai*aj &
+           +OCN_DAstate_data(state_ID)%posterior2d(i+1,j,:)*ri*aj &
+           +OCN_DAstate_data(state_ID)%posterior2d(i,j+1,:)*ai*rj &
+           +OCN_DAstate_data(state_ID)%posterior2d(i+1,j+1,:)*ri*rj 
+       
+   endif
+    
+!=   no spatial interpotation for 3d variable, only vertical
+  
+   if(OCN_DAstate_data(state_ID)%state_dim==3) then 
+      i=nint(OCN_obs_data(ID)%rx(iob))
+      j=nint(OCN_obs_data(ID)%ry(iob))
+!= vertical interpotation
+      kk=minloc(abs(z_r_da(i,j,:)-OCN_obs_data(ID)%depth(iob)))
+      k=kk(1)
+      depth_diff=z_r_da(i,j,k)-OCN_obs_data(ID)%depth(iob) 
+      if(abs(depth_diff) <tiny(z_r_da)) then 
+         fobs= OCN_DAstate_data(state_ID)%posterior(i,j,k,:)
+         return
+      endif
+      if(depth_diff > 0.0) then
+         k0=k-1
+      else
+         k0=k+1
+      endif
+      rk=abs(depth_diff/(z_r_da(i,j,k)-z_r_da(i,j,k0))) 
+      ak=1-rk
+      fobs= OCN_DAstate_data(state_ID)%posterior(i,j,k,:)*ak &
+           +OCN_DAstate_data(state_ID)%posterior(i,j,k0,:)*rk 
+   end if
+!   write(logunit,*) trim(subname),'obs:',i,j,OCN_obs_data(ID)%values(iob),OCN_obs_data(ID)%err_var(iob),' forec obs: ',fobs   
+  end SUBROUTINE obs_operator_O_profile
+!==============================================================================
+!BOP
+!==============================================================================
+!BOP
+!   !ROUTINE: obs_operator_O_reanalysis
+!   obs operator for obs with on model grid. no interpotation need 
+!
+!   !INTERFACE:
+
+  subroutine obs_operator_O_reanalysis(ID,iob,fobs)
+!EOP
+    integer, intent(in)   :: ID,iob
+    real(r8),intent(out)  :: fobs(ensemble_size)
+
+!BOC
+    character(*), parameter :: subName =   '(obs_operator_O_reanalysis) '
+    integer  :: state_ID
+    integer  :: i , j, k
+    integer  :: i0 , j0, k0 , i1,j1,k1
+    real(r8) :: ai,aj,ak
+! here, analysis grid is consistent with model grids, so values of rx,ry,rz are integer. otherwise, intepotation need. 
+! when use EAKF sequential, obs operateor works on updated model state ( here posterior), the prior do not change during analysis step
+! and use to calculate analysis increment and inflation
+
+!   for interpotation @YL  
+    i0=floor(OCN_obs_data(ID)%rx(iob))
+    j0=floor(OCN_obs_data(ID)%ry(iob))
+    k0=floor(OCN_obs_data(ID)%rz(iob))
+    ai= OCN_obs_data(ID)%rx(iob)-i0
+    aj= OCN_obs_data(ID)%ry(iob)-j0
+    ak= OCN_obs_data(ID)%rz(iob)-k0
+    
+    i=nint(OCN_obs_data(ID)%rx(iob))
+    j=nint(OCN_obs_data(ID)%ry(iob))
+    
+    select case(OCN_obs_data(ID)%obs_type)
+      case(O_rea_TEMP_ID)
+         state_ID=OCN_TEMP_index
+      case(O_rea_SALT_ID)
+         state_ID=OCN_SALT_index
+!      case(O_rea_UVEL_ID)
+!         state_ID=OCN_UVEL_index
+!      case(O_rea_VVEL_ID)
+!         state_ID=OCN_VVEL_index
+!      case(O_rea_SSH_ID)
+!         state_ID=OCN_SSH_index
+      CASE DEFAULT
+         write(logunit,*) trim(subname),'observation type:', OCN_obs_data(ID)%obs_type,'not support now'   
+    end select
+
+
+    
+   
+    if(OCN_DAstate_data(state_ID)%state_dim==2) then 
+      ! assume the 2D state variabel is on surface layer for now @YL 
+        fobs= OCN_DAstate_data(state_ID)%posterior2d(i,j,:) 
+    endif
+    if(OCN_DAstate_data(state_ID)%state_dim==3) then
+        k=nint(OCN_obs_data(ID)%rz(iob))
+        fobs= OCN_DAstate_data(state_ID)%posterior(i,j,k,:)
+    end if
+  end SUBROUTINE obs_operator_O_reanalysis
+!==============================================================================
+!BOP
+!   !ROUTINE:observation_deallocate 
+!   ! after analysis step ,deallocate  variabels in OCN_obs_data
+!   !   
+!   
+  SUBROUTINE observation_deallocate()
+!EOP
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(observation_deallocate) '
+        integer                 :: ierr, iobs
+        do iobs=1,NUM_OCN_obs_type
+         !  if(.not. OCN_obs_data(iobs)%assimilate) cycle
+           OCN_obs_data(iobs)%nobs=0     ! initial observation numbers
+           deallocate(OCN_obs_data(iobs)%rx,OCN_obs_data(iobs)%ry,OCN_obs_data(iobs)%rz,stat=ierr)
+           deallocate(OCN_obs_data(iobs)%lon,OCN_obs_data(iobs)%lat,OCN_obs_data(iobs)%depth,stat=ierr)
+           deallocate(OCN_obs_data(iobs)%values,OCN_obs_data(iobs)%err_var,OCN_obs_data(iobs)%qc_flag,stat=ierr)
+        enddo
+        !write(logunit,*) trim(subname),'Finished'
+
+  end SUBROUTINE observation_deallocate
+!==============================================================================
+!BOP
+!   !ROUTINE: phys2ij_mercator
+!   observation lat and lon on model grid. 
+!   for  Mercator projection, dlon is even but the dlat is not
+!   not consider the periodic boundary condition @YL
+!   but  latitude may not even
+!
+!   !INTERFACE:
+      SUBROUTINE phys2ij_mercator(rlon,rlat,ri,rj)
+!EOP
+      IMPLICIT NONE
+      real(r8),INTENT(IN) :: rlon,rlat
+      REAL(r8),INTENT(OUT) :: ri,rj
+      integer :: i , j,jj(1),ii(1) 
+      real(r8)  ::  dlon,dlat,dri,drj   
+
+!-    lontigude, even on degree  
+      dlon= lon_da(da_ibs+1,da_jbs)-lon_da(da_ibs,da_jbs)
+      ri= (rlon-lon_da(da_ibs,da_jbs))/dlon+da_ibs
+      i=nint(ri)
+
+!-   latitude , no even
+      jj= minloc(abs(rlat-lat_da(i,:)))
+      j= jj(1)+ da_jbs-1  ! find nearest J, da_jbs is start point
+      if(rlat<lat_da(i,j)) j=j-1     ! make sure rlat locate @ [j, j+1]
+      drj = rlat-lat_da(i,j)
+      if(abs(drj) <tiny(drj))then
+        rj=j
+      else
+        dlat=lat_da(i,j+1)-lat_da(i,j)
+        rj=j+drj/dlat
+      endif     !
+       
+       RETURN
+      END SUBROUTINE phys2ij_mercator
+
+!==============================================================================
+!BOP
+!   !ROUTINE: com_distll_1
+!   copy from Letf  (Takemasa MIYOSHI)
+!   use the Vincenty's formulae
+!   DISTANCE BETWEEN TWO POINTS (LONa,LATa)-(LONb,LATb)
+      SUBROUTINE com_distll_1(alon,alat,blon,blat,dist, chg_unit)
+
+      IMPLICIT NONE
+      REAL(r8),INTENT(IN) :: alon
+      REAL(r8),INTENT(IN) :: alat
+      REAL(r8),INTENT(IN) :: blon
+      REAL(r8),INTENT(IN) :: blat
+      REAL(r8),INTENT(OUT) :: dist
+      REAL(r8),optional,INTENT(in) :: chg_unit 
+
+      REAL(r8),PARAMETER :: r180=1.0d0/180.0d0
+      REAL(r8),PARAMETER :: re=6371.3d3        ! earth radius
+      REAL(r8) :: lon1,lon2,lat1,lat2
+      REAL(r8) :: cosd
+      
+      ! in common situation, need change from degree to radius, chg_unit= pi /180
+      if( present(chg_unit)) then 
+         lon1 = alon * chg_unit
+         lon2 = blon * chg_unit
+         lat1 = alat * chg_unit
+         lat2 = blat * chg_unit
+      else
+         lon1 = alon 
+         lon2 = blon
+         lat1 = alat
+         lat2 = blat 
+      end if 
+
+      cosd = SIN(lat1)*SIN(lat2) + COS(lat1)*COS(lat2)*COS(lon2-lon1)
+      cosd = MIN( 1.d0,cosd)
+      cosd = MAX(-1.d0,cosd)
+      dist = ACOS( cosd ) * re
+
+      RETURN
+      END SUBROUTINE com_distll_1
+
+
+!-----------------------------------------------------------------------
+
+end module ECDA_mpaso_obs_mod
+
+
+             
+
+
+        
+
+
+
+
+                 

--- a/components/mpas-ocean/driver/ECDA_mpaso_state_mod.F
+++ b/components/mpas-ocean/driver/ECDA_mpaso_state_mod.F
@@ -1,0 +1,497 @@
+!BOP
+!   !MODULE: ecda_mpaso_state_mod
+!   !INTERFACE:
+module ECDA_mpaso_state_mod
+!   !DESCRIPTION:
+!   ! Define the state variable type and initialize the state variabel for ODA-EnKF
+!   !
+!   !REVISION HISTORY:
+!    May  2022 Y. Liu <liu6@tamu.edu> initial release
+!   !USES:
+  use shr_kind_mod, only : r8=> shr_kind_r8
+  use ecda_shr_type_mod
+  use seq_comm_mct,  only : logunit
+
+
+  implicit none
+  public :: ocn_DAstate_init, ocn_DAstate_register,set_state_type_value, &
+            average_state_data_calculate,average_state_data_initial, &
+            IAU_state_data_initial,relax_inflation, &
+            ocn_DAstate_allocate,ocn_DAstate_deallocate,&
+            mpaso_DAstate_allocate,mpaso_DAstate_register,mpas_relax_inflation
+ 
+  integer, parameter, public :: n_OCN_state =  4    ! Currently using T,S
+  integer, parameter, public :: OCN_TEMP_index = 1     ! index of ocean temeprature for CELL
+  integer, parameter, public :: OCN_SALT_index = 2     ! index of ocean salinity for ncell
+  integer, parameter, public :: OCN_VEL_index = 3      ! index of ocean velocity
+  integer, parameter, public :: OCN_SSH_index = 4      ! index of ocean SSH
+
+
+  real(r8),public            ::   Mx_da_increm(4) = (/5.0,5.0,2.0,1.0/)              ! set the maxium analysis increment 
+  integer, parameter, public :: OCN_state_dim(n_OCN_state) = (/2,2,2,1/)   ! dimesion of ocean temeprature for CELL
+  
+  integer,public             ::  steps_IAU, IAU_update
+
+  integer,public             ::  my_inst, ensemble_size
+  integer, public            ::  allCellsSolve, DACellsSolve,DACellsSolve_halo
+  integer, public            ::  allEdgesSolve, DAEdgesSolve,DAEdgesSolve_halo
+  integer, public            ::  DA_nvert                  ! total vertical layers
+
+  !    variable for Data assimilation
+  integer,public :: mpicom_ocn_local           ! mpaso model communicator
+  integer,public :: mpicom_da_all,mpicom_da  !comunicator
+  integer,public :: iam_da_all, iam_da       ! comunicater ID
+  logical,public :: iamin_da_all,iamin_da
+  logical,public :: iamroot_da_all,iamroot_da ! root
+
+
+  integer,public             :: da_its,da_ite,da_jts,da_jte            !DA subdomain grid range without halo
+  integer,public             :: da_ibs,da_ibe,da_jbs,da_jbe            !DA subdomain grid range with halo
+  integer,public             :: da_Cell_nts,da_Cell_nte, da_Cell_nbs,da_Cell_nbe           ! for mpaso, [da_Cell_nbs,da_Cell_nbe]=[da_Cell_nts da_Cell_nte]+halo
+  integer,public             :: da_Edge_nts,da_Edge_nte, da_Edge_nbs,da_Edge_nbe           ! 
+
+    integer,public             :: ibs, ibe, jbs, jbe, &
+                                ids, ide, jds, jde, &
+                                its, ite, jts, jte, &
+                                iue, iuw, jvn, jvs
+
+  
+  real(r8),public            ::  RR=0.0                                   ! the default maxium localization cutoff 2*RR=0 
+  logical,public             ::  average_obs = .FALSE.
+  character(len=10),public   ::  YMDH ='2010010100'
+  
+  integer :: ocnDALogUnit     ! unit number for ocn DA log
+!  
+  real(r8),allocatable,public          :: h_da(:,:), lon_da(:,:), lat_da(:,:),z_r_da(:,:,:)
+  real(r8),allocatable,public    :: DA_lonCell(:), DA_latCell(:),DA_lonEdge(:), DA_latEdge(:), DA_depth(:)
+  integer, allocatable,public    :: DA_maxLevelCell(:), DA_indexToCellID(:), DA_indexToEdgeID(:) 
+  type(ECDA_state_type),public         ::  OCN_DAstate_data(n_OCN_state) 
+contains
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_DAstate_init
+!   pre-initialize the OCN state for DA
+!   !INTERFACE:
+
+    subroutine ocn_DAstate_init()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_DAstate_init) '
+        integer :: ivar
+        
+        OCN_DAstate_data(OCN_TEMP_index)%name = 'OCN_temp'
+        OCN_DAstate_data(OCN_SALT_index)%name = 'OCN_salt'
+        OCN_DAstate_data(OCN_VEL_index)%name = 'OCN_vel'
+        OCN_DAstate_data(OCN_SSH_index)%name = 'OCN_zeta'
+        do ivar =1, n_OCN_state
+           OCN_DAstate_data(ivar)%state_dim = OCN_state_dim(ivar)
+           OCN_DAstate_data(ivar)%required = .false.
+           OCN_DAstate_data(ivar)%update = .false.
+           OCN_DAstate_data(ivar)%averaged = .false.
+           OCN_DAstate_data(ivar)%r2p_fac = 0.0         ! no R2P by default, @YL, not useful 
+        end do       
+
+        !-- set the range of states
+        ! temperature 
+        OCN_DAstate_data(OCN_TEMP_index)%mn_value = -1.97  
+        OCN_DAstate_data(OCN_TEMP_index)%mx_value = 40.0 
+        ! salinity
+        OCN_DAstate_data(OCN_SALT_index)%mn_value = 0.001
+        OCN_DAstate_data(OCN_SALT_index)%mx_value = 60.0
+        ! ssh
+        OCN_DAstate_data(OCN_SALT_index)%mn_value = -2.0
+        OCN_DAstate_data(OCN_SALT_index)%mx_value = 2.0
+        ! vel
+        OCN_DAstate_data(OCN_VEl_index)%mn_value = -2.0
+        OCN_DAstate_data(OCN_VEL_index)%mx_value = 2.0
+
+   end subroutine ocn_DAstate_init
+
+
+!==============================================================================
+!BOP
+!   !ROUTINE: mpaso_DAstate_register
+!   register the mpas_o state for DA when it is required
+!   active IAU_increm wen the state is updated for model simulation
+!   
+!   !INTERFACE:
+
+  subroutine mpaso_DAstate_register()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_DAstate_register) '
+        integer :: ivar,ierr
+
+        do ivar = 1, n_OCN_state
+           if (.not.  OCN_DAstate_data(ivar)%required) CYCLE
+           select case (OCN_DAstate_data(ivar)%state_dim)
+              case(1)
+                     if(OCN_DAstate_data(ivar)%averaged) allocate(OCN_DAstate_data(ivar)%ave_value1d(allCellsSolve),stat=ierr)
+                     if(OCN_DAstate_data(ivar)%update) allocate(OCN_DAstate_data(ivar)%IAU_increm1D(allCellsSolve),stat=ierr)
+              case(2) 
+                     if(OCN_DAstate_data(ivar)%averaged) allocate(OCN_DAstate_data(ivar)%ave_value2d(allCellsSolve,DA_nvert),stat=ierr)
+                     if(OCN_DAstate_data(ivar)%update) allocate(OCN_DAstate_data(ivar)%IAU_increm2D(allCellsSolve,DA_nvert),stat=ierr)
+              CASE DEFAULT
+                  write(logunit,*) trim(subname),'state dimension:',OCN_DAstate_data(ivar)%state_dim,'to be develop'
+            end select
+
+        end do
+
+   end subroutine mpaso_DAstate_register
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_DAstate_register
+!   register the OCN state for DA when it is required
+!   active IAU_increm wen the state is updated for model simulation
+!   
+!   !INTERFACE:
+
+  subroutine ocn_DAstate_register()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_DAstate_register) '
+        integer :: ivar,ierr
+
+        do ivar = 1, n_OCN_state
+           if (.not.  OCN_DAstate_data(ivar)%required) CYCLE
+
+           ! allocate 2D state variable ensemble 
+           if (OCN_DAstate_data(ivar)%state_dim == 3) then
+              if(OCN_DAstate_data(ivar)%averaged) allocate(OCN_DAstate_data(ivar)%ave_value(its:ite,jts:jte,DA_nvert),stat=ierr)
+              if(OCN_DAstate_data(ivar)%update)allocate (OCN_DAstate_data(ivar)%IAU_increm(ibs:ibe,jbs:jbe,DA_nvert), stat=ierr)
+           endif
+
+           ! allocate 2D state variable ensemble 
+           if (OCN_DAstate_data(ivar)%state_dim == 2) then
+              if(OCN_DAstate_data(ivar)%averaged) allocate(OCN_DAstate_data(ivar)%ave_value2d(its:ite,jts:jte),stat=ierr)
+              if(OCN_DAstate_data(ivar)%update)allocate (OCN_DAstate_data(ivar)%IAU_increm2d(ibs:ibe,jbs:jbe), stat=ierr)
+           endif
+
+        end do
+
+ end subroutine ocn_DAstate_register
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_DAstate_allocation
+!    allocation the OCN prior,posterior for four DA
+!   active IAU_increm when the state is updated for model simulation
+!   
+!   !INTERFACE:
+
+  subroutine mpaso_DAstate_allocate()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(mpaso_DAstate_deallocate) '
+        integer :: da_nbs,da_nbe
+        integer :: ivar,ierr
+
+
+        do ivar = 1, n_OCN_state
+           if(.not. OCN_DAstate_data(ivar)%required) CYCLE
+           !@YL, need add the edge/cell settings for state type, now only for cell
+           da_nbs=da_Cell_nbs
+           da_nbe=da_Cell_nbe
+           select case (OCN_DAstate_data(ivar)%state_dim)
+                 case(1)
+                      allocate(OCN_DAstate_data(ivar)%prior1d(da_nbs:da_nbe,ensemble_size),&
+                          OCN_DAstate_data(ivar)%posterior1d(da_nbs:da_nbe,ensemble_size),stat=ierr)
+                      if(OCN_DAstate_data(ivar)%averaged) &
+                          allocate(OCN_DAstate_data(ivar)%prior1d_ave(da_nbs:da_nbe,ensemble_size),stat=ierr)
+
+                 case(2)
+                      allocate(OCN_DAstate_data(ivar)%prior2d(da_nbs:da_nbe,da_nvert,ensemble_size),&
+                          OCN_DAstate_data(ivar)%posterior2d(da_nbs:da_nbe,da_nvert,ensemble_size),stat=ierr)
+                      if(OCN_DAstate_data(ivar)%averaged) &
+                          allocate(OCN_DAstate_data(ivar)%prior2d_ave(da_nbs:da_nbe,da_nvert,ensemble_size),stat=ierr)
+
+                 CASE DEFAULT
+                      write(logunit,*)trim(subname),'More dimension to develop'
+                      return
+           end select     
+        enddo
+        !write(logunit,*) trim(subname),' Finished'
+     end subroutine mpaso_DAstate_allocate
+
+!==============================================================================
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_DAstate_allocation
+!    allocation the OCN prior,posterior for four DA
+!   active IAU_increm when the state is updated for model simulation
+!   
+!   !INTERFACE:
+
+  subroutine ocn_DAstate_allocate()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_DAstate_deallocate) '
+        integer :: ivar,ierr
+
+        do ivar = 1, n_OCN_state
+           if(.not. OCN_DAstate_data(ivar)%required) CYCLE
+           if(OCN_DAstate_data(ivar)%state_dim == 2) then
+              allocate (OCN_DAstate_data(ivar)%prior2d(da_ibs:da_ibe,da_jbs:da_jbe,ensemble_size), &
+                    OCN_DAstate_data(ivar)%posterior2d(da_ibs:da_ibe,da_jbs:da_jbe,ensemble_size),&
+                    OCN_DAstate_data(ivar)%KKlev(1), stat=ierr)
+              if(average_obs) &
+               allocate(OCN_DAstate_data(ivar)%prior2d_ave(da_ibs:da_ibe,da_jbs:da_jbe,ensemble_size),stat=ierr)                  
+           endif
+           
+           if(OCN_DAstate_data(ivar)%state_dim == 3) then
+             allocate (OCN_DAstate_data(ivar)%prior(da_ibs:da_ibe,da_jbs:da_jbe,DA_nvert,ensemble_size), &
+                        OCN_DAstate_data(ivar)%posterior(da_ibs:da_ibe,da_jbs:da_jbe,DA_nvert,ensemble_size),&
+                        OCN_DAstate_data(ivar)%KKlev(DA_nvert), stat=ierr)
+              if(average_obs) &
+               allocate(OCN_DAstate_data(ivar)%prior_ave(da_ibs:da_ibe,da_jbs:da_jbe,DA_nvert,ensemble_size),stat=ierr)                  
+           endif
+
+        enddo
+        !write(logunit,*) trim(subname),' Finished'
+     end subroutine ocn_DAstate_allocate
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ocn_DAstate_deallocation
+!    deallocation the OCN prior,posterior for after DA
+!   active IAU_increm wen the state is updated for model simulation
+!   
+!   !INTERFACE:
+
+  subroutine ocn_DAstate_deallocate()
+!EOP
+
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ocn_DAstate_deallocate) '
+        integer :: ivar,ierr
+
+        do ivar = 1, n_OCN_state
+          select case (OCN_DAstate_data(ivar)%state_dim)
+                 case(1)
+                         deallocate(OCN_DAstate_data(ivar)%prior1d, OCN_DAstate_data(ivar)%posterior1d, &
+                                 OCN_DAstate_data(ivar)%prior1d_ave,stat=ierr)
+                 case(2)
+                         deallocate(OCN_DAstate_data(ivar)%prior2d,OCN_DAstate_data(ivar)%posterior2d,&
+                          OCN_DAstate_data(ivar)%prior2d_ave,OCN_DAstate_data(ivar)%KKlev, stat=ierr)
+                 case(3)
+                         deallocate(OCN_DAstate_data(ivar)%prior,OCN_DAstate_data(ivar)%posterior,&
+                          OCN_DAstate_data(ivar)%prior_ave,OCN_DAstate_data(ivar)%KKlev, stat=ierr)
+          CASE DEFAULT
+                  return
+          end select     
+        enddo
+        !write(logunit,*) trim(subname),' Finished'
+ end subroutine ocn_DAstate_deallocate
+
+
+!==============================================================================
+
+!BOP
+! ! Rountine set_state_type_value(obs_data,...)
+! ! set the obs configures
+
+    subroutine set_state_type_value(ID,type_name, state_dim,required, update,averaged,r2p_fac)
+
+! EOP 
+      integer, intent(in)                                    ::      ID
+      character(*),optional,intent(in)                       ::      type_name
+      integer, optional,intent(in)                           ::      state_dim
+      logical, optional,intent(in)                           ::      required, &
+                                                                     update, &
+                                                                     averaged
+      real(r8),optional,intent(in)                           ::      r2p_fac
+
+      if(present(type_name)) OCN_DAstate_data(ID)%name    = type_name
+      if(present(state_dim)) OCN_DAstate_data(ID)%state_dim = state_dim
+      if(present(required)) OCN_DAstate_data(ID)%required = required
+      if(present(update)) OCN_DAstate_data(ID)%update = update
+      if(present(averaged)) OCN_DAstate_data(ID)%averaged = averaged
+      if(present(r2p_fac)) OCN_DAstate_data(ID)%r2p_fac = r2p_fac
+
+    end subroutine set_state_type_value
+
+
+
+!==============================================================================
+!BOP
+! ! Rountine average_state_data_initial()
+! ! set the obs configures
+
+    subroutine average_state_data_initial()
+
+! EOP 
+      integer :: ivar
+      do ivar=1,n_OCN_state
+         if( OCN_DAstate_data(ivar)%required .and. OCN_DAstate_data(ivar)%averaged) then
+            if(OCN_DAstate_data(ivar)%state_dim == 3) OCN_DAstate_data(ivar)%ave_value =0.0
+            if(OCN_DAstate_data(ivar)%state_dim == 2) OCN_DAstate_data(ivar)%ave_value2d =0.0
+            if(OCN_DAstate_data(ivar)%state_dim == 1) OCN_DAstate_data(ivar)%ave_value1d =0.0
+            OCN_DAstate_data(ivar)%ave_num =  0
+         endif
+      enddo
+
+    end subroutine average_state_data_initial
+
+!==============================================================================
+!BOP
+! ! Rountine average_state_data_calculate()
+! ! set the obs configures
+
+    subroutine average_state_data_calculate()
+
+! EOP 
+      integer :: ivar
+      do ivar=1,n_OCN_state
+         if( OCN_DAstate_data(ivar)%required .and. OCN_DAstate_data(ivar)%averaged) then
+            if(OCN_DAstate_data(ivar)%state_dim == 3)&
+               OCN_DAstate_data(ivar)%ave_value = OCN_DAstate_data(ivar)%ave_value/ OCN_DAstate_data(ivar)%ave_num
+            if(OCN_DAstate_data(ivar)%state_dim == 2) &
+               OCN_DAstate_data(ivar)%ave_value2d =OCN_DAstate_data(ivar)%ave_value2d/ OCN_DAstate_data(ivar)%ave_num
+            if(OCN_DAstate_data(ivar)%state_dim == 1) &
+               OCN_DAstate_data(ivar)%ave_value1d =OCN_DAstate_data(ivar)%ave_value1d/ OCN_DAstate_data(ivar)%ave_num
+            OCN_DAstate_data(ivar)%ave_num =  0
+         endif
+      enddo
+
+    end subroutine average_state_data_calculate
+ 
+!==============================================================================
+!BOP
+! ! Rountine IAU_state_data_initial()
+! ! set the obs configures
+
+    subroutine IAU_state_data_initial()
+
+! EOP 
+      integer :: ivar
+      do ivar=1,n_OCN_state
+         if(.not. OCN_DAstate_data(ivar)%update) return
+         if(OCN_DAstate_data(ivar)%state_dim == 3) OCN_DAstate_data(ivar)%IAU_increm =0.0
+         if(OCN_DAstate_data(ivar)%state_dim == 2) OCN_DAstate_data(ivar)%IAU_increm2D =0.0
+         if(OCN_DAstate_data(ivar)%state_dim == 1) OCN_DAstate_data(ivar)%IAU_increm1D =0.0
+      enddo
+
+    end subroutine IAU_state_data_initial
+
+ 
+!==============================================================================
+!BOP
+!  ! routine relax2prior_inflation()
+!   relaxiation inflation to prior spread
+    subroutine mpas_relax_inflation()
+! EOP
+    use sEnKF_mod,     only :inflation_RTPS
+    
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(mpas_relax_inflation) '
+        integer                 :: i,j,k,ivar
+        integer                 :: da_nbs,da_nbe
+        real(r8)                :: RTP_rate
+        real(r8)                :: prior(ensemble_size),analysis(ensemble_size)
+
+        !write(logunit,*) trim(subname),'inflation of RTPS'
+        flush(logunit)
+        do ivar  = 1, n_OCN_state
+           if(.not. OCN_DAstate_data(ivar)%update) cycle
+           RTP_rate=OCN_DAstate_data(ivar)%r2p_fac
+           !write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),'RTPS rate',RTP_rate
+           if(RTP_rate <= tiny(RTP_rate)) cycle 
+           da_nbs=da_Cell_nbs
+           da_nbe=da_cell_nbe
+           do i=da_nbs,da_nbe
+               if (OCN_DAstate_data(ivar)%state_dim==1) then
+                     prior=OCN_DAstate_data(ivar)%prior1d(i,:)
+                     analysis=OCN_DAstate_data(ivar)%posterior1d(i,:)
+                     call inflation_RTPS(analysis,prior,RTP_rate,ensemble_size)
+                     OCN_DAstate_data(ivar)%posterior1d(i,:)=analysis
+                 endif
+                 if (OCN_DAstate_data(ivar)%state_dim==2) then
+                    do k=1,DA_nvert
+                       prior=OCN_DAstate_data(ivar)%prior2d(i,k,:)
+                       analysis=OCN_DAstate_data(ivar)%posterior2d(i,k,:)
+                       call inflation_RTPS(analysis,prior,RTP_rate,ensemble_size)
+                       OCN_DAstate_data(ivar)%posterior2d(i,k,:)=analysis
+                    end do
+                 endif
+           end do ! i
+        end do ! ivar
+        !write(logunit,*) trim(subname),' finished'
+        flush(logunit)
+    end subroutine mpas_relax_inflation
+!==============================================================================
+!BOP
+!  ! routine relax2prior_inflation()
+!   relaxiation inflation to prior spread
+    subroutine relax_inflation()
+! EOP
+    use sEnKF_mod,     only :inflation_RTPS
+    
+!BOC
+        implicit none
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(relax2prior_inflation) '
+        integer                 :: i,j,k,ivar
+        real(r8)                :: RTP_rate
+        real(r8)                :: prior(ensemble_size),analysis(ensemble_size)
+
+        !write(logunit,*) trim(subname),'inflation of RTPS'
+        flush(logunit)
+        do ivar  = 1, n_OCN_state
+           if(.not. OCN_DAstate_data(ivar)%update) cycle
+           RTP_rate=OCN_DAstate_data(ivar)%r2p_fac
+           !write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),'RTPS rate',RTP_rate
+           if(RTP_rate <= tiny(RTP_rate)) cycle 
+           do i=da_ibs,da_ibe
+              do j=da_jbs,da_jbe
+                 if (OCN_DAstate_data(ivar)%state_dim==2) then
+                     prior=OCN_DAstate_data(ivar)%prior2d(i,j,:)
+                     analysis=OCN_DAstate_data(ivar)%posterior2d(i,j,:)
+                     call inflation_RTPS(analysis,prior,RTP_rate,ensemble_size)
+                     OCN_DAstate_data(ivar)%posterior2d(i,j,:)=analysis
+                 endif
+                 if (OCN_DAstate_data(ivar)%state_dim==3) then
+                    do k=1,DA_nvert
+                       prior=OCN_DAstate_data(ivar)%prior(i,j,k,:)
+                       analysis=OCN_DAstate_data(ivar)%posterior(i,j,k,:)
+                       call inflation_RTPS(analysis,prior,RTP_rate,ensemble_size)
+                       OCN_DAstate_data(ivar)%posterior(i,j,k,:)=analysis
+                    end do
+                 endif
+              end do ! 
+           end do ! i
+        end do ! ivar
+        !write(logunit,*) trim(subname),'inflation of RTPS finished'
+        flush(logunit)
+    end subroutine relax_inflation
+
+
+end module ECDA_mpaso_state_mod
+
+
+        
+
+
+
+
+                 

--- a/components/mpas-ocean/driver/Makefile
+++ b/components/mpas-ocean/driver/Makefile
@@ -2,17 +2,24 @@
 
 OBJS = ocn_comp_mct.o \
        mpaso_cpl_indices.o \
-	   mpaso_mct_vars.o
+	   mpaso_mct_vars.o \
+	      mpaso_DA_mod.o \
+		ECDA_mpaso_obs_mod.o \
+	          ECDA_mpaso_state_mod.o 
 
 OCEAN_SHARED_INCLUDES=-I../core_ocean/mode_forward -I../core_ocean/shared -I../core_ocean/analysis_members -I../core_ocean/cvmix -I../framework -I../operators
 
 all: $(OBJS)
 
-ocn_comp_mct.o: mpaso_cpl_indices.o mpaso_mct_vars.o
+ocn_comp_mct.o: mpaso_cpl_indices.o mpaso_mct_vars.o mpaso_DA_mod.o
 
 mpaso_cpl_indices.o:
 
 mpaso_mct_vars.o:
+
+mpaso_DA_mod.o: ECDA_mpaso_obs_mod.o ECDA_mpaso_state_mod.o
+
+ECDA_mpaso_obs_mod.o: ECDA_mpaso_state_mod.o
 
 clean:
 	$(RM) *.o *.mod *.f90

--- a/components/mpas-ocean/driver/mpaso_DA_mod.F
+++ b/components/mpas-ocean/driver/mpaso_DA_mod.F
@@ -1,0 +1,1370 @@
+module mpaso_DA_mod
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!BOP
+! !MODULE: mpaso_DA_mod
+! ! interfacce:
+      
+! !DESCRIPTION:
+!   !This is the online DA program for the Model for Predication Across Scales Ocean Model (MPASO).
+!   !REVISION HISTORY:
+
+!   !USES:
+    use mct_mod
+    use esmf
+    use seq_timemgr_mod
+    use perf_mod
+    use shr_file_mod
+    use shr_cal_mod,       only : shr_cal_date2ymd
+    use shr_sys_mod,  only : shr_sys_flush
+!    use shr_kind_mod,      only : r8=> shr_kind_r8                     
+!   !mpaso
+    use mpaso_cpl_indices
+    use mpaso_mct_vars
+
+    use mpas_framework
+    use mpas_derived_types
+    use mpas_pool_routines
+    use mpas_io
+    use mpas_io_streams
+    use mpas_stream_manager
+    use mpas_kind_types
+    use mpas_io_units
+    use mpas_timekeeping
+    use mpas_bootstrapping
+    use mpas_dmpar
+    use mpas_constants
+    use mpas_log
+    
+!   ! DA module
+    use seq_comm_mct,  only : logunit
+    use seq_comm_mct,  only : num_inst_driver
+    use seq_comm_mct,  only : DAOCNID,DAOCNALLID
+    use seq_comm_mct,  only : seq_DA_comm_iamin
+    use seq_comm_mct,  only : seq_DA_comm_iamroot
+    use seq_comm_mct,  only : seq_DA_comm_iam
+    use seq_comm_mct,  only : seq_DA_comm_mpicom
+    use seq_comm_mct,  only : seq_DA_comm_inst
+    use seq_comm_mct,  only : seq_DA_comm_npes
+
+    use seq_comm_mct,  only : OCNID
+    use seq_comm_mct,  only : seq_comm_iamin
+    use seq_comm_mct,  only : seq_comm_iamroot
+    use seq_comm_mct,  only : seq_comm_iam
+    use seq_comm_mct,  only : seq_comm_mpicom
+
+    use ECDA_mpaso_state_mod
+    use ECDA_mpaso_obs_mod
+
+#ifdef _MPI
+#ifndef NOMPIMOD
+    use mpi
+#endif
+#endif
+
+    implicit none
+
+#ifdef _MPI
+#ifdef NOMPIMOD
+    include 'mpif.h'
+#endif
+#endif
+    integer, parameter :: MPI_INTEGERKIND = MPI_INTEGER
+    integer, parameter :: MPI_2INTEGERKIND = MPI_2INTEGER
+
+#ifdef SINGLE_PRECISION
+    integer, parameter :: MPI_REALKIND = MPI_REAL
+    integer, parameter :: MPI_2REALKIND = MPI_2REAL
+#else
+    integer, parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+    integer, parameter :: MPI_2REALKIND = MPI_2DOUBLE_PRECISION
+#endif
+
+!
+!   !PUBLIC MEMBER FUNCTIONS:
+
+    public :: mpaso_DA_init
+    public :: mpaso_DA_run
+!    public :: state_update_IAU
+!    public :: ocean_ave4da
+
+!   Public variables !
+!
+    
+!    integer,public             ::  my_inst, ensemble_size
+!    integer :: allCellsSolve, DACellsSolve,DACellsSolve_halo
+!    integer :: da_nts,da_nte, da_nbs,da_nbe   ! [da_nbs,da-nbe]=[da_nts da_nte]+halo
+!EOP
+
+
+!   !Private by default
+    private
+
+    type (domain_type), pointer:: domain 
+
+!    variable for Data assimilation, move to ECDA_mpaso_state_mod
+!    integer :: mpicom_ocn_local           ! mpaso model communicator
+!    integer :: mpicom_da_all,mpicom_da  !comunicator
+!    integer :: iam_da_all, iam_da       ! comunicater ID
+!    logical :: iamin_da_all,iamin_da
+!    logical :: iamroot_da_all,iamroot_da ! root
+    
+    integer :: iam_local                ! local comunicater
+
+    integer :: init_obs_YR               ! ex:2016
+    integer :: init_obs_MO              ! ex: 1~12
+    integer :: init_obs_DY             ! ex:1~31
+    integer :: init_obs_HR              ! ex:0~23
+    integer :: init_obs_doy            
+
+    type(ESMF_Time) :: obs_init_Time                  ! use ESMF to manage observation time, can it be public? @Yun
+!  DA namelist
+   character(len = 10) :: init_obs_YMDH = '1980010112'   ! start time for DA ex:2010010103
+   integer :: DA_interv = 1                    ! By default the obervation record time interval = da_interv, record 1 on the time of init_obs_YMDH, record 2 at time init_obs_YMDH+DA_interv
+   character(len =2) :: DA_interv_unit = 'dy'  ! it can be hour:'hr' or day:'dy', 'mo',month. for hours, it should be full divided by day: 1,2,3,4,6,8,12,24 for DA_interv
+   integer :: obs_interv  = 1               ! @YL: the observation interval, may small than da_interv (for sensitivty test),  use the same unit as da_interv for now.
+   logical :: update_states(n_OCN_state)= .False.    ! define the states to be updated by observation, default is no update
+   real(kind=RKIND) :: relax_inf_rate=0.5                      ! relaxiation to prior weight on prior, for RTPS,RTPP 
+   !- increment analysis updates (IAU) to prevent the model crash by abrupt modifying model state. (analysis increment add into model within multiple couple interval)
+   !   need know the couple interval and ocean integrate interval. @YL to be develop
+   integer :: IAU_cpl_cycles = 0    ! 0, default, no IAU applied
+
+   namelist /ocn_DA_nml/init_obs_YMDH, DA_interv, DA_interv_unit,obs_interv, &
+                           update_states,relax_inf_rate,&
+                          IAU_cpl_cycles
+
+contains
+!==============================================================================
+!BOP
+!   ! get the basic grid for current PE for DA
+!   !ROUTINE: mpaso_DA_init
+!   !INTERFACE:
+
+subroutine mpaso_DA_init(mpicom_ocn,domain_ptr)
+!BOC
+      implicit none
+      integer,intent(in) :: mpicom_ocn
+      type (domain_type), pointer:: domain_ptr 
+!  begin
+      character(*), parameter :: subName =   '(mpaso_DA_init) '
+      character(*), parameter :: nml_inpfile = 'ocean_da.namelist'
+      type(ESMF_CalKind_Flag) :: esmf_calkind
+      type(ESMF_Calendar) :: esmf_cal
+      integer :: init_obs_sod                    ! seconds of the day.
+      integer :: ierr,iunit,rc
+      logical :: exists
+      integer :: ymd, tod, ihour, iminute, isecond
+      integer :: iyear, imonth, iday, curr_ymd, curr_tod
+      integer :: shrloglev, shrlogunit
+      real (kind=RKIND) :: dt, current_wallclock_time
+      integer :: ivar
+
+!      call seq_cdata_setptrs(cdata_o, ID=OCNID, mpicom=mpicom_o, &
+!         gsMap=gsMap_o, dom=dom_o, infodata=infodata)
+
+      mpicom_ocn_local=mpicom_ocn
+      call MPI_comm_rank(mpicom_ocn_local,iam_local,ierr) 
+      domain => domain_ptr    ! acess the domain at current PE
+      if (num_inst_driver <= 1) then
+          write(logunit,*) trim(subname), 'single ocean copy, no ensmeble DA, OI to be developed '
+          return
+      endif
+      ensemble_size = num_inst_driver         !       multi-driver for DA ensemble
+
+!      ocnDALogUnit = shr_file_getUnit()      
+      ! open the logfile for DA
+!      if(iam_local==0) then
+!        open( ocnDALogUnit, file = './mpaso_da_log')
+!      endif
+
+      call get_OCN_DA_comm()                
+      call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here 
+
+!-      read in the name list for ocean da
+        inquire(file=trim(nml_inpfile), exist=exists)
+        if (exists) then
+             iunit = shr_file_getUnit()
+             open(unit = iunit, file = trim(nml_inpfile), action = 'read')
+             rewind(unit = iunit)
+             read(unit = iunit, nml = ocn_DA_nml, iostat = ierr)
+             close(unit = iunit)
+             call shr_file_freeUnit( iunit )
+             if (ierr /= 0) write(logunit,*) trim(subname),'ERROR reading namelist ocn_DA_nml from ',trim(nml_inpfile)
+        end if
+
+!-     convert the observation initial time to ESMF format
+        read(init_obs_YMDH(1:4),'(i)') init_obs_YR
+        read(init_obs_YMDH(5:6),'(i)') init_obs_MO
+        read(init_obs_YMDH(7:8),'(i)') init_obs_DY
+        read(init_obs_YMDH(9:10),'(i)') init_obs_HR
+        esmf_calkind = ESMF_CALKIND_NOLEAP   ! @YL, need input from domain%clock
+        !esmf_calkind = ESMF_CALKIND_GREGORIAN   ! default for
+        esmf_cal = ESMF_CalendarCreate( name="mpaso_obs_calendar", calkindflag=esmf_calkind, rc=rc )
+        init_obs_sod= init_obs_HR * 3600
+        call ESMF_TimeSet( obs_init_Time, yy=init_obs_YR, mm=init_obs_MO, dd=init_obs_DY, s=init_obs_sod, calendar=esmf_cal, rc=rc )
+        call ESMF_TimeGet( obs_init_Time, dayOfYear=init_obs_doy, rc=rc )
+       ! write(logunit,*) trim(subname),'obs initial time day of year',init_obs_doy
+
+!-       initial state, observation         
+        call ocn_DAstate_init() ! initial state for DA
+        call ocn_obs_type_register() ! register assimilating observations type,need after ocn_DAstate_init
+        call Define_OCN_DA_grids() 
+
+        if(iamroot_da_all) write(logunit,*) trim(subname),'NUM_OCN_obs_type:',NUM_OCN_obs_type
+        if (NUM_OCN_obs_type==0) return   ! no valid observation type. @YL
+
+!-     set ocn state for DA
+        ! all the updated variables are required
+
+       if(iamroot_da_all) write(logunit,*) trim(subname),'update states:',update_states
+        do ivar=1, n_OCN_state
+!           OCN_DAstate_data(ivar)%averaged = average_obs
+           if(update_states(ivar)) then
+              OCN_DAstate_data(ivar)%r2p_fac = relax_inf_rate
+              OCN_DAstate_data(ivar)%required = .true.
+              OCN_DAstate_data(ivar)%update = .true.
+           endif
+        end do
+        call ocn_DAstate_register()
+!-    test read in obs
+!        call read_ocn_obs4da(1,exists)
+
+!-    No IAU applied ,set IAU weight as 1 @YL, for IAU need to calculate based on coupling timesteps 
+       steps_IAU=1
+
+       call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here
+       if(iamroot_da_all) write(logunit,*) trim(subname), 'finsh OCN DA initial'
+
+    end subroutine mpaso_DA_init
+!==============================================================================
+!BOP
+!   !ROUTINE: mpaso_DA_run
+!   !INTERFACE:
+
+    subroutine mpaso_DA_run(MPASclock)
+!BOC
+
+      implicit none
+      type (MPAS_Clock_type), intent(in) :: MPASclock
+
+!  begin
+      character(*), parameter :: subName =   '(mpaso_DA_run) '
+      logical :: isdatime
+      integer :: shrloglev, shrlogunit
+      integer :: ierr,i,j,k,n
+!     observation related
+      integer :: obs_rec      ! the file record for observations @YL
+      logical ::  obs_exists 
+
+      type (MPAS_Time_Type) :: currTime
+      type (domain_type), pointer :: domain_ptr
+      character(len=StrKIND) :: timeStamp, streamName, WCstring
+      real (kind=RKIND) :: pertubation
+      
+
+      if (num_inst_driver <= 1) return
+
+      if (NUM_OCN_obs_type==0) return
+
+!       IAU update in multiple coupling steps, when it reach to 0, stop IAU.
+        IAU_update= IAU_update -1
+
+      !if reach to assimilation time @YL, maybe use the alarm way
+      call is_ocn_da_time(isdatime,obs_rec,MPASclock)
+      if( .not. isdatime)  return
+
+      call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here
+
+!     read in observations
+
+!      obs_rec = 1
+      call read_ocn_obs4da(obs_rec,obs_exists)
+
+      call collect_mpaso_state4da()
+
+      call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here
+
+      call ecda_eakf_core()    !do the assimilation
+
+      !=    inflation after DA
+      call mpas_relax_inflation()     ! relaxiation  inflation  with RPTS
+
+      !=    calculate increment for IAU
+      call ecda_calculate_IAU()
+     
+      != update state
+      IAU_update = IAU_cpl_cycles ! set IAU update coupling cycles
+!      write(logunit,*)trim(subname),'IAU_update',IAU_update,'steps_IAU',steps_IAU
+!    if IAU applied, update all the increment on model states
+      if(steps_IAU == 1) then
+          IAU_update=1
+          call mpaso_update_IAU()  ! no IAU selection, Update the all increment ocean
+          IAU_update = 0           ! make sure no additional update happens.
+       endif 
+
+!=   release DA related variable
+      call  ocn_DAstate_deallocate()
+      call observation_deallocate()
+
+      !if(average_obs) call average_state_data_initial()  !reinitial the average variables
+      call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here
+     if(iamroot_da_all) write(logunit,*)trim(subname),'Finished '
+      flush(logunit)
+      
+      return
+
+    end subroutine mpaso_DA_run
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ecda_eakf_core
+!   ! the main subroutine of ECDA, use EAKF
+!   ! 
+!   ! loop through all assimilated obs data
+!   !     step 1  observation oprerator followed by calculate the ensemble increment at observation space
+!   !     Step 2 loop through all updated states to calculate the ensemble increment at model space.
+
+    subroutine ecda_eakf_core()
+
+       use sEnKF_mod,     only : obs_inflation
+       use sEnKF_mod,     only : obs_increment,update_from_obs_inc
+       use sEnKF_mod,     only : cal_lcwt_latlon
+!BOC
+       implicit none
+       include 'mpif.h'
+       character(*), parameter :: subName =   '(ecda_eakf_core) '
+       integer                 :: ID
+       integer                 :: i,j,k, iobs,ivar,ierr
+       integer                 :: icell_edge
+       real(kind=RKIND)        :: fobs(ensemble_size),obs_inc(ensemble_size)
+       real(kind=RKIND)        :: obs,obs_var
+       real(kind=RKIND)        :: fstate(ensemble_size),state_inc(ensemble_size)
+       real(kind=RKIND)        :: rlon,rlat
+       real(kind=RKIND)        :: loc_wt0,loc_wt,vertical_distance, horiz_distance
+
+       do ID=1,NUM_OCN_obs_type
+          !write(logunit,*) trim(subname),trim(OCN_obs_data(ID)%obs_name),OCN_obs_data(ID)%assimilate
+          if(.not. OCN_obs_data(ID)%assimilate .or. OCN_obs_data(ID)%nobs <=0) cycle
+          !write(logunit,*) trim(subname),trim(OCN_obs_data(ID)%obs_name),'for obs of', OCN_obs_data(ID)%nobs, &
+          !               'update:',OCN_obs_data(ID)%update_states
+           do iobs=1, OCN_obs_data(ID)%nobs
+               if (abs(OCN_obs_data(ID)%values(iobs))>999.0) cycle  ! an ad hoc value
+               !  @YL skip ice cover region
+               !if(OCN_obs_data(ID)%obs_type == OCN_TEMP_index .and. &
+               !           OCN_obs_data(ID)%values(iobs) <= 5.0  ) cycle
+               call  mpaso_obs_operator(ID,iobs,fobs,obs,obs_var, icell_edge)
+               !if(iobs==10 .and. iamroot_da ) &
+               !       write(logunit,*) trim(subname),'iobs,icell,obs, fobs,location',iobs,icell_edge,obs,fobs,&
+               !       OCN_obs_data(ID)%lon(iobs),OCN_obs_data(ID)%lat(iobs),DA_lonCell(icell_edge),DA_latCell(icell_edge)
+               !--eakf step 1
+               call obs_increment(fobs, obs,ensemble_size, obs_var, obs_inc)
+               !write(logunit,*) trim(subname),'iobs,da inc',iobs,obs_inc
+               !--eakf step two
+               do ivar=1,n_OCN_state
+                   if(.not. OCN_obs_data(ID)%update_states(ivar)) cycle
+                   do i=da_Cell_nbs,da_Cell_nbe
+                   !do i=icell_edge,icell_edge
+                      ! the horizontal distance between obs and state for localization
+                       call cal_lcwt_latlon(DA_lonCell(i),DA_latCell(i),OCN_obs_data(ID)%lon(iobs),OCN_obs_data(ID)%lat(iobs), &
+                               OCN_obs_data(ID)%RR_xy, loc_wt0)
+
+                       if (loc_wt0 < 0.05) cycle 
+                       if (OCN_DAstate_data(ivar)%state_dim==1) then
+                          fstate=OCN_DAstate_data(ivar)%posterior1d(i,:)
+                          call update_from_obs_inc(fobs,obs_inc, fstate, ensemble_size, state_inc, loc_wt0)
+                          OCN_DAstate_data(ivar)%posterior1d(i,:)=OCN_DAstate_data(ivar)%posterior1d(i,:)+state_inc
+                       endif    ! state_dim==1
+
+                       if (OCN_DAstate_data(ivar)%state_dim==2) then
+                           do k=1,DA_maxLevelCell(i)       !-1       !@YL, skip the bottom    
+                                vertical_distance=abs(OCN_obs_data(ID)%depth(iobs)-DA_depth(k))
+                                if (vertical_distance > 3*OCN_obs_data(ID)%RR_z) CYCLE  ! exp(-3) ~= 0.05, weight will be small
+
+                                loc_wt=exp(-1.0*vertical_distance/OCN_obs_data(ID)%RR_z)*loc_wt0
+                                !if(iobs==10 .and. iamroot_da) write(logunit,*) trim(subname),'dpth/wt',k,DA_depth(k),loc_wt0,loc_wt  
+                             
+                                if (loc_wt < 0.05) cycle 
+                                fstate=OCN_DAstate_data(ivar)%posterior2d(i,k,:)
+                                call update_from_obs_inc(fobs,obs_inc, fstate, ensemble_size, state_inc, loc_wt)
+                                OCN_DAstate_data(ivar)%posterior2d(i,k,:)=OCN_DAstate_data(ivar)%posterior2d(i,k,:)+state_inc
+                            end do
+                      endif    ! state_dim ==2
+                   enddo  ! i
+               enddo  ! ivar
+           enddo   ! iobs
+
+           !write(logunit,*) trim(subname),'increment', state_inc
+       end do !ID
+
+       call mpi_barrier(mpicom_da_all, ierr)   !       make sure all the ocn pes reach to here
+       if(iamroot_da_all) write(logunit,*)trim(subname),'finished'
+       flush(logunit)
+    end subroutine ecda_eakf_core
+
+!==============================================================================
+!BOP
+!   !ROUTINE: mpaso_update_IAU
+!   !INTERFACE:
+
+    subroutine mpaso_update_IAU()
+!BOC
+      implicit none
+!  begin
+      character(*), parameter :: subName =   '(mpaso_update_IAU) '
+      logical :: isdatime
+      integer :: shrloglev, shrlogunit
+      integer :: ierr,i,j,k,n,ivar
+!     temporal for testing communication
+      real (kind=RKIND), dimension(:,:),allocatable :: state_da_2D, state_da_2D_all
+      real (kind=RKIND), dimension(:,:,:),allocatable :: state_da_3D
+
+      type (block_type), pointer :: block_ptr    
+      integer, pointer :: nCellsSolve,nVertLevels
+      integer, pointer :: index_temperature, index_salinity
+!     define array      
+      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), dimension(:), pointer :: SSHValue
+      real (kind=RKIND), dimension(:,:), pointer :: TValue
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+      integer :: idx
+      type (field1DReal), pointer :: SSHfield
+      type (field2DReal), pointer :: normalVelocity
+
+      type (mpas_pool_type), pointer :: meshPool, statePool, diagnosticsPool, forcingPool, averagePool, scratchPool
+      type (mpas_pool_type), pointer :: tracersPool
+      type (mpas_pool_iterator_type) :: groupItr
+
+!     to add the analysis increment to the state using IAU, One should consider for multi steps of model integration
+      if(IAU_update <= 0) RETURN   ! not updat time
+      
+      n=0
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
+          call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature) !  OCN_TEMP_index
+          call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)       ! OCN_SALT_index
+  !        call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity,1)           ! OCN_VEL_index
+          call mpas_pool_get_array(statePool, 'ssh', SSHValue,1)                            ! OCN_SSH_index
+
+          if(iamroot_da_all) write(logunit,*)trim(subname),'before update sst', activeTracers(index_temperature,1,1), &
+                             OCN_DAstate_data(1)%IAU_increm2D(n+1,1)
+          do i = 1, nCellsSolve
+             n = n + 1
+             do ivar=1,n_OCN_state
+                if(.not. OCN_DAstate_data(ivar)%update) cycle
+                select case (ivar)
+                    case (OCN_TEMP_index)
+                            idx=index_temperature
+                            do k=1,maxLevelCell(i)  
+                               activeTracers(idx,k,i)=activeTracers(idx,k,i) + OCN_DAstate_data(ivar)%IAU_increm2D(n,k)
+                            end do
+                    case (OCN_SALT_index)
+                            idx=index_salinity
+                            do k=1,maxLevelCell(i)  
+                               activeTracers(idx,k,i)=activeTracers(idx,k,i) + OCN_DAstate_data(ivar)%IAU_increm2D(n,k)
+                            end do
+                    case (OCN_SSH_index)
+                            SSHValue(i)=SSHValue(i) +OCN_DAstate_data(ivar)%IAU_increm1D(n)
+
+                    case (OCN_VEL_index)
+                            write(logunit,*) trim(subname),'OCN_VELOCITY to be develop'
+
+                    CASE DEFAULT
+                        write(logunit,*) trim(subname),'DA state not valide:', ivar
+                end select
+             end do ! ivar,n_OCN_state
+          end do  ! i, nCellsSolve
+
+         if(iamroot_da_all) write(logunit,*)trim(subname),'after update sst', activeTracers(index_temperature,1,1)
+
+          block_ptr => block_ptr % next
+      enddo
+      call mpi_barrier(mpicom_ocn_local, ierr)
+
+!   exchange halo field 
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         ! for regular state
+         if (OCN_DAstate_data(OCN_SSH_index)%update) then 
+             call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+             call mpas_pool_get_field(statePool, 'ssh', SSHfield)
+             call mpas_dmpar_exch_halo_field(SSHfield)
+          end if
+         ! for tracers : temperature and salinity
+         if (OCN_DAstate_data(OCN_TEMP_index)%update .or. OCN_DAstate_data(OCN_SALT_index)%update) then
+              call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+              call mpas_pool_begin_iteration(tracersPool)
+               do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
+                  if (groupItr%memberType == MPAS_POOL_FIELD) then
+                      call mpas_dmpar_field_halo_exch(domain,  groupItr%memberName, timeLevel=1)
+                  end if
+               end do
+         end if
+
+         block_ptr => block_ptr % next
+      enddo 
+     
+    end subroutine mpaso_update_IAU
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ecda_calculate_IAU
+!   ! calculate IAU and redistribute to each model PEs
+
+!   !INTERFACE:
+    subroutine  ecda_calculate_IAU()
+!EOP
+!BOC
+        ! --- Local variables ---
+        character(*), parameter :: subName =   '(ecda_calculate_IAU) '
+        integer :: i, ierr, j, k, lu, lv, ien, iz,ix,iy, ivar
+        real(kind=RKIND), dimension(:), allocatable :: increment1d
+        real(kind=RKIND), dimension(:,:), allocatable :: increment2d
+        integer ::  da_nbs,da_nbe
+
+
+!EOC
+        call mpi_barrier(mpicom_da_all, ierr)
+        da_nbs=da_Cell_nbs
+        da_nbe=da_Cell_nbe
+
+        allocate(increment1d(da_nbs:da_nbe), &
+                increment2d(da_nbs:da_nbe,DA_nvert), stat=ierr)
+
+
+        do ivar=1,n_OCN_state   ! loop through all  variables
+           !write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),OCN_DAstate_data(ivar)%update
+           if(.not.  OCN_DAstate_data(ivar)%update) cycle
+
+
+           if (OCN_DAstate_data(ivar)%state_dim==1) then
+               increment1d=0.0
+               do i=da_nbs,da_nbe
+                  OCN_DAstate_data(ivar)%posterior1d(i,my_inst)=max(OCN_DAstate_data(ivar)%posterior1d(i,my_inst),OCN_DAstate_data(ivar)%mn_value)
+                  OCN_DAstate_data(ivar)%posterior1d(i,my_inst)=min(OCN_DAstate_data(ivar)%posterior1d(i,my_inst),OCN_DAstate_data(ivar)%mx_value)
+                  increment1d(i)=OCN_DAstate_data(ivar)%posterior1d(i,my_inst)-OCN_DAstate_data(ivar)%prior1d(i,my_inst)
+                  increment1d(i)=sign(min(Mx_da_increm(ivar),abs( increment1d(i))),increment1d(i))
+               enddo
+               if(iamroot_da_all) write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),' increment max',maxval(abs(increment1d)), maxloc(abs(increment1d))
+               OCN_DAstate_data(ivar)%IAU_increm1D=0.0
+               ! halo issue 
+               ! call  ensem_async_IAU2d(increment1d,OCN_DAstate_data(ivar)%IAU_increm1d)
+
+               OCN_DAstate_data(ivar)%IAU_increm1D=increment1d /steps_IAU
+           endif
+
+!           if (OCN_DAstate_data(ivar)%state_dim==1) then
+!              increment1d=OCN_DAstate_data(ivar)%posterior1d-OCN_DAstate_data(ivar)%prior1d
+!               do i=da_nbs,da_nbe
+!                  do ien=1,ensemble_size
+!                           increment1d(i,ien)=sign(min(Mx_da_increm(ivar),abs( increment1d(i,ien))),increment1d(i,ien))
+!                  enddo
+!               enddo
+!               if(iamroot_da_all) write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),' increment max',maxval(abs(increment1d))
+!           !   call   ensem_async_IAU2d(increment1d,OCN_DAstate_data(ivar)%IAU_increm1d)
+!               OCN_DAstate_data(ivar)%IAU_increm1D=increment1d(:,my_inst) /steps_IAU
+!           endif
+
+           if (OCN_DAstate_data(ivar)%state_dim==2) then
+               increment2d=0.0
+               do i=da_nbs,da_nbe
+                   do k=1,DA_maxLevelCell(i)
+                      OCN_DAstate_data(ivar)%posterior2d(i,k,my_inst)=max(OCN_DAstate_data(ivar)%posterior2d(i,k,my_inst),OCN_DAstate_data(ivar)%mn_value)
+                      OCN_DAstate_data(ivar)%posterior2d(i,k,my_inst)=min(OCN_DAstate_data(ivar)%posterior2d(i,k,my_inst),OCN_DAstate_data(ivar)%mx_value)
+                      increment2d(i,k)=OCN_DAstate_data(ivar)%posterior2d(i,k,my_inst)-OCN_DAstate_data(ivar)%prior2d(i,k,my_inst)
+                      increment2d(i,k)=sign(min(Mx_da_increm(ivar),abs(increment2d(i,k))),increment2d(i,k))
+                   enddo
+               enddo
+              if(iamroot_da_all) write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),' increment max/loc',maxval(abs(increment2d)),maxloc(abs(increment2d))
+              OCN_DAstate_data(ivar)%IAU_increm2D=0.0
+              !for halo @YL
+              !call ensem_async_IAU3d(increment3d,OCN_DAstate_data(ivar)%IAU_increm)
+              OCN_DAstate_data(ivar)%IAU_increm2D=increment2d /steps_IAU
+           endif
+
+!           if (OCN_DAstate_data(ivar)%state_dim==2) then
+!               increment2d=OCN_DAstate_data(ivar)%posterior2d-OCN_DAstate_data(ivar)%prior2d
+!               do i=da_nbs,da_nbe
+!                   do ien=1,ensemble_size
+!                      do k=1,DA_maxLevelCell(i)
+!                           increment2d(i,k,ien)=sign(min(Mx_da_increm(ivar),abs(increment2d(i,k,ien))),increment2d(i,k,ien))
+!                      enddo
+!                   enddo
+!               enddo
+!              if(iamroot_da_all) write(logunit,*) trim(subname),trim(OCN_DAstate_data(ivar)%name),' increment max/loc',maxval(abs(increment2d)),maxloc(abs(increment2d))
+!           !    call ensem_async_IAU3d(increment3d,OCN_DAstate_data(ivar)%IAU_increm)
+!                OCN_DAstate_data(ivar)%IAU_increm2D=increment2d(:,:,my_inst) /steps_IAU
+!           endif
+
+        end do !ivar
+        deallocate(increment2d,increment1d)
+!        if(iamroot_da_all) write(logunit,*) trim(subname),'finished'
+
+!EOC
+    end subroutine ecda_calculate_IAU
+!==============================================================================
+
+
+
+!==============================================================================
+!BOP
+!   !ROUTINE: get_OCN_DA_comm
+!   !DESCRIPTION:
+!       set the DA grids for each PE, 
+    subroutine get_OCN_DA_comm()
+!EOP
+!BOC
+        implicit none
+        character(*), parameter :: subName =   '(get_OCN_DA_comm) '
+        integer :: npes_da_all,npes_da  ! for diagnostic
+        integer :: ierr
+!EOC
+        ! --- Local variables ---
+
+!-      get current comm for DA
+        mpicom_da_all = seq_DA_comm_mpicom (DAOCNALLID)
+        iam_da_all = seq_DA_comm_iam (DAOCNALLID)
+        iamin_da_all = seq_DA_comm_iamin (DAOCNALLID)
+        iamroot_da_all = seq_DA_comm_iamroot (DAOCNALLID)
+        call mpi_comm_size(mpicom_da_all,npes_da_all,ierr)
+
+        my_inst=seq_DA_comm_inst(DAOCNALLID)  ! use for DA ensemble ID
+
+        mpicom_da = seq_DA_comm_mpicom (DAOCNID)
+        iam_da = seq_DA_comm_iam (DAOCNID)
+        iamin_da = seq_DA_comm_iamin (DAOCNID)
+        iamroot_da = seq_DA_comm_iamroot (DAOCNID)
+        call mpi_comm_size(mpicom_da,npes_da,ierr)
+
+!       iamin_da  and iamin_da_all should be consistant
+
+        if(iamroot_da_all) write(logunit,*)trim(subname),'npes :',npes_da_all,npes_da, &
+                    'my peID:',iam_da_all,iam_da,'root:',iamroot_da_all,iamroot_da, &
+                    'my_inst',my_inst
+        flush(logunit)
+     end subroutine get_OCN_DA_comm
+!=============================================================================
+!BOP
+!   !ROUTINE: Define_OCN_DA_grids
+!   !DESCRIPTION:
+!       set the DA grids for each PE, 
+    subroutine Define_OCN_DA_grids()
+!EOP
+!BOC
+       implicit none
+!EOC
+      ! --- Local variables ---
+      character(*), parameter :: subName =   '(Define_OCN_DA_grids) '
+      integer, pointer :: nCellsSolve,nVertLevels,nEdgesSolve
+      type (block_type), pointer :: block_ptr
+      type (mpas_pool_type), pointer :: meshPool,verticalMeshPool
+      real (kind=RKIND), dimension(:), pointer :: lonCell,latCell, lonEdge, latEdge, refZMid
+      integer, dimension(:), pointer :: maxLevelCell,indexToCellID, indexToEdgeID
+      integer :: i,ierr,icell,iedge
+      real (kind=RKIND), dimension(:),allocatable :: local_lonCell, local_latCell, local_lonEdge, local_latEdge
+      integer, dimension(:), allocatable:: local_maxLevelCell
+      integer, dimension(:), allocatable::  local_indexToCellID,local_indexToEdgeID
+
+      block_ptr => domain % blocklist
+
+      !=get the verital layer depth: z-coordinator, [-5,-15,...]
+      call mpas_pool_get_subpool(block_ptr % structs, 'mesh',    meshPool)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh',    verticalMeshPool)
+      call mpas_pool_get_array(verticalMeshPool, 'refZMid',refZMid)
+      DA_nvert=nVertLevels   ! vertical layers
+      allocate(DA_depth(DA_nvert),stat=ierr)    
+      do i=1,DA_nvert
+             DA_depth(i)=refZMid(i)
+      enddo
+      if(iamroot_da_all) write(logunit,*) trim(subname),'ocn depth',DA_depth(1:10)
+      
+!==     derive  DA Cell/Edge from model Cell/Edge at current PE  
+
+      != get size of Cell and edge of current PE for allocate variables
+      allCellsSolve=0
+      allEdgesSolve=0
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+          
+         !write(logunit,*) trim(subname),'blockID', block_ptr %blockID, block_ptr %localBlockID
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh',    meshPool)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+
+         allCellsSolve=allCellsSolve + nCellsSolve
+         allEdgesSolve=allEdgesSolve + nEdgesSolve
+
+         block_ptr => block_ptr % next
+      end do
+      allocate(local_lonCell(allCellsSolve),local_latCell(allCellsSolve),local_maxLevelCell(allCellsSolve),stat=ierr)
+      allocate(local_lonEdge(allEdgesSolve),local_latEdge(allEdgesSolve),stat=ierr)
+      !allocate(local_indexToCellID(allCellsSolve),local_indexToEdgeID(allEdgesSolve),stat=ierr)
+      !write(logunit,*) trim(subname), 'Cells/Edge on current block/domian',nCellsSolve, nEdgesSolve,allCellsSolve,allEdgesSolve
+      !write(logunit,*) trim(subname),'test local_lonCell',local_lonCell(1:4)
+      !write(logunit,*) trim(subname),'test local_latCell',local_latCell(1:4)
+      
+      !=get the lontitude, latitude for each Cell, Edge
+      icell = 0
+      iedge = 0
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh',    meshPool)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+         call mpas_pool_get_array(meshPool, 'lonCell',lonCell)
+         call mpas_pool_get_array(meshPool, 'latCell',latCell)
+         call mpas_pool_get_array(meshPool, 'lonEdge',lonEdge)
+         call mpas_pool_get_array(meshPool, 'latEdge',latEdge)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+ 
+         !the output indexToCellID values are not as expected 
+         !call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
+         !call mpas_pool_get_array(meshPool, 'indexToEdgeID', indexToEdgeID)
+         !write(logunit,*) trim(subname), 'index cell/edge',indexToCellID(1),indexToEdgeID(1),maxLevelCell(3)
+
+         !=local cell lon/lat for T/S,...
+         do i = 1, nCellsSolve
+             icell = icell + 1
+             local_lonCell(icell)=lonCell(i)
+             local_latCell(icell)=latCell(i)
+             local_maxLevelCell(icell)=maxLevelCell(i)
+             !local_indexToCellID(icell)=indexToCellID(i)
+
+             !write(logunit,*) trim(subname), 'lon, i,icell',i,icell,lonCell(i),local_lonCell(icell)
+             !write(logunit,*) trim(subname), 'lat, i,icell',i,icell,latCell(i),local_latCell(icell)
+             !write(logunit,*) trim(subname), 'maxLevelCell, i,icell',i,icell,maxLevelCell(i),local_maxLevelCell(icell)
+         end do
+        !=local edge lon/lat for velocity DA
+         do i = 1, nEdgesSolve
+             iedge = iedge + 1
+             local_lonEdge(iedge)=lonEdge(i)
+             local_latEdge(iedge)=latEdge(i)
+             !local_indexToEdgeID(iedge)=indexToEdgeID(i)
+         end do
+
+         block_ptr => block_ptr % next
+      end do
+
+      != DA local Cells/Edges for current PE   
+      DACellsSolve = ceiling(allCellsSolve *1.0 /ensemble_size)
+      DAEdgesSolve = ceiling(allEdgesSolve *1.0 /ensemble_size)
+     ! Cells
+      da_Cell_nts=(my_inst-1)*DACellsSolve+1
+      da_Cell_nte=my_inst * DACellsSolve
+      da_Cell_nte=min(da_cell_nte,allCellsSolve)
+     ! Edges
+      da_Edge_nts=(my_inst-1)*DAEdgesSolve+1
+      da_Edge_nte=my_inst * DAEdgesSolve
+      da_Edge_nte=min(da_Edge_nte,allEdgesSolve)
+
+     ! @YL, no local decomposation for DA, redundant, use for EAKF first version
+      da_Cell_nts=1
+      da_Cell_nte=allCellsSolve
+      da_Edge_nts=1
+      da_Edge_nte=allEdgesSolve
+
+      !  set halo as zero for now, Good for LETKF, to be develop for EAKF @YL
+      da_Cell_nbs=da_Cell_nts
+      da_Cell_nbe=da_Cell_nte
+      da_Edge_nbs=da_Edge_nts
+      da_Edge_nbe=da_Edge_nte
+
+      allocate(DA_lonCell(da_Cell_nbs:da_Cell_nbe),DA_latCell(da_Cell_nbs:da_Cell_nbe),stat=ierr)
+      allocate(DA_maxLevelCell(da_Cell_nbs:da_Cell_nbe),stat=ierr)
+      allocate(DA_lonEdge(da_Edge_nbs:da_Edge_nbe),DA_latEdge(da_Edge_nbs:da_Edge_nbe),stat=ierr)
+
+!      allocate(DA_indexToCellID(da_Cell_nbs:da_Cell_nbe),DA_indexToEdgeID(da_Edge_nbs:da_Edge_nbe),stat=ierr)
+           
+!   Set the DA local lon/lat
+      DA_lonCell(da_Cell_nbs:da_Cell_nbe)=local_lonCell(da_Cell_nbs:da_Cell_nbe)
+      DA_latCell(da_Cell_nbs:da_Cell_nbe)=local_latCell(da_Cell_nbs:da_Cell_nbe)
+      DA_maxLevelCell(da_Cell_nbs:da_Cell_nbe)=local_maxLevelCell(da_Cell_nbs:da_Cell_nbe)
+!      DA_indexToCellID(da_Cell_nbs:da_Cell_nbe)=local_indexToCellID(da_Cell_nbs:da_Cell_nbe)
+
+      DA_lonEdge(da_Edge_nbs:da_Edge_nbe)=local_lonEdge(da_Edge_nbs:da_Edge_nbe)
+      DA_latEdge(da_Edge_nbs:da_Edge_nbe)=local_latEdge(da_Edge_nbs:da_Edge_nbe)
+!      DA_indexToEdgeID(da_Edge_nbs:da_Edge_nbe)=local_indexToEdgeID(da_Edge_nbs:da_Edge_nbe)
+
+!      write(logunit,*) trim(subname), 'Cells on current PE',allCellsSolve,DACellsSolve
+!      write(logunit,*) trim(subname), 'DA local grid',my_inst,da_Cell_nbs,da_Cell_nbe,da_Edge_nbs,da_Edge_nbe
+      if(iam_local .eq. 0) write(logunit,*) trim(subname), 'DA inst,cell/edge min/max lon/lat',my_inst, &
+                        minval(DA_lonCell),maxval( DA_lonCell),minval(DA_latCell),maxval( DA_latCell)
+!      if(iamroot_da) write(logunit,*) trim(subname), 'local DA lon/lat', DA_lonCell(1:4),DA_latCell(1:4)
+!      if(iamroot_da) write(logunit,*) trim(subname), 'local PE lon/lat', lonCell(1:4),latCell(1:4)
+
+!      write(logunit,*) trim(subname), 'DA index cell/edge',DA_indexToCellID(da_Cell_nbs),DA_indexToEdgeID(da_Edge_nbs)
+      
+      
+      deallocate(local_lonCell,local_latCell,local_lonEdge,local_latEdge)
+          
+      
+     end subroutine Define_OCN_DA_grids
+
+
+!==============================================================================
+!BOP
+!   !ROUTINE: is_ocn_da_time
+!
+!   !DESCRIPTION:
+!       judge if mode reach to DA time for ocean and return the observation record
+!
+!   !REVISION HISTORY:
+!       Feb 5, 2019 - Y. Liu <liu6@tamu.edu> - initial release
+!   !INTERFACE:
+    subroutine is_ocn_da_time(isdatime,obs_rec,o_clock)
+!EOP
+!BOC
+      implicit none
+      Logical, intent(out) :: isdatime
+      integer, intent(out) :: obs_rec
+      type (MPAS_Clock_type), intent(in) :: o_clock
+!EOC
+       !local variables
+      character(*), parameter :: subName =   '(is_ocn_da_time) '
+      type (MPAS_Time_Type) :: currTime
+      integer :: err_tmp, err
+      integer :: ymd, tod, ihour, iminute, isecond
+      integer :: iyear, imonth, iday, curr_ymd, curr_tod
+      integer :: year,month,day,hour,minute,second, doy
+      isdatime = .FALSE.
+      obs_rec=0   ! the record for grids data
+
+      err = 0
+      currTime = mpas_get_clock_time(o_clock, MPAS_NOW, err_tmp)
+      err = ior(err,err_tmp)
+
+      !if(currTime < obs_init_Time) return       ! model time before observation initial time, @YL not working
+
+      call mpas_get_time(curr_time=currTime, YYYY=year, MM=month, DD=day,DoY=doy, H=hour, M=minute, S=second, ierr=err_tmp)
+      err = ior(err,err_tmp)
+      
+      ! DA only in whole hours now
+      select case (DA_interv_unit)
+          case ('mo')
+            if(hour /=0 .or. second /= 0 .or. minute /= 0) return
+             imonth = (year-init_obs_YR)*12 + (month-init_obs_MO)
+             if ( day /=init_obs_DY  .or. mod(imonth,DA_interv) /=0 ) RETURN     ! the DA interval in month, do DA at the middle of the month (ex: 1/16,2/16,3/16),00z
+             imonth = (year-init_obs_YR)*12 + (month-init_obs_MO)
+             if( mod(imonth,obs_interv) == 0) obs_rec=imonth/obs_interv+1                    ! add 1 is the first record are the obs initial time
+
+          case ('dy')
+             if(second /= 0 .or. minute /= 0) return
+             iday= (year-init_obs_YR)*365+(doy-init_obs_doy)
+             if ( hour /= init_obs_HR .or. mod(iday,DA_interv) /=0 ) RETURN     ! the DA interval in day, do DA at the middle of the day depend on input, ex: 12z  @YL
+             !obs_rec=idays/DA_interv+1                    ! add 1 is the first record are the obs initial time
+             if( mod(iday,obs_interv) ==0)obs_rec=iday/obs_interv+1                    ! add 1 is the first record are the obs initial time
+
+          case ('hr')                                    ! the 24/DA_interv is whole number
+             if(second /= 0 .or. minute /= 0) return
+             if(mod(hour-init_obs_HR,DA_interv) /=0 ) RETURN     ! do DA at begining of the hour @YL
+             iday= (year-init_obs_YR)*365+(doy-init_obs_doy)   ! ignore the leap year, revisit @Yun ???
+             ihour =iday*24+hour-init_obs_HR        ! hours from current model time to observation initial time.
+             if( mod(ihour,obs_interv) ==0) obs_rec= ihour/obs_interv+1
+
+          CASE DEFAULT
+             write(logunit,*) trim(subname),'data assimilation time interval unit error, ask for hr,dy,mo, but get ', DA_interv_unit
+             return
+
+        end select
+     
+       ! some profile data save in the file of XX.YMDH 
+        write(YMDH,'(I4.4,I2.2,I2.2,I2.2)')year,month,day,hour
+        if(iamroot_da_all) write(logunit,*) trim(subname),'YMDH/obs_rec', YMDH,obs_rec
+        if(obs_rec>0) isdatime = .TRUE.    ! here the obs_rec is for all the grid obs
+        RETURN
+  
+
+      ! @YL assimilate on 12:00:00
+   !   if(hour == 12 .and. iminute == 0 .and. isecond == 0) isdatime = .TRUE.
+
+     end subroutine is_ocn_da_time
+
+!==============================================================================
+!BOP
+!   !ROUTINE: read_ocn_obs4da
+!   ! read oceanic observations into OCN_obs_data
+    subroutine read_ocn_obs4da(obs_rec,obs_exists)
+!BOC
+       implicit none
+       integer, intent(in) :: obs_rec
+       logical,intent(out) :: obs_exists
+
+       character(*), parameter :: subName =   '(read_ocn_obs4da) '
+       integer :: i,j,k, ID
+       logical :: exists
+
+       obs_exists=.false.
+       do ID=1,NUM_OCN_obs_type
+          if (.not. OCN_obs_data(ID)%assimilate) cycle
+          SELECT CASE (OCN_obs_data(ID)%grid_type)
+            CASE(O_grid_model)
+               call read_mpaso_obs_profile(ID,obs_rec,exists)
+            CASE(O_profile)
+               call read_mpaso_obs_profile(ID,obs_rec,exists)
+            CASE DEFAULT
+               write(logunit,*) trim(subname), 'to be developed'
+          end SELECT
+          if(exists)obs_exists=.true.
+       enddo
+
+    end subroutine read_ocn_obs4da
+!==============================================================================
+
+!BOP
+!   !ROUTINE: read_mpaso_obs_profile
+!   ! read observation in profile ( in records)
+!   ! the time dimension is on the filename
+
+    subroutine read_mpaso_obs_profile(ID,obs_rec,exists)
+!EOP
+     implicit none
+     integer,intent(in) :: ID
+     integer,intent(in) :: obs_rec
+
+     logical,intent(out) :: exists
+!BOC
+     character(*), parameter :: subName = '(read_mpaso_obs_profile)'
+
+     type (MPAS_IO_Handle_type) :: inputFile
+     type (MPAS_Stream_type) :: observationStream
+     type (mpas_io_context_type), pointer :: iocontext_ptr
+     type (field1DReal) :: OB_lon,OB_lat,OB_depth,OB_obs, OB_err
+     type (field1DInteger) :: OB_index 
+     
+     real (kind=RKIND) :: mxlon,mnlon,mxlat,mnlat   
+     integer :: nDIMOBS, nobs,iob, iErr,i,j,k
+     integer :: blockID
+     integer, dimension(:),allocatable :: obs_index 
+   
+     !      check if the observation exist at current time YMDH
+     if(OCN_obs_data(ID)%grid_type == O_profile) then 
+           inquire(file=trim(OCN_obs_data(ID)%filename)//YMDH//'.nc', exist=exists)
+     else
+           inquire(file=trim(OCN_obs_data(ID)%filename), exist=exists)
+
+     endif
+     if (.not. exists) return         !no observation file exist
+
+     ! use for decomp OBS
+     blockID = domain % blocklist %blockID    ! here I assume only one block for each PE. @YL
+     
+     !character (len=StrKIND), pointer ::   config_ocean_observation_file, &
+     !                                      config_ocean_observation_lat_varname, &
+     !                                      config_ocean_observation_nlat_dimname, &
+     !                                      config_ocean_observation_lon_varname, &
+     !                                      config_ocean_observation_nlon_dimname, &
+     !                                      config_ocean_observation_depth_varname, &
+     !                                      config_ocean_observation_ndepth_dimname, &
+     !                                      config_ocean_observation_obs_varname, &
+     !                                      config_ocean_observation_nobs_dimname, &
+     !                                      config_ocean_observation_err_varname, &
+     !                                      config_ocean_observation_nerr_dimname
+
+     !  the  MPAS_readStream(observationStream, obs_rec, iErr) can not identify the correct obs_rec, it always read tghe first
+     !  record. SO need fugure out the issues @YL
+       ! get observation dimension
+       iocontext_ptr  =>  domain % iocontext
+       if(OCN_obs_data(ID)%grid_type == O_profile) then 
+           inputFile = MPAS_io_open(trim(OCN_obs_data(ID)%filename)//YMDH//'.nc', MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
+       else
+           inputFile = MPAS_io_open(trim(OCN_obs_data(ID)%filename), MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
+       endif
+       call MPAS_io_inq_dim(inputFile, trim(OCN_obs_data(ID)%Dm_name), nDIMOBS, iErr)
+       call MPAS_io_close(inputFile, iErr)
+
+       if(OCN_obs_data(ID)%grid_type == O_profile) then 
+            call MPAS_createStream(observationStream, domain % iocontext, trim(OCN_obs_data(ID)%filename)//YMDH//'.nc', MPAS_IO_NETCDF, &
+                              MPAS_IO_READ, ierr=iErr)
+       else
+            call MPAS_createStream(observationStream, domain % iocontext, trim(OCN_obs_data(ID)%filename), MPAS_IO_NETCDF, MPAS_IO_READ, ierr=iErr)
+       endif
+       ! the same dimesion name for, lon,lat,depth,obs,obs error
+
+      ! Setup OB_lon,OB_lat,OB_depth,OB_obs, OB_err to be read in 
+       OB_lat % fieldName = trim(OCN_obs_data(ID)%latname)
+       OB_lat % dimSizes(1) = nDIMOBS
+       OB_lat % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+       OB_lat % isVarArray = .false.
+       OB_lat % isPersistent = .true.
+       OB_lat % isActive = .true.
+       OB_lat % hasTimeDimension = .false.
+       OB_lat % block => domain % blocklist
+       allocate(OB_lat % attLists(1))
+       allocate(OB_lat % array(nDIMOBS))
+       call MPAS_streamAddField(observationStream, OB_Lat, iErr)
+
+       OB_lon % fieldName = trim(OCN_obs_data(ID)%lonname)
+       OB_lon % dimSizes(1) = nDIMOBS
+       OB_lon % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+       OB_lon % isVarArray = .false.
+       OB_lon % isPersistent = .true.
+       OB_lon % isActive = .true.
+       OB_lon % hasTimeDimension = .false.
+       OB_lon % block => domain % blocklist
+       allocate(OB_lon % attLists(1))
+       allocate(OB_lon % array(nDIMOBS))
+       call MPAS_streamAddField(observationStream, OB_Lon, iErr)
+
+       OB_depth % fieldName = trim(OCN_obs_data(ID)%vertical_name)
+       OB_depth % dimSizes(1) = nDIMOBS
+       OB_depth % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+       OB_depth % isVarArray = .false.
+       OB_depth % isPersistent = .true.
+       OB_depth % isActive = .true.
+       OB_depth % hasTimeDimension = .false.
+       OB_depth % block => domain % blocklist
+       allocate(OB_depth % attLists(1))
+       allocate(OB_depth % array(nDIMOBS))
+       call MPAS_streamAddField(observationStream, OB_depth, iErr)
+
+       OB_obs % fieldName = trim(OCN_obs_data(ID)%varname)
+       OB_obs % dimSizes(1) = nDIMOBS
+       OB_obs % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+       OB_obs % isVarArray = .false.
+       OB_obs % isPersistent = .true.
+       OB_obs % isActive = .true.
+       OB_obs % hasTimeDimension = .true.
+       OB_obs % block => domain % blocklist
+       allocate(OB_obs % attLists(1))
+       allocate(OB_obs % array(nDIMOBS))
+       call MPAS_streamAddField(observationStream, OB_obs, iErr)
+
+       if(OCN_obs_data(ID)%err_var0 <=0.0) then
+          OB_err % fieldName = trim(OCN_obs_data(ID)%uncert_name)
+          OB_err % dimSizes(1) = nDIMOBS
+          OB_err % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+          OB_err % isVarArray = .false.
+          OB_err % isPersistent = .true.
+          OB_err % isActive = .true.
+          OB_err % hasTimeDimension = .true.
+          OB_err % block => domain % blocklist
+          allocate(OB_err % attLists(1))
+          allocate(OB_err % array(nDIMOBS))
+          call MPAS_streamAddField(observationStream, OB_err, iErr)
+       end if
+
+     ! use for decomp OBS
+       OB_index % fieldName = 'indexToblock'
+       OB_index % dimSizes(1) = nDIMOBS
+       OB_index % dimNames(1) = trim(OCN_obs_data(ID)%Dm_name)
+       OB_index % isVarArray = .false.
+       OB_index % isPersistent = .true.
+       OB_index % isActive = .true.
+       OB_index % hasTimeDimension = .false.
+       OB_index % block => domain % blocklist
+       allocate(OB_index % attLists(1))
+       allocate(OB_index % array(nDIMOBS))
+       call MPAS_streamAddField(observationStream, OB_index, iErr)
+
+       ! Add  OB_lon,OB_lat,OB_obs 
+
+       ! Read stream
+       if(OCN_obs_data(ID)%grid_type == O_profile) then 
+             call MPAS_readStream(observationStream, 1, iErr)
+       else
+             call MPAS_readStream(observationStream, obs_rec, iErr)
+       endif
+       ! Close stream
+       call MPAS_closeStream(observationStream)      ! If need destroy the Strem for next observations? @YL
+
+       ! output to check the value
+        if(iamroot_da_all) then
+           write(logunit,*) trim(subname),'obs input begin',OB_lat%array(1),OB_lon%array(1),OB_obs%array(1) 
+           write(logunit,*) trim(subname),'obs input end',OB_lat%array(nDIMOBS),OB_lon%array(nDIMOBS),OB_obs%array(nDIMOBS) 
+        end if
+!      collect local obs 
+       ! can be move to grid setting @YL
+       ! periodic boundary to be take care @YL
+!        mxlon=max(maxval(DA_lonCell),maxval(DA_lonEdge))
+!        mnlon=min(minval(DA_lonCell),minval(DA_lonEdge))
+!        mxlat=max(maxval(DA_latCell),maxval(DA_latEdge))
+!        mnlat=min(minval(DA_latCell),minval(DA_latEdge))
+!        write(logunit,*) trim(subname),'local DA grid lon,lat range',mnlon,mxlon,mxlat,mnlat,'@ curent PE:',iam_da_all,iam_da
+        
+        ! get local obs number
+        allocate(obs_index(nDIMOBS),stat=ierr)
+        nobs=0
+        do i=1,nDIMOBS
+!           if(OB_lat%array(i)<mnlat .or. OB_lat%array(i)>mxlat .or. OB_lon%array(i)<mnlon .or. OB_lon%array(i)> mxlon) CYCLE
+            if(OB_index%array(i) .NE. blockID) CYCLE
+            nobs=nobs+1
+            obs_index(nobs)=i
+        enddo
+        !-     set the observation size  based on observation dimension 
+        OCN_obs_data(ID)%nobs=nobs
+       ! write(logunit,*) trim(subname),'nobs:',nobs,'@ curent PE:',iam_da_all,iam_da
+        if(nobs==0)then
+           write(logunit,*) trim(subname),'finish read obs:',trim(OCN_obs_data(ID)%obs_name),OCN_obs_data(ID)%nobs
+            return
+        endif
+
+        allocate (OCN_obs_data(ID)%values(nobs), stat=ierr)
+        allocate (OCN_obs_data(ID)%lon(nobs), stat=ierr)
+        allocate (OCN_obs_data(ID)%lat(nobs), stat=ierr)
+        allocate (OCN_obs_data(ID)%depth(nobs), stat=ierr)
+        allocate (OCN_obs_data(ID)%err_var(nobs), stat=ierr)
+
+        !save the local observations     
+        do iob=1,nobs
+            OCN_obs_data(ID)%lon(iob) = OB_lon%array(obs_index(iob))
+            OCN_obs_data(ID)%lat(iob) = OB_lat%array(obs_index(iob)) 
+            OCN_obs_data(ID)%depth(iob) = OB_depth%array(obs_index(iob))
+            OCN_obs_data(ID)%values(iob)= OB_obs%array(obs_index(iob))
+           ! OCN_obs_data(ID)%err_var(iob)=OB_err%array(obs_index(iob))
+       end do
+
+       if(OCN_obs_data(ID)%err_var0 <=0.0) then
+            do iob=1,nobs
+              OCN_obs_data(ID)%err_var(iob)=OB_err%array(obs_index(iob))
+            end do
+       else 
+            OCN_obs_data(ID)%err_var= OCN_obs_data(ID)%err_var0
+       endif 
+       
+      deallocate(obs_index) 
+        !
+!     write(logunit,*) trim(subname),'lon range: obs/state',maxval(OCN_obs_data(ID)%lon),minval(OCN_obs_data(ID)%lon),&
+!              maxval(DA_lonCell),minval(DA_lonCell)
+!     write(logunit,*) trim(subname),'lat range: obs/state',maxval(OCN_obs_data(ID)%lat),minval(OCN_obs_data(ID)%lat),&
+!              maxval(DA_latCell),minval(DA_latCell)
+
+!     write(logunit,*) trim(subname),'finished:',trim(OCN_obs_data(ID)%obs_name),OCN_obs_data(ID)%nobs, &
+!               '@ curent PE:',iam_da_all,iam_da
+
+       call mpi_barrier(mpicom_da_all, ierr)
+       !
+
+    end subroutine read_mpaso_obs_profile
+
+
+!==============================================================================
+!BOP
+!   !ROUTINE: collect_mpaso_state4da
+!   ! collect DA required ocean state from each model member to creat ensmeble array.
+    subroutine collect_mpaso_state4da()
+
+!BOC
+       implicit none
+       character(*), parameter :: subName =   '(collect_mpaso_state4da) '
+       integer :: i,j,k, ivar,ierr
+
+       call mpaso_DAstate_allocate()
+       do ivar = 1, n_OCN_state
+           if(.not. OCN_DAstate_data(ivar)%required) CYCLE
+           !write(logunit,*) trim(subname),ivar, OCN_DAstate_data(ivar)%name,OCN_DAstate_data(ivar)%state_dim
+           select case (ivar)
+                case(OCN_TEMP_index)
+                        call ensem_async_prior_tracers(ivar,'index_temperature')
+                case(OCN_SALT_index)
+                        call ensem_async_prior_tracers(ivar,'index_salinity')
+                case(OCN_VEL_index)
+                        call ensem_async_prior_states(ivar,'normalVelocity')
+                case(OCN_SSH_index)
+                        call ensem_async_prior_states(ivar,'ssh')
+                CASE DEFAULT
+                       write(logunit,*)trim(subname),'More states to develop'
+           end select
+           
+           if(iamroot_da_all .and. OCN_DAstate_data(ivar)%state_dim == 1) &
+           write(logunit,*)trim(subname),trim(OCN_DAstate_data(ivar)%name), &
+                   'max/min',maxval(OCN_DAstate_data(ivar)%prior1d),minval(OCN_DAstate_data(ivar)%prior1d)
+           if(iamroot_da_all .and. OCN_DAstate_data(ivar)%state_dim == 2) &
+           write(logunit,*)trim(subname),trim(OCN_DAstate_data(ivar)%name), &
+                   'max/min',maxval(OCN_DAstate_data(ivar)%prior2d),minval(OCN_DAstate_data(ivar)%prior2d)
+       end do
+    end subroutine collect_mpaso_state4da
+!==============================================================================
+!BOP
+!   !ROUTINE: ensem_async_prior_tracers
+!   ! collect DA required ocean tracers from each model member to creat ensmeble array.
+!   ! mpaso treat temperature and salinity as tracers 
+!   ! All tracers are 2-D, DA will be 3D
+    subroutine ensem_async_prior_tracers(VID, idx_name)
+!BOC
+       implicit none
+       integer,intent(in) :: VID
+       character(*),intent(in) :: idx_name
+    
+!BOC
+       character(*), parameter :: subName =   '(ensem_async_prior_tracers) '
+      
+!     temporal for testing communication
+      real (kind=RKIND), dimension(:,:,:),allocatable :: state_da,state_da_all
+
+!      type (mpas_pool_type), pointer ::  diagnosticsPool, forcingPool, averagePool, scratchPool
+      type (mpas_pool_type), pointer :: meshPool, statePool, tracersPool
+
+      type (block_type), pointer :: block_ptr    
+      integer, pointer :: nCellsSolve,nVertLevels
+      integer, pointer :: idx
+      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), dimension(:), pointer :: SSHValue
+      real (kind=RKIND), dimension(:,:), pointer :: TValue
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+
+      integer :: da_nbs,da_nbe
+      integer:: i,j,k,n
+      integer:: ierr
+
+ !    allocate local  array, tracers are 2D, so ensemble are 3D, @YL no halo used
+      allocate (state_da(allCellsSolve,DA_nvert,ensemble_size),state_da_all(allCellsSolve,DA_nvert,ensemble_size),stat=ierr)
+      state_da=0.0
+      state_da_all=0.0
+
+ !    collect state from mesh
+      n = 0
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
+         call mpas_pool_get_dimension(tracersPool, trim(idx_name), idx)
+
+         !if (iamroot_da) write(logunit,*) 'vertlevels',nVertLevels, maxLevelCell(1), maxLevelCell(nCellsSolve)
+         do i = 1, nCellsSolve
+             n = n + 1
+             do k=1,maxLevelCell(i)
+                  state_da(n,k,my_inst)=activeTracers(idx,k,i)
+             end do
+         end do
+
+          block_ptr => block_ptr % next
+      end do       
+
+     !gather ensemble with DA local comm
+      call MPI_ALLREDUCE(state_da,state_da_all,size(state_da),MPI_REALKIND,MPI_SUM,mpicom_da, ierr)
+     ! keep the local DA ensemble for current PE
+      OCN_DAstate_data(VID)%prior2d(da_Cell_nbs:da_Cell_nbe,:,:)=state_da_all(da_Cell_nbs:da_Cell_nbe,:,:)
+      OCN_DAstate_data(VID)%posterior2d=OCN_DAstate_data(VID)%prior2d
+
+!      if (iamroot_da) write(logunit,*) &
+!            trim(subname), 'PEIDs,array',my_inst, iam_local, state_da(da_Cell_nbs,1,my_inst),state_da_all(da_Cell_nbs,1,my_inst), &
+!                       OCN_DAstate_data(VID)%prior2d(da_Cell_nbs,1,:)
+      deallocate(state_da,state_da_all)
+      call mpi_barrier(mpicom_da_all, ierr)
+
+    end subroutine ensem_async_prior_tracers
+
+!==============================================================================
+!BOP
+!   !ROUTINE: ensem_async_prior_states
+!   ! collect DA required ocean tracers from each model member to creat ensmeble array.
+!   ! mpaso treat temperature and salinity as tracers 
+!   ! All tracers are 2-D, DA will be 3D
+    subroutine ensem_async_prior_states(VID, var_name)
+!BOC
+       implicit none
+       integer,intent(in) :: VID
+       character(*),intent(in) :: var_name
+    
+!BOC
+       character(*), parameter :: subName =   '(ensem_async_prior_states) '
+      
+!     temporal for testing communication
+      real (kind=RKIND), dimension(:,:,:),allocatable :: state_da,state_da_all
+      real (kind=RKIND), dimension(:,:),allocatable :: state_1D_da,state_1D_da_all
+
+!      type (mpas_pool_type), pointer ::  diagnosticsPool, forcingPool, averagePool, scratchPool
+      type (mpas_pool_type), pointer :: meshPool, statePool, tracersPool
+
+      type (block_type), pointer :: block_ptr    
+      integer, pointer :: nCellsSolve,nVertLevels
+      integer, pointer :: idx
+      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), dimension(:), pointer :: state1DValue
+      real (kind=RKIND), dimension(:,:), pointer :: state2DValue
+
+      integer :: da_nbs,da_nbe, allSolve
+      integer:: i,j,k,n,ierr
+
+      ! there are three type of grids: CEll, Edge, Vertex. Start from CELL
+      allSolve=allCellsSolve
+      da_nbs=da_Cell_nbs
+      da_nbe=da_Cell_nbe
+
+ !    allocate local  array, tracers are 1/2D, so ensemble are 2/3D, @YL no halo used
+     if(OCN_DAstate_data(VID)%state_dim ==2) then 
+          allocate (state_da(allSolve,DA_nvert,ensemble_size),state_da_all(allSolve,DA_nvert,ensemble_size),stat=ierr)
+          state_da=0.0
+          state_da_all=0.0
+      end if 
+      if(OCN_DAstate_data(VID)%state_dim ==1) then
+          allocate (state_1D_da(allSolve,ensemble_size),state_1D_da_all(allSolve,ensemble_size),stat=ierr)
+          state_1D_da=0.0
+          state_1D_da_all=0.0
+      end if 
+
+ !    collect state from mesh
+      n = 0
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)      !@YL
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)    !@YL
+         if(OCN_DAstate_data(VID)%state_dim ==1)  call mpas_pool_get_array(statePool, trim(var_name), state1DValue,1)
+         if(OCN_DAstate_data(VID)%state_dim ==2)  call mpas_pool_get_array(statePool, trim(var_name), state2DValue,1)
+
+         !if (iamroot_da) write(logunit,*) 'vertlevels',nVertLevels, maxLevelCell(1), maxLevelCell(nCellsSolve)
+
+         do i = 1, nCellsSolve
+             n = n + 1
+             if(OCN_DAstate_data(VID)%state_dim ==1) state_1D_da(n,my_inst)=state1DValue(i)
+             
+             if(OCN_DAstate_data(VID)%state_dim ==2)then
+                do k=1,maxLevelCell(i)
+                   state_da(n,k,my_inst)=state2DValue(k,i)
+                enddo
+             endif
+         end do
+          block_ptr => block_ptr % next
+      end do       
+
+     !gather ensemble with DA local comm
+      if (OCN_DAstate_data(VID)%state_dim ==2) then
+          call MPI_ALLREDUCE(state_da,state_da_all,size(state_da),MPI_REALKIND,MPI_SUM,mpicom_da, ierr)
+          ! keep the local DA ensemble for current PE
+          OCN_DAstate_data(VID)%prior2d(da_nbs:da_nbe,:,:)=state_da_all(da_nbs:da_nbe,:,:)
+          OCN_DAstate_data(VID)%posterior2d=OCN_DAstate_data(VID)%prior2d
+          ! if (iamroot_da) write(logunit,*) &
+          !       trim(subname), 'PEIDs,array',my_inst, iam_local, state_da(da_nbs,1,my_inst),state_da_all(da_nbs,1,my_inst), &
+          !              OCN_DAstate_data(VID)%prior2d(da_nbs,1,:)
+          deallocate(state_da,state_da_all)
+      endif
+
+      if (OCN_DAstate_data(VID)%state_dim ==1) then
+          call MPI_ALLREDUCE(state_1D_da,state_1D_da_all,size(state_1D_da),MPI_REALKIND,MPI_SUM,mpicom_da, ierr)
+          ! keep the local DA ensemble for current PE
+          OCN_DAstate_data(VID)%prior1d(da_nbs:da_nbe,:)=state_1D_da_all(da_nbs:da_nbe,:)
+          OCN_DAstate_data(VID)%posterior1d=OCN_DAstate_data(VID)%prior1d
+          !if (iamroot_da) write(logunit,*) &
+          !    trim(subname), 'PEIDs,array',my_inst, iam_local, state_1D_da(da_nbs,my_inst),state_1D_da_all(da_nbs,my_inst), &
+          !             OCN_DAstate_data(VID)%prior1d(da_nbs,:)
+          deallocate( state_1D_da,state_1D_da_all)
+      endif
+       call mpi_barrier(mpicom_da_all, ierr)
+
+    end subroutine ensem_async_prior_states
+
+!==============================================================================
+
+
+
+
+end module mpaso_DA_mod

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -62,6 +62,8 @@ module ocn_comp_mct
    use ocn_config
    use ocn_submesoscale_eddies
    use ocn_eddy_parameterization_helpers
+   
+   use mpaso_DA_mod, only:mpaso_DA_init,mpaso_DA_run ! For ECDA   
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -836,6 +838,8 @@ contains
         call memmon_reset_addr()
     endif
 #endif
+  
+    call mpaso_DA_init(mpicom_o,domain_ptr)    ! for ECDA
 
     call mpas_log_write('=== Completed ocn_init_mct ===', flushNow=.true.)
 
@@ -924,6 +928,9 @@ contains
       timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
       call mpas_get_timeInterval(timeStep, dt=dt)
       call mpas_reset_clock_alarm(domain_ptr % clock, coupleAlarmID, ierr=ierr)
+
+      !   ECDA, location may be adjust @YL
+      call mpaso_DA_run(domain % clock)
 
       ! Import state from coupler
       call ocn_import_mct(x2o_o, ierr)

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -18,6 +18,9 @@ list(APPEND RAW_SOURCES
   ../../mpas-ocean/driver/ocn_comp_mct.F
   ../../mpas-ocean/driver/mpaso_cpl_indices.F
   ../../mpas-ocean/driver/mpaso_mct_vars.F
+  ../../mpas-ocean/driver/mpaso_DA_mod.F
+  ../../mpas-ocean/driver/ECDA_mpaso_obs_mod.F
+  ../../mpas-ocean/driver/ECDA_mpaso_state_mod.F
 )
 
 # dycore

--- a/driver-mct/shr/ECDA_shr_type_mod.F90
+++ b/driver-mct/shr/ECDA_shr_type_mod.F90
@@ -1,0 +1,110 @@
+!BOP
+!   !MODULE: ecda_shr_type_mod
+!   !INTERFACE:
+module ECDA_shr_type_mod
+!   !DESCRIPTION:
+!   ! Define the state/obs type
+!   !
+!   !REVISION HISTORY:
+!    Jul  2019 Y. Liu <liu6@tamu.edu> initial release
+!   !USES:
+
+  use shr_kind_mod, only : r8=> shr_kind_r8
+
+  integer, public, parameter :: filename_len      = 256
+  integer, public, parameter :: type_name_len     = 72
+  integer, public, parameter :: var_name_len      = 72
+
+  type, public ::  ECDA_state_type
+       character(len=type_name_len)                ::   name              ! state variable  name,ex : ocn_temp,ocn_salt...
+       integer                                     ::   state_type = 1    ! state type for mpas grid: 1 cells (default); 2,edgers; 3 Vertex 
+       integer                                     ::   state_dim         ! dimension of state variables (1, 2,3 for now) 
+       logical                                     ::   required          ! if required for DA by obsope or update 
+       logical                                     ::   update            ! if  final analysis results to updated in model, IAU 
+       logical                                     ::   averaged          ! if the observations averaged
+       real(r8)                                    ::   r2p_fac           ! the relaxiation to prior factor, current use Zhang F. scheme
+       real(r8), allocatable,dimension(:)          ::   KKlev             ! the vertical coordinator for model state
+       real(r8)                                    ::   mx_value          ! Max values of the state 
+       real(r8)                                    ::   mn_value          ! Min values of the state 
+       
+       != model original grid
+       real(r8), allocatable,dimension(:,:)        ::   h_da              ! the water depth for the grid
+       real(r8), allocatable,dimension(:,:)        ::   lon_da            ! longitude 
+       real(r8), allocatable,dimension(:,:)        ::   lat_da            ! latitude  
+
+       real(r8), allocatable,dimension(:)        ::   h_da_1d              ! the water depth for the grid
+       real(r8), allocatable,dimension(:)        ::   lon_da_1d            ! longitude 
+       real(r8), allocatable,dimension(:)        ::   lat_da_1d            ! latitude  
+
+       real(r8), allocatable,dimension(:,:,:,:)    ::   prior             ! the original prior value, ensemble
+       real(r8), allocatable,dimension(:,:,:)      ::   prior2d           ! the original prior value for 2D, ensemble
+       real(r8), allocatable,dimension(:,:)        ::   prior1d           ! the original prior value for 2D, ensemble
+       real(r8), allocatable,dimension(:,:,:,:)    ::   posterior         ! the original posterior value before final inflation,ensemble
+       real(r8), allocatable,dimension(:,:,:)      ::   posterior2d       ! the original posterior value for 2D, ensemble
+       real(r8), allocatable,dimension(:,:)        ::   posterior1d       ! the original posterior value for 1D, ensemble
+
+       real(r8), allocatable,dimension(:,:,:,:)    ::   prior_ave         ! the original prior ave value ,ensemble
+       real(r8), allocatable,dimension(:,:,:)      ::   prior2d_ave       ! the original prior ave value for 2D, ensemble
+       real(r8), allocatable,dimension(:,:)        ::   prior1d_ave       ! the original prior ave value for 1D, ensemble
+
+       != model original grid
+       integer                                     ::   ave_num           ! the total average number
+       real(r8), allocatable,dimension(:,:,:)      ::   ave_value         !  average values for average observations
+       real(r8), allocatable,dimension(:,:)        ::   ave_value2d       !  average values for average observations (2D) 
+       real(r8), allocatable,dimension(:)          ::   ave_value1d       !  average values for average observations (21D) 
+       real(r8), allocatable,dimension(:,:,:)      ::   IAU_increm        ! IAU increment at current PE
+       real(r8), allocatable,dimension(:,:)        ::   IAU_increm2d      ! IAU increment at current PE
+       real(r8), allocatable,dimension(:)          ::   IAU_increm1d      ! IAU increment at current PE
+  end type ECDA_state_type
+
+
+  type, public ::  ECDA_obs_type
+       character(len=type_name_len)                ::   obs_name          ! observation name, use for identify observations, it is the observation namelist name
+       integer                                     ::   obs_type          ! observation type :  ex:TEMP_ID,SALT_ID, use for obs_ope
+       character(len=filename_len)                 ::   filename          ! the obs file name or part
+       character(len=var_name_len)                 ::   varname           ! the obs variable name in ncfile 
+       character(len=var_name_len)                 ::   uncert_name           ! the obs variable name in ncfile 
+       character(len=var_name_len)                 ::   lonname           ! the lon coordinator name in ncfile 
+       character(len=var_name_len)                 ::   latname           ! the lat coordinator name in ncfile 
+       character(len=var_name_len)                 ::   vertical_name     ! the vertical coordinator name in ncfile 
+       character(len=var_name_len)                 ::   dm_name           ! use for profile observation 
+       character(len=10)                           ::   init_obs_YMDH     ! the inital time to observations, use to calculate record
+       integer                                     ::   uncert_type       ! variance 0, std 1
+       integer                                     ::   init_obs_YR       ! ex:2016
+       integer                                     ::   init_obs_MO       ! ex: 1~12
+       integer                                     ::   init_obs_DY       ! ex:1~31
+       integer                                     ::   init_obs_HR       ! ex:0~23
+       integer                                     ::   grid_type         ! netcdf file, 1,2 are grid file, 1: model grid, 2 other resolution, need read coordinator information, 3: station data, (lon,lat,lev, value,error) 
+       integer                                     ::   obs_dm            ! data dimension in file, only used for grid file
+       integer                                     ::   start_layer       ! data start from (vertical layer) for 3D,only used for grid file
+       integer                                     ::   nlayer            ! total vertical layer for 3D,only used for grid file
+       integer                                     ::   ilayer            ! pick vertical layer ,only used for grid file
+       logical                                     ::   assimilate        ! if this observation avaliable 
+       integer                                     ::   inst_type         ! instrument types are defined by platform class (e.g. MOORING, DROP) and instrument type (XBT, CTD, ...)
+       integer                                     ::   nobs              ! the number of observation record at current PE
+       logical, allocatable,dimension(:)           ::   required_states   ! the required state variables for obsope 
+       logical, allocatable,dimension(:)           ::   update_states     ! the updated  state variables for current variable 
+       real(r8),allocatable,dimension(:)           ::   skip_sfc          ! skip surface for ssh lik observation 
+       real(r8), allocatable,dimension(:)          ::   rx, ry,rz         ! obs location in grids in real 
+       real(r8), allocatable,dimension(:)          ::   lon,lat,depth     ! obs location in longitude and latitude and depth (ocn:negtive, atm:positive)
+       real(r8), allocatable,dimension(:)          ::   values            ! the observation values
+       real(r8), allocatable,dimension(:)          ::   err_var           ! the observation error variance. 
+       real(r8)                                    ::   err_var0          ! specify constant observation error variance (>0). When <=0, input from observation file.
+       real(r8)                                    ::   adj_scale = 1.0   ! some variable need adjust scale
+       logical,  allocatable,dimension(:)          ::   valid             ! partial DA switch, to be developed
+       integer, allocatable,dimension(:)           ::   qc_flag           ! observation quality flag
+       real(r8)                                    ::   obs_range_min     ! observation need larger than the obs_range_min 
+       real(r8)                                    ::   obs_range_max     ! observation need smaller than obs_range_max
+       real(r8)                                    ::   RR_xy,RR_z        ! half of localization cutoff for spatial and vertical
+       real(r8)                                    ::   Mx_PO_dist        ! maxium distance allowed between observation and forecast
+       real(r8)                                    ::   Mx_misfit         ! maxium rate allowed for inflate  observation uncertainty
+
+       integer                                     ::   gl_nobs                  ! global observation record for letkf
+       real(r8), allocatable,dimension(:)          ::   gl_lon,gl_lat,gl_depth   ! global obs location in longitude and latitude and depth (ocn:-, atm:+)
+       real(r8), allocatable,dimension(:,:)        ::   fcst_obs                 ! local forecast observations
+
+
+  end type ECDA_obs_type
+
+end module ECDA_shr_type_mod
+

--- a/driver-mct/shr/ran_mod.F90
+++ b/driver-mct/shr/ran_mod.F90
@@ -1,0 +1,99 @@
+module ran_mod
+! module contains three functions
+! ran1 returns a uniform random number between 0-1
+! spread returns random number between min - max
+! normal returns a normal distribution
+use shr_kind_mod, only : r8=> shr_kind_r8
+!use mod_kinds        , only : r8
+public :: ran1, spread, normal,init_random_seed,randperm
+
+
+contains
+    function ran1()  !returns random number between 0 - 1
+!        use numz
+        implicit none
+        real(r8):: ran1,x
+!        call init_random_seed()
+        call random_number(x) ! built in fortran 90 random number function
+        ran1=x
+    end function ran1
+
+    function spread(min,max)  !returns random number between min - max
+!        use numz
+        implicit none
+        real(r8):: spread
+        real(r8):: min,max
+        spread=(max - min) * ran1() + min
+    end function spread
+
+    function normal() !returns a normal distribution of (0,1.0)
+ !       use numz
+        implicit none
+!        real(r8),intent(in):: mean,sigma
+        real(r8):: normal,tmp
+        integer :: flag
+        real(r8):: fac,gsave,rsq,r1,r2
+        save flag,gsave
+        data flag /0/
+        if (flag.eq.0) then
+        rsq=2.0
+            do while(rsq.ge.1.0.or.rsq.eq.0.0) ! new from for do
+                r1=2.0*ran1()-1.0
+                r2=2.0*ran1()-1.0
+                rsq=r1*r1+r2*r2
+            enddo
+            fac=sqrt(-2.0*log(rsq)/rsq)
+            gsave=r1*fac
+            tmp=r2*fac
+            flag=1
+        else
+            tmp=gsave
+            flag=0
+        endif
+        normal=tmp
+        return
+    end function normal
+
+
+   SUBROUTINE init_random_seed()
+     implicit none
+     INTEGER :: i, n, clock
+     INTEGER, DIMENSION(:), ALLOCATABLE :: seed
+     CALL RANDOM_SEED(size = n)
+     ALLOCATE(seed(n))
+     CALL SYSTEM_CLOCK(COUNT=clock)
+     seed = clock + 37 * (/ (i - 1, i = 1, n) /)
+     CALL RANDOM_SEED(PUT = seed)
+     DEALLOCATE(seed)
+     END SUBROUTINE init_random_seed
+
+
+
+function randperm(num)
+!  use data_type, only : IB, RP
+  implicit none
+  integer(kind=4), intent(in) :: num
+  integer(kind=4) :: number, i, j, k
+  integer(kind=4), dimension(num) :: randperm
+  real(r8), dimension(num) :: rand2
+  intrinsic random_number
+  call random_number(rand2)
+  do i=1,num
+     number=1
+     do j=1,num
+        if (rand2(i) > rand2(j)) then
+               number=number+1
+        end if
+     end do
+     do k=1,i-1
+        if (rand2(i) <= rand2(k) .and. rand2(i) >= rand2(k)) then
+               number=number+1
+        end if
+     end do
+     randperm(i)=number
+  end do
+  return
+end function randperm
+
+
+end module ran_mod

--- a/driver-mct/shr/sEnKF_mod.F90
+++ b/driver-mct/shr/sEnKF_mod.F90
@@ -1,0 +1,848 @@
+!BOP
+!   !MODULE: sEnKF_mod
+!   !INTERFACE:
+module sEnKF_mod
+!   !DESCRIPTION:
+!   ! Random subgrouping ensemble kalman filter
+!   ! two steps of ensemble kalman filter: EAKF and EnKF with perturbed observations
+!   !First step: calculate the increment at observation space
+!   !Second step: Project the analysis increment @ observation space to the model space.
+
+!   !REVISION HISTORY:
+!    July 25 2018 Y. Liu <liu6@tamu.edu> initial release
+!   !USES:
+use shr_kind_mod, only : r8=> shr_kind_r8
+!use mod_kinds        , only : r8
+    implicit none
+    public :: obs_increment,update_from_obs_inc,obs_inflation, &
+              obs_increment_sEAKF, update_increment_sEAKF, &
+              obs_increment_bia,update_from_obs_inc_bia,&
+              EnKF_squen, update_EnKF, &
+              sEnKF_squen, update_sEnKF, &
+              get_ens_mean,get_ens_mean3,get_ens_corr,&
+              inflation_RTPS,inflation_RTPP, inflation_corvariance,&
+              cal_lcwt1d,cal_lcwt2d,cal_lcwt_latlon
+    private
+        real(r8), parameter :: cor_cutoff = 0.0
+
+    contains
+
+!==============================================================================
+!BOP
+    !ROUTAINE: obs_increment
+!   !INTERFACE: 
+
+    subroutine obs_increment(ens, obs,ens_size, obs_var, obs_inc)
+!   !DESCRIPTION:
+       ! sequential EAKF step one:
+       ! calculate analysis increment @ observation space using EAKF
+       ! Anderson (2013)doi:10.1175/1520-0493(2003)131,0634:ALLSFF.2.0.CO;2.
+
+       !ens     : forecast observation
+       !obs     : observation value
+       !obs_var : observation error variance 
+
+        implicit none
+        integer, intent(in) :: ens_size
+        real(r8), intent(in) :: ens(ens_size), obs, obs_var
+        real(r8), intent(out) :: obs_inc(ens_size)
+!EOP
+
+!BOC
+        real(r8) :: af_rate, cov
+        real(r8) :: mean, new_cov, new_mean
+        integer :: ie
+
+        mean = sum(ens) / ens_size
+
+        cov = 0.0
+    
+        do ie = 1, ens_size
+           cov = cov + (ens(ie)-mean)*(ens(ie)-mean)
+        end do
+        
+        cov = cov / (ens_size-1)
+
+        if(cov >= 1.e-8) then                ! ignore  too tiny corvariace 
+           new_cov = (cov *obs_var)/(cov + obs_var)
+           new_mean = new_cov * (obs_var*mean + cov*obs)/(cov*obs_var)
+           af_rate = sqrt(new_cov/cov)    ! the std rate between analysis and forecast
+           obs_inc = af_rate * (ens - mean) + new_mean - ens
+        else
+          obs_inc = 0.0
+        endif
+
+    end subroutine obs_increment
+
+!==============================================================================
+!BOP
+    !ROUTAINE: obs_inflation  @YL need revisit for exactly values
+    !  
+!   !INTERFACE: 
+
+    subroutine obs_inflation(ens, obs,ens_size, obs_var0,  obs_var, distance )
+!   !DESCRIPTION:
+      !inflation observation error for weakly constrain because model could crash when constrained by an obs far from model (mainly caused by model error) 
+      ! model need reject an obs too far away from the forecast values
+      ! here we follow (Parrish and Derber 1992; Dee 1995) for observation variance
+      ! D*D=B+R
+
+       !ens     : forecast observation
+       !obs     : observation value
+       !obs_var0 : default observation error variance 
+       !obs_var : inflated observation error variance 
+
+
+        implicit none
+        integer, intent(in) :: ens_size
+        real(r8), intent(in) :: ens(ens_size), obs, obs_var0
+        real(r8), intent(out) :: obs_var
+        real(r8), optional,intent(out) :: distance
+!EOP
+
+!BOC
+        real(r8) :: cov, mean, min_obs_var
+        integer :: ie
+
+        mean = sum(ens) / ens_size
+        distance = abs(mean - obs)  ! the distance between ensemble mean and observation
+        
+        cov = 0.0
+        do ie = 1, ens_size
+           cov = cov + (ens(ie)-mean)*(ens(ie)-mean)
+        end do
+        cov = cov / (ens_size-1)        
+        min_obs_var= distance*distance-cov;
+
+        obs_var= max(min_obs_var, obs_var0)
+
+        return               
+
+    end subroutine obs_inflation
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: obs_increment_sEAKF
+!   !INTERFACE: 
+    subroutine obs_increment_sEAKF(fobs,zob,EFsize,ens_size,err, &
+             obs_inc,rll)
+!   !DESCRIPTION:
+        ! sequential sEAKF step two:
+        ! calculate analysis increment @ observation space using sEAKF
+        ! Liu 2014 https://search.proquest.com/docview/1667464678?pq-origsite=gscholar
+
+        ! EFsize      : total ensemble size
+        ! ens_size    : sub-ensmble size
+        ! rll         : ensemble member order for subgrouping, need consistant with next step, project to model space
+        ! fobs        : forecast observation
+        ! zob         : observation
+        implicit none
+        integer, intent(in) :: EFsize, ens_size
+        integer, intent(in) :: rll(EFsize)
+        real(r8), intent(in) :: fobs(EFsize),zob,err
+        real(r8), intent(out) :: obs_inc(EFsize)
+!EOP
+
+!BOC
+        real(r8) ::  obs, obs_var
+        real(r8) ::  ens(ens_size),gobs_inc(ens_size)
+        integer :: i, j,ie, sub_size, kk(ens_size), grp
+
+        obs=zob
+        obs_var=err*err
+        sub_size=ens_size
+        grp = EFsize/ens_size
+        do i=1,grp
+           do j=1,ens_size
+               kk(j)=rll(j+(i-1)*ens_size)
+               ens(j)=fobs(kk(j))
+           enddo
+           call obs_increment(ens, obs,sub_size, obs_var, gobs_inc) 
+           do j=1,ens_size
+                obs_inc(kk(j))=gobs_inc(j)
+           enddo
+        enddo
+!EOC
+    end subroutine obs_increment_sEAKF
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: obs_increment_bia
+!   !INTERFACE: 
+    subroutine obs_increment_bia(ens, obs,ens_size, obs_var, obs_inc, bia_var)
+!   !DESCRIPTION:
+        ! calculate analysis increment @ observation space using EAKF with biased  forecast uncertainty (bia_var)
+        ! Y. Liu 2012 unfinished test 
+
+         implicit none
+         integer, intent(in) :: ens_size
+         real(r8), intent(in) :: ens(ens_size), obs, obs_var, bia_var
+         real(r8), intent(out) :: obs_inc(ens_size)
+!EOP
+
+!BOC
+         real(r8) :: af_rate, cov
+         real(r8) :: mean, new_cov, new_mean
+         integer :: ie
+         mean = sum(ens) / ens_size
+
+         cov = 0.0
+
+         do ie = 1, ens_size
+           cov = cov + (ens(ie)-mean)*(ens(ie)-mean)
+         end do
+
+         cov = cov / (ens_size-1)
+
+         if(cov >= 1.e-4) then
+           new_cov = ((cov+bia_var) *obs_var)/(cov +bia_var+ obs_var)
+           new_mean = new_cov * (obs_var*mean + (cov+bia_var)*obs)/((cov+bia_var)*obs_var)
+           af_rate = sqrt(new_cov/cov)
+           obs_inc = af_rate * (ens - mean) + new_mean - ens
+         else
+           obs_inc = 0.0
+         endif
+!EOC
+
+    end subroutine obs_increment_bia
+
+!==============================================================================
+!BOP
+    !ROUTAINE: update_from_obs_inc
+!   !INTERFACE: 
+
+    subroutine update_from_obs_inc(fobs, obs_inc, state, ens_size, state_inc, &
+               wt_factor)
+!   !DESCRIPTION:
+       ! sequential EAKF step two:
+       ! calculate model state analysis increment based on the analysis increment @ observation space
+       ! Anderson (2013)doi:10.1175/1520-0493(2003)131,0634:ALLSFF.2.0.CO;2.
+
+       !fobs      : forecast observation
+       !obs_inc   : analysis increment at observation space
+       !state     : state ensemble at model space
+       !ens_size  : ensemble size
+       !state_inc :  analysis state @ model space
+       !wt_factor:  weighting effect for localization
+
+       implicit none
+
+       integer, intent(in) :: ens_size
+       real(r8), intent(in) :: fobs(ens_size), obs_inc(ens_size)
+       real(r8), intent(in) :: state(ens_size), wt_factor
+       real(r8), intent(out) :: state_inc(ens_size)
+
+!EOP
+!BOC
+       real(r8) :: mean_s, mean_o, cv_s, cv_o, cv, cr
+       real(r8) ::s_prim(ens_size),o_prim(ens_size)
+       integer :: ie
+
+       mean_s = sum(state) / ens_size
+       s_prim=state-mean_s
+       mean_o = sum(fobs) / ens_size
+       o_prim=fobs-mean_o
+
+       cv_s = 0.0
+       cv_o = 0.0
+       cv   = 0.0
+
+       do ie = 1, ens_size
+        !  cv_s = cv_s + (state(ie) - mean_s)*(state(ie) - mean_s)
+        !  cv_o = cv_o + (fobs(ie) - mean_o)*(fobs(ie) - mean_o)
+        !  cv   = cv + (state(ie) - mean_s)*(fobs(ie) - mean_o)
+          cv_s = cv_s + s_prim(ie)*s_prim(ie)
+          cv_o = cv_o +o_prim(ie)*o_prim(ie)
+          cv   = cv + o_prim(ie)*s_prim(ie)
+       end do
+
+       cv_s = cv_s / (ens_size-1)
+       cv_o = cv_o / (ens_size-1)
+       cv   = cv / (ens_size-1)
+       if(cv_o > 1.e-8 .and. cv_s > 1.e-8) then
+          cr   = cv /(sqrt(cv_s)*sqrt(cv_o))
+       else
+          cr = 0.0
+       endif
+
+       if(abs(cr) > cor_cutoff .and. cv_o > 1.e-8)then
+          state_inc = (wt_factor * cv/cv_o) * obs_inc
+       else
+          state_inc = 0.0
+       endif
+!EOC
+    end subroutine update_from_obs_inc
+
+!==============================================================================
+!BOP
+    !ROUTAINE: update_from_obs_inc
+!   !INTERFACE: 
+
+    subroutine update_increment_sEAKF(fobs,obs_inc,state,state_inc, &
+               EFsize,ens_size,rll,sprt,wt_factor)
+!   !DESCRIPTION:
+       ! sequential sEAKF step two:
+       ! calculate model state analysis increment based on the analysis increment @ observation space
+       ! Liu 2014 https://search.proquest.com/docview/1667464678?pq-origsite=gscholar
+       ! EAKF,Anderson (2013)doi:10.1175/1520-0493(2003)131,0634:ALLSFF.2.0.CO;2.
+
+       !fobs      : forecast observation
+       !obs_inc   : analysis increment at observation space
+       !state     : state ensemble at model space
+       !state_inc :  analysis state @ model space
+       !EFsize    : full ensemble size
+       !ens_size  : subgroup ensemble size
+       !rll       : ensemble order for subgrouping
+       !sprt      : switch for updating using 0 (full ensemble corvariace), 1(subgroup ensemble corvariaces) 
+       !wt_factor :  weighting effect for localization
+
+       implicit none
+
+       integer, intent(in) :: EFsize, sprt,ens_size
+       integer, intent(in) :: rll(EFsize)
+       real(r8), intent(in) :: fobs(EFsize), obs_inc(EFsize)
+       real(r8), intent(in) :: state(EFsize), wt_factor
+       real(r8), intent(out) :: state_inc(EFsize)
+!EOP
+!BOC
+       real(r8) :: obs(ens_size), gobs_inc(ens_size),cov_factor, &
+               gstate(ens_size), gstate_inc(ens_size)
+       integer :: grp , i ,j ,kk(ens_size)
+
+       grp = EFsize/ens_size
+
+       if( grp==1 .OR. sprt ==0) then
+           call update_from_obs_inc(fobs, obs_inc, state, EFsize, &
+                state_inc,   wt_factor)
+       else
+
+          do i=1,grp
+             do j=1,ens_size
+                kk(j)=rll(j+(i-1)*ens_size)
+                obs(j)=fobs(kk(j))
+                gobs_inc(j)=obs_inc(kk(j))
+                gstate(j)=state(kk(j))
+             enddo
+             call update_from_obs_inc(obs, gobs_inc, gstate, ens_size, &
+                  gstate_inc, wt_factor)
+             do j=1,ens_size
+                  state_inc(kk(j))=gstate_inc(j)
+             enddo
+          enddo
+       endif
+!EOC
+    end subroutine update_increment_sEAKF
+!==============================================================================
+!BOP
+    !ROUTAINE: update_from_obs_inc_bia
+!   !INTERFACE: 
+
+    subroutine update_from_obs_inc_bia(fobs, obs_inc, state, ens_size, state_inc, &
+               wt_factor,obs_bia,state_bia,r)
+!   !DESCRIPTION:
+       ! sequential EAKF with negtive biased forecast uncertianty step two:
+       ! calculate model state analysis increment based on the analysis increment @ observation space
+       ! Y. Liu 2012, unfinished test 
+       ! EAKF,Anderson (2013)doi:10.1175/1520-0493(2003)131,0634:ALLSFF.2.0.CO;2.
+
+       !fobs      : forecast observation
+       !obs_inc   : analysis increment at observation space
+       !state     : state ensemble at model space
+       !ens_size  : ensemble size
+       !state_inc : analysis state @ model space
+       !wt_factor : weighting effect for localization
+       !obs_bia   : missing error variance of forecast observation
+       !state_bia : missing error variance of forecast state
+       !r         ; correlation corefficent of obs_bia and state_bia
+
+       implicit none
+
+       integer, intent(in) :: ens_size
+       real(r8), intent(in) :: fobs(ens_size), obs_inc(ens_size)
+       real(r8), intent(in) :: state(ens_size), wt_factor
+       real(r8), intent(out) :: state_inc(ens_size)
+       real(r8), intent(in) :: obs_bia,state_bia,r
+
+       real(r8) :: mean_s, mean_o, cv_s, cv_o, cv, cr,cv_b
+       integer :: ie
+
+       mean_s = sum(state) / ens_size
+       mean_o = sum(fobs) / ens_size
+
+       cv_s = 0.0
+       cv_o = 0.0
+       cv   = 0.0
+
+       do ie = 1, ens_size
+         cv_s = cv_s + (state(ie) - mean_s)*(state(ie) - mean_s)
+         cv_o = cv_o + (fobs(ie) - mean_o)*(fobs(ie) - mean_o)
+         cv   = cv + (state(ie) - mean_s)*(fobs(ie) - mean_o)
+       end do
+       cv_s = cv_s / (ens_size-1)
+       cv_o = cv_o / (ens_size-1)
+       cv   = cv / (ens_size-1)
+       cr   = cv /(sqrt(cv_s)*sqrt(cv_o))
+
+       cv_b=r*sqrt(obs_bia*state_bia)
+
+       if(abs(cr) > cor_cutoff .and. cv_o > 1.e-8)then
+          state_inc=(wt_factor *(cv+cv_b)/(cv_o+obs_bia)) *obs_inc
+       else
+          state_inc = 0.0
+       endif
+!EOC
+    end subroutine update_from_obs_inc_bia
+
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: EnKF_squen
+!   !INTERFACE: 
+    subroutine EnKF_squen(ens,obs,ens_size,err,Kinv,Iens)
+!   !DESCRIPTION:
+       ! a sequential EnKF (pertuberd observation) with two steps setting
+       use ran_mod, only : normal
+       integer, intent(in) :: ens_size
+       real(r8), intent(in) :: ens(ens_size), err,obs
+       real(r8), intent(out) :: Kinv, Iens(ens_size)
+!EOP
+!BOC
+       real(r8) :: cov, mean, pert_obs(ens_size)
+       integer :: ie
+
+       mean = sum(ens) / ens_size
+       cov = 0.0
+
+       do ie = 1, ens_size
+         cov = cov + (ens(ie)-mean)*(ens(ie)-mean)
+         pert_obs(ie)= normal() * err    ! random noice for observation
+       end do
+       cov = cov / (ens_size-1)
+       pert_obs=pert_obs-sum(pert_obs)/ens_size+obs !  removed the peturbation mean
+       if(cov >= 1.e-8) then
+           Kinv= 1.0/(cov+err*err)
+           Iens=Iens-sum(Iens)/ens_size+obs-ens
+           Iens=pert_obs-ens
+       else
+           Kinv=0
+           Iens=0
+       endif
+!EOC
+    end subroutine EnKF_squen
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: sEnKF_squen
+!   !INTERFACE: 
+    subroutine sEnKF_squen(ens,obs,EFsize,ens_size,err,rll,spd,Iens)
+!   !DESCRIPTION:
+       ! a sequential subgrouping EnKF (pertuberd observation) with two steps setting
+       ! spd is not one, subgrouping method from Houtekamer and Mitchell (1998)
+       use ran_mod, only : normal
+       integer, intent(in) :: ens_size,spd,EFsize
+       real(r8), intent(in) :: ens(EFsize), err,obs
+       real(r8), intent(out) :: Iens(EFsize)
+       integer ,intent(in) :: rll(EFsize)
+!EOP
+!BOC
+       real(r8) :: cov, mean,fens(ens_size),IIens(ens_size),Kinv
+       integer :: ie,i,k,grp,kk,spd1
+
+       grp=EFsize/ens_size
+       spd1=spd
+       if(grp==1)spd1=1
+       do i=1,grp
+          do k=1,ens_size
+             kk=ens_size*(i-1)+k
+             fens(k)=ens(rll(kk))
+          enddo
+
+          if (spd1==1 )then
+             mean = sum(fens) / ens_size
+             cov = sum((fens-mean)**2)
+             cov=cov/(ens_size-1)
+          else
+!            Houtekamer and Mitchell
+             mean = (sum(ens)-sum(fens)) / (EFsize-ens_size)
+             cov = sum((ens-mean)**2)-sum((fens-mean)**2) 
+             cov=cov/(EFsize-ens_size-1)
+          endif
+
+          do ie = 1, ens_size
+            IIens(ie)=normal()*err
+          end do
+          Kinv= 1.0/(cov+err*err)
+          IIens=IIens-sum(IIens)/ens_size+obs-fens
+          IIens=Kinv*IIens
+          do k=1,ens_size
+             kk=ens_size*(i-1)+k
+             Iens(rll(kk))=IIens(k)
+          enddo
+       enddo
+!EOC
+    end subroutine sEnKF_squen
+
+!==============================================================================
+!BOP
+    !ROUTAINE: update_EnKF
+!   !INTERFACE: 
+    subroutine update_EnKF(fens,Kinv,Iens,state,ens_size,cov_factor)
+!   !DESCRIPTION:
+       ! a sequential EnKF (pertuberd observation) with two steps setting
+       ! Step 2 : update model state, ** here we are not calculate the increment only, wich is different than the EAKF
+       ! fens     : forecast observation
+       ! state    : model state
+
+!
+       integer, intent(in) :: ens_size
+       real(r8), intent(in) :: fens(ens_size),Kinv, Iens(ens_size),cov_factor
+       real(r8), intent(inout) :: state(ens_size)
+!EOP
+!BOC
+       real(r8) :: cov, mean1,mean2
+       integer :: ie,j,k
+
+       mean1=sum(fens)/ens_size
+       mean2=sum(state)/ens_size
+       cov=0.0;
+       do ie=1,ens_size
+         cov = cov + (fens(ie)-mean1)*(state(ie)-mean2)
+       enddo
+       cov=cov/(ens_size-1)
+       state=state+(cov*Kinv*cov_factor)*Iens
+!EOC
+    end subroutine update_EnKF
+
+!==============================================================================
+!BOP
+    !ROUTAINE: update_sEnKF
+!   !INTERFACE: 
+    subroutine update_sEnKF(ens,Iens,state,EFsize,ens_size,rll,spd,wt)
+!   !DESCRIPTION:
+       ! a sequential subgrouping EnKF (pertuberd observation) with two steps setting
+       ! Step 2 : update model state, ** here we are not calculate the increment only, wich is different than the EAKF
+       ! ens     : forecast observation
+       ! state    : model state
+       integer, intent(in) :: EFsize,ens_size,spd
+       real(r8), intent(in) :: ens(EFsize), Iens(EFsize),wt
+       integer, intent(in) :: rll(EFsize)
+       real(r8), intent(inout) :: state(EFsize)
+!EOP
+!BOC
+       real(r8) :: cov, mean1,mean2,IIens(ens_size),fstate(ens_size),fens(ens_size)
+       integer :: ie,i,k,j,grp,kk,spd1
+
+       spd1=spd;
+       grp=EFsize/ens_size
+       if(grp==1)spd1=1
+       do i=1,grp
+          do k=1,ens_size
+              kk=ens_size*(i-1)+k
+              fstate(k)=state(rll(kk))
+              fens(k)=ens(rll(kk))
+              IIens(k)=Iens(rll(kk))
+          enddo
+
+          if (spd1==1)then
+              mean1 = sum(fens) / ens_size
+              mean2=sum(fstate)/ ens_size
+              cov = sum((fens-mean1)*(fstate-mean2))/(ens_size-1)
+          else
+              mean1 = (sum(ens)-sum(fens)) / (EFsize-ens_size)
+              mean2 = (sum(state)-sum(fstate)) / (EFsize-ens_size)
+              cov = sum((ens-mean1)*(state-mean2)) &
+                    -sum((fens-mean1)*(fstate-mean2))
+              cov=cov/(EFsize-ens_size-1)
+          endif
+
+          fstate=fstate+(cov*wt)*IIens
+          do k=1,ens_size
+              kk=ens_size*(i-1)+k
+              state(rll(kk))=fstate(k)
+          enddo
+
+       enddo
+!EOC
+    end subroutine update_sEnKF
+!==============================================================================
+!BOP
+    !ROUTAINE: inflation_RTPP
+!   !INTERFACE: 
+    subroutine inflation_RTPP(anal,prior,alpha,ens_size)
+!   !DESCRIPTION:
+       ! the inflation scheme of relaxiation to prior (Fuqing Zhang's method) 
+       !doi:10.1175/1520-0493(2004)132<1238:IOIEAO>2.0.CO;2
+       ! alfa    : < 1.0, the partitial using prior spread
+       implicit none
+       integer, intent(in) :: ens_size
+       real(r8) , intent(in) :: prior(ens_size), alpha
+       real(r8), intent(inout) :: anal(ens_size) 
+!EOP
+!BOC
+       real(r8) :: umean,xmean,xprm(ens_size),uprm(ens_size) 
+
+       xmean=sum(prior)/ens_size
+       umean=sum(anal)/ens_size
+       xprm=prior-xmean
+       uprm=anal-umean
+       anal = uprm*(1-alpha)+xprm*alpha+umean
+!EOC
+    end subroutine inflation_RTPP
+
+!==============================================================================
+!BOP
+    !ROUTAINE: inflation_RTPS
+!   !INTERFACE: 
+    subroutine inflation_RTPS(anal,prior,alpha,ens_size)
+!   !DESCRIPTION:
+      !Whitaker and Hamill 2012
+      ! relaxiation to prior spread
+      !x_u'= x_a'*(1+alpha*(sigma_p/sigma_a-1))
+      implicit none
+      integer, intent(in) :: ens_size
+      real(r8) , intent(in) :: prior(ens_size),alpha
+      real(r8), intent(inout) :: anal(ens_size)
+!EOP
+!BOC
+      real(r8) :: prior_mean(2),anal_mean(2),anal_anom(ens_size)
+      ! *_mean(1) is mean, *_mean(2) is std
+
+      call get_ens_mean(anal,anal_mean,ens_size)
+      call get_ens_mean(prior,prior_mean,ens_size)
+      if(prior_mean(2) <= anal_mean(2) )  return  ! the observation did not affect the state
+      anal_anom=anal-anal_mean(1)
+      anal=anal_anom*(1+alpha*(prior_mean(2)/anal_mean(2)-1)) + anal_mean(1)
+      return
+!EOC
+    end subroutine inflation_RTPS
+
+!==============================================================================
+!BOP
+    !ROUTAINE: inflation_corvariance
+!   !INTERFACE: 
+    subroutine inflation_corvariance(x,rt,k,ens_size)
+!   !DESCRIPTION:
+       ! the multiplive  corvariace  inflation scheme of Anderson and Anderson (1999)
+
+       integer, intent(in) ::  k,ens_size 
+       real(r8), intent (in) :: rt 
+       real(r8), intent(inout) :: x(k,ens_size)
+!EOP
+!BOC
+       real(r8) :: xmean,xprm(ens_size)
+       integer :: i
+
+       do i=1,k
+          xmean=sum(x(k,:))/ens_size
+          xprm=x(k,:)-xmean
+          x(k,:)=xprm*rt+xmean
+       enddo
+!EOC
+    end subroutine inflation_corvariance
+!==============================================================================
+!BOP
+    !ROUTAINE: cal_lcwt2d
+!   !INTERFACE: 
+    subroutine cal_lcwt2d(wt,lengthx,lengthy,R,xdim,ydim)
+!   !DESCRIPTION:
+       ! calculate corvariance localization weight in 2D based on Gaspari and Cohn (1999)
+       ! doi:10.1002/qj.49712555417
+
+       ! R: localization radus.
+       ! wt: covariance weight coefficeint
+       ! assume the observation location(0,0), the horizontal wt pattern is symmetry 
+       implicit none
+       integer, intent(in) :: xdim,ydim
+       real(r8), intent(in) :: lengthx,lengthy,R
+       real(r8), intent(inout):: wt(0:xdim,0:ydim)
+!EOP
+
+!BOC
+       real(r8) :: dist
+       integer :: i,k,m,n
+       wt=0.0
+       if (R < tiny(R)) then
+         wt(0,0)=1.0
+         return
+       endif
+
+       do k=0,ydim
+         do i=0,xdim
+            dist=sqrt((i*lengthx)**2+(k*lengthy)**2)/R
+            if(dist>2.0) CYCLE
+
+            if(dist<=1.0)then
+               wt(i,k)=1+(((0.5-0.25*dist)*dist+0.625)*dist-1.6667)*dist*dist
+            else
+               wt(i,k)=((((0.0833*dist-0.5)*dist+0.625)*dist+1.6667)*dist-5.0)*dist &
+                          + 4-0.6667/dist
+            endif
+         enddo
+       enddo
+!EOC
+    end subroutine cal_lcwt2d
+
+!==============================================================================
+!BOP
+    !ROUTAINE: cal_lcwt1d
+!   !INTERFACE: 
+    subroutine cal_lcwt1d(wt,length,R,xdim)
+!   !DESCRIPTION:
+       ! calculate corvariance localization weight in 1D based on Gaspari and Cohn (1999)
+       ! doi:10.1002/qj.49712555417
+
+       ! R: localization radus.
+       ! wt: covariance weight coefficeint
+       ! assume the observation location at 0, the  wt pattern is symmetry 
+
+       implicit none
+       integer, intent(in) :: xdim
+       real(r8), intent(in) :: length,R
+       real(r8), intent(inout):: wt(0:xdim)
+!EOP
+
+!BOC
+       real(r8) :: dist
+       integer :: i,k,m,n
+       wt=0.0
+
+       do i=0,xdim
+          dist=(i*length)/R
+          if(dist>=2.0) CYCLE
+          if(dist<=1.0)then
+               wt(i)=1+(((0.5-0.25*dist)*dist+0.625)*dist-1.6667)*dist*dist
+          else
+               wt(i)=((((0.0833*dist-0.5)*dist+0.625)*dist+1.6667)*dist-5.0)*dist &
+                 + 4-0.6667/dist
+          endif
+       enddo
+!EOC
+    end subroutine cal_lcwt1d
+
+!==============================================================================
+!BOP
+    !ROUTAINE: cal_covfactor
+!   !INTERFACE: 
+subroutine cal_lcwt_latlon(lon1,lat1,lon2,lat2,RR,wgt, ifdegree)
+!   !DESCRIPTION:
+       ! calculate corvariance localization weight on lat lon grid  based on Gaspari and Cohn (1999)
+       ! doi:10.1002/qj.49712555417
+
+       ! use the distance from (lon1,lat1) to (lon2,lat2),
+       !  haversine formula
+       ! lon1,lat1:  first grid in dgree/radius
+       ! lon2,lat2:  second grid in degree/radius
+       ! RR      :localization radus.
+       ! wgt: covariance weight coefficeint
+       implicit none
+       real(r8),intent(in) :: lon1,lat1,lon2,lat2
+       real(r8),intent(in) :: RR
+       real(r8),intent(out) :: wgt
+       logical, optional, intent(in) :: ifdegree  
+!EOP
+!BOC
+       real(r8) :: lonb,latb,lone,late
+       real(r8) :: RE,PI,Y,dist
+
+       RE = 6430.0
+       PI = 3.1415926
+       if ( present(ifdegree) .and. ifdegree) then
+           latb = lat1/180*PI;
+           late = lat2/180*PI;
+           lonb = lon1/180*PI;
+           lone = lon2/180*PI;
+       else
+           latb = lat1
+           late = lat2
+           lonb = lon1
+           lone = lon2
+       endif
+
+       Y = 2*asin(sqrt(sin((late-latb)/2)**2+cos(latb)*cos(late)*sin((lonb-lone)/2)**2));
+       ! print *,'Y=',Y
+       Y = Y*RE
+       dist = Y/RR
+       if (Y<=RR) then
+            wgt = 1.0-1.0/4.0*dist**5+1.0/2.0*dist**4+5.0/8.0*dist**3-5.0/3.0*dist**2
+       else
+            if(Y>=2*RR) then
+                wgt = 0.0
+            else
+                wgt = 1.0/12.0*(dist**5)-1.0/2.0*(dist**4)+5.0/8.0*(dist**3)+5.0/3.0*(dist**2)-5.0*dist+4.0-2.0/3.0/dist
+           endif
+       endif
+!EOF
+    end subroutine cal_lcwt_latlon
+
+!==============================================================================
+!BOP
+    !ROUTAINE: get_ens_mean
+!   !INTERFACE: 
+    subroutine get_ens_mean(X,Y,ens_size)
+!   !DESCRIPTION:
+       ! calculate ensemble mean and standard derivation
+        
+       integer, intent(in) :: ens_size 
+       real(r8) , intent (in) :: X(ens_size)
+       real(r8), intent (inout) :: Y(2)
+!EOP
+!BOC
+       real(r8) :: xmean, xprm(ens_size)
+       xmean=sum(X)/ens_size
+       Y(1)=xmean
+       xprm=(X-xmean)**2
+       Y(2)=sqrt(sum(xprm)/(ens_size-1))
+!EOC
+    end subroutine get_ens_mean
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: get_ens_mean3
+!   !INTERFACE: 
+    subroutine get_ens_mean3(X,Y,ens_size)
+!   !DESCRIPTION:
+       ! calculate ensemble mean and standard derivation,kurtosis
+       integer, intent(in) :: ens_size
+       real(r8) , intent (in) :: X(ens_size)
+       real(r8), intent (out) :: Y(3)
+!EOP
+!BOC
+       real(r8) :: xmean, xprm(ens_size),yy(3)
+       xmean=sum(X)/ens_size
+       Y(1)=xmean
+       xprm=(x-xmean)**2
+       Y(2)=sqrt(sum(xprm)/(ens_size-1))
+       Y(3)=sum(xprm**2)/(y(2)**4)/(ens_size-1)
+!EOC
+    end subroutine get_ens_mean3
+
+
+!==============================================================================
+!BOP
+    !ROUTAINE: get_ens_corr
+!   !INTERFACE: 
+    subroutine get_ens_corr(X,X1,Y,ens_size)
+!   !DESCRIPTION:
+       ! calculate ensemble correlation
+       integer, intent(in) :: ens_size
+       real(r8) , intent (in) :: X(ens_size),X1(ens_size)
+       real(r8), intent (inout) :: Y
+!EOP
+!EOC
+       !local
+       real(r8) :: xmean, xprm(ens_size),x1mean,x1prm(ens_size)
+
+       xmean=sum(X)/ens_size
+       x1mean=sum(X1)/ens_size
+       xprm=(x-xmean)
+       x1prm=(X1-x1mean)
+       Y=sum(xprm*x1prm)/sqrt(sum(xprm*xprm)*sum(x1prm*x1prm))
+!EOC
+    end subroutine get_ens_corr
+
+end module sEnKF_mod


### PR DESCRIPTION
This is an online Ensemble coupled data assimilation (ECDA) capacity that integrates ECDA into E3SM package to achieve high computational efficiency for data assimilation.  The development was sponsored by the project "COLLABORATIVE PROJECT: DEVELOPING COUPLED DATA ASSIMILATION STRATEGY" led by Zhengyu Liu and  Luke Van Roekel.

The first part of development applies ECDA  in the mpas-ocean.

The test below shows the difference between e3sm output  with ECDA and without ECDA:

<img width="468" alt="image" src="https://user-images.githubusercontent.com/13125787/217893214-c90b7fd0-6ff5-4c70-ae0c-35843eced024.png">
The domain averaged SST from synthetic observations and assimilation analysis with E3SM for Nino 3.4 (upper left, [190-240, 5S~5E]), South Ocean( upper right, [0-360, 30S-70S]), North Atlantic( lower left, [300-360,30N-60N]), and Indian Ocean (lower right, [50-110, 20S-20N]). The black lines indicate the observations; the red lines indicate the assimilation ensemble mean; the solid green lines indicate the ensemble mean of free simulation, and the blue dashed lines indicate the ensemble spread(s) of the assimilation run. 
 


