### PR TITLE
Add ocean wetting-and-drying ramp feature

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2936,7 +2936,7 @@
     <domain name="oQU240wLI">
       <nx>7268</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240wLI.160929.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240wLI_mask.160929.nc</file>
       <desc>oQU240wLI is an MPAS ocean mesh with quasi-uniform 240 km grid cells, nominally 2 degree resolution. Additionally, it has ocean under landice cavities.:</desc>
     </domain>
 

--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -28,6 +28,19 @@
         </nthrds>
       </pes>
     </mach>
+    <mach name="anvil">
+      <pes compset="any" pesize="any">
+        <comment>tests+anvil: default, 4 nodes x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne4np4.*">
     <mach name="chrysalis">
@@ -57,7 +70,26 @@
         </nthrds>
       </pes>
     </mach>
+    <mach name="anvil">
+      <pes compset="any" pesize="any">
+        <comment>test+anvil: any compset on ne4 grid -- 4 nodes pure-MPI </comment>
+        <ntasks>
+          <ntasks_atm>108</ntasks_atm>
+          <ntasks_ice>108</ntasks_ice>
+          <ntasks_cpl>108</ntasks_cpl>
+          <ntasks_lnd>36</ntasks_lnd>
+          <ntasks_rof>36</ntasks_rof>
+          <ntasks_ocn>36</ntasks_ocn>
+        </ntasks>
+        <rootpe>
+          <rootpe_lnd>108</rootpe_lnd>
+          <rootpe_rof>108</rootpe_rof>
+          <rootpe_ocn>108</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
   </grid>
+  <!-- allactive -->
   <grid name="a%ne30np4.pg.+_oi%EC30to60E2r2">
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="any">
@@ -73,6 +105,62 @@
         <rootpe>
           <rootpe_ocn>192</rootpe_ocn>
         </rootpe>
+      </pes>
+    </mach>
+    <mach name="anvil">
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
+        <comment>tests+anvil: pelayout for tri-grid BGC tests with EAM+DOCN</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-8</ntasks_cpl>
+        </ntasks>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+_SESP$" pesize="any">
+        <comment> --compset WCYCL* --res ne30pg2_EC30to60E2r2 on 16 nodes pure-MPI, ~2.7 sypd </comment>
+        <ntasks>
+          <ntasks_atm>396</ntasks_atm>
+          <ntasks_lnd>396</ntasks_lnd>
+          <ntasks_rof>396</ntasks_rof>
+          <ntasks_ice>396</ntasks_ice>
+          <ntasks_ocn>180</ntasks_ocn>
+          <ntasks_cpl>396</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ocn>396</rootpe_ocn>
+        </rootpe>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
+        <comment>anvil: --compset BGC* --res ne30pg2_r05_EC30to60E2r2 on 30 nodes pure-MPI, ~3 sypd </comment>
+        <ntasks>
+          <ntasks_atm>675</ntasks_atm>
+          <ntasks_lnd>684</ntasks_lnd>
+          <ntasks_rof>684</ntasks_rof>
+          <ntasks_ice>684</ntasks_ice>
+          <ntasks_ocn>396</ntasks_ocn>
+          <ntasks_cpl>684</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ocn>684</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4">
+    <mach name="anvil">
+      <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART" pesize="any">
+        <comment>"anvil, GPMPAS-JRA compset, 6 nodes"</comment>
+        <ntasks>
+          <ntasks_atm>-6</ntasks_atm>
+          <ntasks_lnd>-6</ntasks_lnd>
+          <ntasks_rof>-6</ntasks_rof>
+          <ntasks_ice>-6</ntasks_ice>
+          <ntasks_ocn>-6</ntasks_ocn>
+          <ntasks_cpl>-6</ntasks_cpl>
+        </ntasks>
       </pes>
     </mach>
   </grid>
@@ -91,6 +179,69 @@
         <rootpe>
           <rootpe_ocn>192</rootpe_ocn>
         </rootpe>
+      </pes>
+    </mach>
+    <mach name="anvil">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
+        <comment>tests+anvil: --compset WCYCL1850 --res northamericax4v1pg2_WC14to60E2r3 on 20 nodes pure-MPI, ~0.8 sypd </comment>
+        <ntasks>
+          <ntasks_atm>468</ntasks_atm>
+          <ntasks_lnd>468</ntasks_lnd>
+          <ntasks_rof>468</ntasks_rof>
+          <ntasks_ice>468</ntasks_ice>
+          <ntasks_ocn>252</ntasks_ocn>
+          <ntasks_cpl>468</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ocn>468</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <!-- EAM -->
+  <grid name="a%ne0np4.*">
+    <mach name="anvil">
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+MOSART.+" pesize="any">
+        <comment>tests+anvil: 10x36x1--res conusx4v1_r05_oECv3 --compset F2010 </comment>
+        <ntasks>
+          <ntasks_atm>-10</ntasks_atm>
+          <ntasks_lnd>-10</ntasks_lnd>
+          <ntasks_rof>-10</ntasks_rof>
+          <ntasks_ice>-10</ntasks_ice>
+          <ntasks_ocn>-10</ntasks_ocn>
+          <ntasks_cpl>-10</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30v3">
+    <mach name="anvil">
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+" pesize="any">
+        <comment>tests+anvil 8x36x1 for F-cases on anvil, to fix testing issues that default to 144 pes on 4 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-8</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <!-- ELM -->
+  <grid name="l%360x720cru|a%r05_l%r05_oi%null_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
+    <mach name="anvil">
+      <pes compset="any" pesize="any">
+        <comment>tests+anvil: elm: anvil PEs for grid l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-8</ntasks_cpl>
+        </ntasks>
       </pes>
     </mach>
   </grid>

--- a/components/eam/src/physics/crm/samxx/samxx_const.h
+++ b/components/eam/src/physics/crm/samxx/samxx_const.h
@@ -209,8 +209,6 @@ int  constexpr index_cloud_ice = 0;
 real constexpr rhor = 1000.; // Density of water, kg/m3
 real constexpr rhos = 100.;  // Density of snow, kg/m3
 real constexpr rhog = 400.;  // Density of graupel, kg/m3
-real constexpr tbgmin = 253.16;    // Minimum temperature for cloud water., K
-real constexpr tbgmax = 273.16;    // Maximum temperature for cloud ice, K
 real constexpr tprmin = 268.16;    // Minimum temperature for rain, K
 real constexpr tprmax = 283.16;    // Maximum temperature for snow+graupel, K
 real constexpr tgrmin = 223.16;    // Minimum temperature for snow, K
@@ -231,10 +229,37 @@ real constexpr nzeros = 3.e6;   // Intersept coeff. for snow
 real constexpr nzerog = 4.e6;   // Intersept coeff. for graupel
 real constexpr qp_threshold = 1.e-8; // minimal rain/snow water content
 
-real constexpr qcw0 = 1.e-3;
-real constexpr qci0 = 1.e-4;
 real constexpr alphaelq = 1.e-3;
 real constexpr betaelq = 1.e-3;
+
+//------------------------------------------------------------------------------
+// MMF climate tuning parameters
+//------------------------------------------------------------------------------
+#ifdef MMF_TMN
+real constexpr tbgmin = MMF_TMN;
+#else
+real constexpr tbgmin = 253.16; // Min temperature for cloud liq, K
+#endif
+
+#ifdef MMF_TMX
+real constexpr tbgmax = MMF_TMX;
+#else
+real constexpr tbgmax = 273.16; // Max temperature for cloud ice, K
+#endif
+
+#ifdef MMF_QCW
+real constexpr qcw0 = MMF_QCW;
+#else
+real constexpr qcw0 = 1.e-3;    // liq autoconversion threshold
+#endif
+
+#ifdef MMF_QCI
+real constexpr qci0 = MMF_QCI;
+#else
+real constexpr qci0 = 1.e-4;    // ice autoconversion threshold
+#endif
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 real constexpr crm_accel_coef = 1.0/( (real) nx * (real) ny );
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1616,8 +1616,8 @@ contains
                 if (j > nlevbed) then
                    this%h2osoi_vol(c,j) = 0.0_r8
                 else
-		               if (use_fates_planthydro .or. use_hydrstress) then
-                      this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES HYDRO
+		               if (use_fates .or. use_hydrstress) then
+                      this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -782,7 +782,7 @@ if ($OCN_ISMF eq 'coupled') {
 } elsif ($OCN_ISMF eq 'internal') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"standalone");
 } else {
-	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"pressure_only");
+	add_default($nl, 'config_land_ice_flux_mode');
 }
 add_default($nl, 'config_land_ice_flux_formulation');
 add_default($nl, 'config_land_ice_flux_useHollandJenkinsAdvDiff');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -333,12 +333,12 @@
 
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oQU240wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oEC60to30v3wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="ECwISC30to60E1r2">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oRRS30to10v3wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'standalone'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oQU240wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oEC60to30v3wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="ECwISC30to60E1r2">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oRRS30to10v3wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_formulation>'Jenkins'</config_land_ice_flux_formulation>
 <config_land_ice_flux_useHollandJenkinsAdvDiff>.false.</config_land_ice_flux_useHollandJenkinsAdvDiff>
 <config_land_ice_flux_attenuation_coefficient>10.0</config_land_ice_flux_attenuation_coefficient>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -90,10 +90,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx_040803.oEC60to30v3wLI.nc'
         analysis_mask_file = 'masks_SingleRegionAtlanticWTransportTransects_EC60to30v3wLI_171116.nc'
-        ic_date = '171031'
+        ic_date = '230220'
         ic_prefix = 'oEC60to30v3wLI60lev'
         if ocn_ic_mode == 'spunup':
-            ic_date = '171116'
+            ic_date = '230220'
             ic_prefix = 'oEC60to30v3wLI60lev.restart_theta_year26'
 
     elif ocn_grid == 'ECwISC30to60E1r2':
@@ -101,7 +101,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.ECwISC30to60E1r02.200408.nc'
         analysis_mask_file = 'ECwISC30to60E1r02_transportTransects.nc'
-        ic_date = '200408'
+        ic_date = '230220'
         ic_prefix = 'ocean.ECwISC30to60E1r2'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -128,7 +128,7 @@ def buildnml(case, caseroot, compname):
     elif ocn_grid == 'oQU240wLI':
         decomp_date = '160929'
         decomp_prefix = 'mpas-o.graph.info.'
-        ic_date = '160929'
+        ic_date = '230220'
         ic_prefix = 'ocean.QU.240wLI'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -159,7 +159,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx.2004_08_03.180503.nc'
         analysis_mask_file = 'masks_SingleRegionAtlanticWTransportTransects_RRS30to10v3wLI.nc'
-        ic_date = '171109'
+        ic_date = '230220'
         ic_prefix = 'oRRS30to10v3wLI'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -261,10 +261,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.SOwISC12to60E2r4_nomask.210120.nc'
         analysis_mask_file = 'SOwISC12to60E2r4_mocBasinsAndTransects20210623.nc'
-        ic_date = '210107'
+        ic_date = '230220'
         ic_prefix = 'ocean.SOwISC12to60E2r4'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210203'
+            ic_date = '230220'
             ic_prefix = 'mpaso.SOwISC12to60E2r4.rstFromG-anvil'
 
     elif ocn_grid == 'ECwISC30to60E2r1':
@@ -272,10 +272,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.ECwISC30to60E2r1_nomask.201221.nc'
         analysis_mask_file = 'ECwISC30to60E2r1_mocBasinsAndTransects20210623.nc'
-        ic_date = '210413'
+        ic_date = '230220'
         ic_prefix = 'ocean.ECwISC30to60E2r1'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210414'
+            ic_date = '230220'
             ic_prefix = 'mpaso.ECwISC30to60E2r1.rstFromG-anvil'
 
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -790,10 +790,9 @@ contains
     call t_stopf ('mpaso_mct_init')
 
     call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
-    if ( trim(config_land_ice_flux_mode) .eq. 'pressure_only' ) then
-       call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
-                                            ocn_c2_glcshelf=.false.)
-    else if ( trim(config_land_ice_flux_mode) .eq. 'standalone' ) then
+    if ( trim(config_land_ice_flux_mode) == 'off' .or. &
+         trim(config_land_ice_flux_mode) == 'pressure_only' .or. &
+         trim(config_land_ice_flux_mode) == 'standalone' ) then
        call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
                                             ocn_c2_glcshelf=.false.)
     else if ( trim(config_land_ice_flux_mode) .eq. 'coupled' ) then
@@ -2784,7 +2783,8 @@ contains
 !JW       o2x_o % rAttr(index_o2x_So_htv, n) = landIceHeatTransferVelocity(i)
 !JW       o2x_o % rAttr(index_o2x_So_stv, n) = landIceSaltTransferVelocity(i)
  
-       if ( trim(config_land_ice_flux_mode) .ne. 'pressure_only' ) then
+       if ( trim(config_land_ice_flux_mode) .eq. 'standalone' .or. &
+            trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
           o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerTracers(indexBLS,i)
           o2x_o % rAttr(index_o2x_So_htv, n) = landIceTracerTransferVelocities(indexHeatTrans,i)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1140,9 +1140,13 @@
 					description="If true, ramp velocities and tendencies to zero rather than applying a simple on/off switch."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_zero_drying_velocity_ramp_hmin" type="real" default_value="1e-3"
+					description="Minimum layer thickness at which velocities and tendencies are ramped toward zero. Recommended value equal to config_drying_min_cell_height."
+					possible_values="Any positive real"
+		/>
 		<nml_option name="config_zero_drying_velocity_ramp_hmax" type="real" default_value="2e-3"
-					description="Maximum column thickness at which velocities and tendencies are ramped toward zero."
-					possible_values="Any positive real greater than config_drying_min_cell_height"
+					description="Maximum layer thickness at which velocities and tendencies are ramped toward zero. Recommended values between 2x and 10x config_drying_min_cell_height."
+					possible_values="Any positive real"
 		/>
 		<nml_option name="config_verify_not_dry" type="logical" default_value=".false." units="unitless"
 					description="If true, verify that cells are at least config_min_cell_height thick."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2751,8 +2751,8 @@
 			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="wettingVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
-			 description="Velocity to prevent drying of cell."
+		<var name="wettingVelocityFactor" type="real" dimensions="nVertLevels nEdges Time"
+			 description="Scaling factor for normalVelocity and its tendency to prevent drying of cell between 0 (no scaling) and 1 (normalVelocity and tendency set to 0)."
 			 packages="forwardMode"
 		/>
 		<var name="vertAleTransportTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^-1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1129,14 +1129,22 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_drying_min_cell_height" type="real" default_value="1.0e-3" units="m"
-					description="Minimum allowable cell height under drying.  Cell to be kept wet to at least this thickness."
+					description="Minimum allowable cell height under drying.  Cell to be kept wet to at least this thickness. When ramp is applied this is the min edge height"
 					possible_values="any positive real, typically 1.0e-3"
 		/>
 		<nml_option name="config_zero_drying_velocity" type="logical" default_value=".false."
 					description="If true, just zero out velocity that is contributing to drying for cell that is drying.  This option can be used to estimate acceptable minimum thicknesses for a run."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_verify_not_dry" type="logical" default_value=".false."
+		<nml_option name="config_zero_drying_velocity_ramp" type="logical" default_value=".false."
+					description="If true, ramp velocities and tendencies to zero rather than applying a simple on/off switch."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_zero_drying_velocity_ramp_hmax" type="real" default_value="2e-3"
+					description="Maximum column thickness at which velocities and tendencies are ramped toward zero."
+					possible_values="Any positive real greater than config_drying_min_cell_height"
+		/>
+		<nml_option name="config_verify_not_dry" type="logical" default_value=".false." units="unitless"
 					description="If true, verify that cells are at least config_min_cell_height thick."
 					possible_values=".true. or .false."
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1640,6 +1640,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -1749,6 +1751,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 		<stream name="block_debug_output"
 				type="output"
@@ -1848,6 +1852,8 @@
 			<var name="landIceDraft"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var name="seaIcePressure"/>
 			<var name="atmosphericPressure"/>
 			<var_array name="tracersSurfaceValue"/>
@@ -1990,6 +1996,7 @@
 				immutable="true">
 			<var name="landIcePressureForcing"/>
 			<var name="landIceFractionForcing"/>
+			<var name="landIceFloatingFractionForcing"/>
 			<var name="landIceDraftForcing"/>
 		</stream>
 
@@ -2106,6 +2113,8 @@
 			<var name="nAccumulatedCoupled"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var_array name="landIceInterfaceTracers"/>
 			<var_array name="landIceBoundaryLayerTracers"/>
 			<var name="landIceFrictionVelocity"/>
@@ -3612,6 +3621,14 @@
 			description="Mask indicating where land-ice is present (1) or absent (0)"
 			packages="landIcePressurePKG"
 		/>
+		<var name="landIceFloatingFraction" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by an ice shelf"
+			packages="landIcePressurePKG"
+		/>
+		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time" default_value="-1"
+			description="Mask indicating where an ice shelf is present (1) or absent (0)"
+			packages="landIcePressurePKG"
+		/>
 		<var name="landIcePressure" type="real" dimensions="nCells Time" units="Pa"
 			description="Pressure defined at the sea surface due to land ice."
 			packages="landIcePressurePKG"
@@ -3806,6 +3823,10 @@
 			packages="timeVaryingAtmosphericForcingPKG"
 		/>
 		<var name="landIceFractionForcing" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by land ice"
+			packages="timeVaryingLandIceForcingPKG"
+		/>
+		<var name="landIceFloatingFractionForcing" type="real" dimensions="nCells Time" units="1"
 			description="The fraction of each cell covered by land ice"
 			packages="timeVaryingLandIceForcingPKG"
 		/>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -234,7 +234,7 @@ contains
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
       integer, dimension(:), pointer :: minLevelCell, minLevelEdgeBot, minLevelVertexTop, maxLevelCell, &
-          maxLevelEdgeTop, maxLevelVertexBot, landiceMask
+          maxLevelEdgeTop, maxLevelVertexBot, landIceFloatingMask
 
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
@@ -364,7 +364,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
          call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
          call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
          call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
          call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersPistonVelocity', &
@@ -381,8 +381,8 @@ contains
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
 
          allocate(landIceFloatingArea(1:nCellsSolve))
-         if ( associated(landIceMask) ) then
-            landIceFloatingArea = landIceMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
+         if ( associated(landIceFloatingMask) ) then
+            landIceFloatingArea = landIceFloatingMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
          else
             landIceFloatingArea = 0.
          end if

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -176,7 +176,6 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
@@ -214,7 +213,6 @@ contains
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -286,11 +284,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceMask) ) then
+               if (associated(landIceDraft) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -352,11 +350,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel
@@ -417,11 +415,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1244,7 +1244,7 @@ module ocn_time_integration_rk4
          do k = 1, nVertLevels
             normalVelocityProvis(k, iEdge) = edgeMask(k, iEdge)*(normalVelocityCur(k, iEdge) + rkSubstepWeight &
                                            * normalVelocityTend(k, iEdge))
-            normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
+            normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocityFactor(k, iEdge))
          end do
       end do
       !$omp end do
@@ -1487,12 +1487,12 @@ module ocn_time_integration_rk4
       
       ! the loop below is on all vertlevels but we used edgemask to set
       ! velocities to zero below topo (esp. edges between topo and ocean)
-      !$omp do schedule(runtime)
+      !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, nVertLevels
             normalVelocityNew(k, iEdge) = edgeMask(k,iEdge) &
                                       *(normalVelocityNew(k, iEdge) + rkWeight * normalVelocityTend(k, iEdge))
-            normalVelocityNew(k, iEdge) = normalVelocityNew(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
+            normalVelocityNew(k, iEdge) = normalVelocityNew(k, iEdge) * (1.0_RKIND - wettingVelocityFactor(k, iEdge))
          end do
       end do
       !$omp end do

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1073,13 +1073,16 @@ contains
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
        real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, landIceDraftObserved, &
-                                                   landIceFracObserved, landIceGroundedFracObserved
+                                                   landIceFracObserved, &
+                                                   landIceFloatingFracObserved, &
+                                                   landIceGroundedFracObserved
 
-       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, ssh, &
+       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+                                                   landIceFloatingFraction, ssh, &
                                                    bottomDepth
 
        integer, pointer :: nCells
-       integer, dimension(:), pointer :: maxLevelCell, landIceMask
+       integer, dimension(:), pointer :: maxLevelCell, landIceMask, landIceFloatingMask
 
        integer :: iCell
 
@@ -1123,6 +1126,7 @@ contains
                                                           inXPeriod = 2.0_RKIND * pii)
 
              elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
+
                 call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
                                                            landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
                                                            lonCell, latCell, landIceThkObserved, nCells, &
@@ -1186,20 +1190,34 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFloatingFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
           call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
+          if (landIceFloatingMask(1) == -1) then
+             call mpas_log_write('landIceFloatingMask contains the default value which likely ' // &
+               'indicates that this field is missing in the initial condition file (e.g. ' // &
+               'because it is meant for an older E3SM version).', MPAS_LOG_CRIT)
+          endif
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
           modifyLandIcePressureMask(:) = 0
           landIcePressure(:) = 0.0_RKIND
           do iCell = 1, nCells
 
-             if(landIceMask(iCell) == 1) then
+             if (landIceMask(iCell) == 1) then
                 landIceFraction(iCell) = landIceFracObserved(iCell)
+             end if
+
+             ! this implicitly assumes that when a cell is considered floating, the
+             ! full landIceFracObserved is floating
+             if (landIceFloatingMask(iCell) == 1) then
+                landIceFloatingFraction(iCell) = landIceFloatingFracObserved(iCell)
              end if
 
              ! nothing to do here if the cell is land
@@ -1207,7 +1225,7 @@ contains
 
              ! we compute the SSH first and find out the land-ice pressure
              ssh(iCell) = min(0.0_RKIND, landIceDraftObserved(iCell))
-             if(ssh(iCell) < 0.0_RKIND) then
+             if (ssh(iCell) < 0.0_RKIND) then
                 modifyLandIcePressureMask(iCell) = 1
              end if
           end do
@@ -2056,7 +2074,6 @@ contains
                  inXPeriod = 2.0_RKIND * pii)
 
          elseif (config_global_ocean_tracer_method .eq. "bilinear_interpolation") then
-
             call ocn_init_interpolation_bilinear_horiz(tracerLon % array, tracerLat % array, &
                  tracerIC % array, nLonTracer, nLatTracer, &
                  lonCell, latCell, interpTracer, nCells, &

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -217,7 +217,7 @@ mpas_ocn_framework_forcing.o:
 
 mpas_ocn_time_varying_forcing.o:  mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_gm.o
+mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_gm.o mpas_ocn_mesh.o
 
 mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -134,7 +134,7 @@ contains
         frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
 
       integer, dimension(:), pointer :: &
-        landIceMask
+        landIceFloatingMask
 
       call mpas_timer_start('diagnostic solve')
 
@@ -169,8 +169,12 @@ contains
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+         if (landIceFloatingMask(1) == -1) then
+            call mpas_log_write('landIceFloatingMask contains the default value which likely indicates that this field is missing in the initial condition file (e.g. because it is meant for an older E3SM version).', &
+                                MPAS_LOG_CRIT)
+         endif
       end if
 
       nEdges = nEdgesAll
@@ -445,11 +449,11 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       !
-      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceMask
+      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceFloatingMask
       ! outputs: 
       if (landIcePressureOn) then
          call ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, activeTracers, &
-                landIceFraction, landIceMask, timeLevel, indexTemperature, indexSalinity)
+                landIceFraction, landIceFloatingMask, timeLevel, indexTemperature, indexSalinity)
       end if
 
       if ( full_compute ) then
@@ -3229,7 +3233,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, &
-      activeTracers, landIceFraction, landIceMask, &
+      activeTracers, landIceFraction, landIceFloatingMask, &
       timeLevel, indexTval, indexSval)!{{{
 
       !-----------------------------------------------------------------
@@ -3250,7 +3254,7 @@ contains
          activeTracers
 
       integer, dimension(:), intent(in) :: &
-         landIceMask
+         landIceFloatingMask
 
       !-----------------------------------------------------------------
       !
@@ -3288,7 +3292,7 @@ contains
                blSaltScratch(nCellsAll))
       !$acc enter data create(blTempScratch, blSaltScratch)
 
-      ! Compute top drag
+      ! Compute top drag everywhere there is grounded or floating land ice
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(landIceFraction)
 
@@ -3449,15 +3453,15 @@ contains
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceMask)
+      !$acc enter data copyin(landIceFloatingMask)
 
-      !$acc parallel loop present(landIceMask, sfcFlxAttCoeff)
+      !$acc parallel loop present(landIceFloatingMask, sfcFlxAttCoeff)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if(landIceMask(iCell) == 1) then
+         if(landIceFloatingMask(iCell) == 1) then
             sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -137,7 +137,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: viscosity
    real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfEdge
    real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfCell
-   real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: wettingVelocityFactor
    type (field2DReal), pointer :: wettingVelocityField
 
    real (kind=RKIND), dimension(:,:), pointer :: vertDiffTopOfCell
@@ -255,9 +255,9 @@ contains
       end if
 
       if ( trim(config_ocean_run_mode) == 'forward' ) then
-         call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', &
-                   wettingVelocity)
-         call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', &
+         call mpas_pool_get_array(diagnosticsPool, 'wettingVelocityFactor', &
+                   wettingVelocityFactor)
+         call mpas_pool_get_field(diagnosticsPool, 'wettingVelocityFactor', &
                    wettingVelocityField)
       end if
 
@@ -779,8 +779,8 @@ contains
          !$acc                   )
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
-         !$acc enter data create( &
-         !$acc                   wettingVelocity              &
+         !$acc enter data copyin( &
+         !$acc                   wettingVelocityFactor            &
          !$acc                   )
       end if
       if (config_use_GM.or.config_use_Redi) then
@@ -1021,7 +1021,7 @@ contains
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          !$acc exit data delete(                              &
-         !$acc                   wettingVelocity              &
+         !$acc                   wettingVelocityFactor        &
          !$acc                   )
       end if
       if (config_use_GM.or.config_use_Redi) then
@@ -1218,7 +1218,7 @@ contains
                  normalizedRelativeVorticityCell)
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
-         nullify(wettingVelocity)
+         nullify(wettingVelocityFactor)
       end if
       if (config_use_GM.or.config_use_Redi) then
          nullify(RediKappa,         &

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -197,7 +197,6 @@ module ocn_eddy_parameterization_helpers
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
-     integer, dimension(:), pointer :: landIceMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
      real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
@@ -209,7 +208,6 @@ module ocn_eddy_parameterization_helpers
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -281,11 +279,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceMask) ) then
+        if (associated(landIceDraft) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -113,7 +113,7 @@ contains
          effectiveDensityNew   ! effective density at new time level
                                                   
       integer, dimension(:), pointer :: &
-         landIceMask           ! mask for land ice presence on cell
+         landIceFloatingMask   ! mask for land ice presence on cell
 
       ! Scratch Arrays
       ! effectiveDensityScratch: effective seawater density in land
@@ -130,8 +130,8 @@ contains
       if ( (trim(config_land_ice_flux_mode) /= 'coupled') ) return
 
       ! Retrieve forcing and state variables
-      call mpas_pool_get_array(forcingPool, 'landIceMask', &
-                                             landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', &
+                                             landIceFloatingMask)
       call mpas_pool_get_array(forcingPool, 'landIcePressure', &
                                              landIcePressure)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
@@ -139,7 +139,7 @@ contains
                                            effectiveDensityCur, 1)
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
                                            effectiveDensityNew, 2)
-      !$acc enter data copyin(landIceMask, landIcePressure, ssh, &
+      !$acc enter data copyin(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                   effectiveDensityCur, effectiveDensityNew)
 
       allocate(effectiveDensityScratch(nCellsAll))
@@ -151,13 +151,13 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(effectiveDensityScratch, effectiveDensityCur, &
-      !$acc            landIcePressure, landIceMask, ssh)
+      !$acc            landIcePressure, landIceFloatingMask, ssh)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if (landIceMask(iCell) == 1) then
+         if (landIceFloatingMask(iCell) == 1) then
             ! land ice is present to update the effective density
             effectiveDensityScratch(iCell) = -landIcePressure(iCell)/ &
                                               (ssh(iCell)*gravity)
@@ -198,7 +198,7 @@ contains
 #endif
 
       !$acc exit data delete(effectiveDensityScratch)
-      !$acc exit data delete(landIceMask, landIcePressure, ssh, &
+      !$acc exit data delete(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                  effectiveDensityCur, effectiveDensityNew)
       deallocate(effectiveDensityScratch)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -360,7 +360,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
       real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
       real (kind=RKIND), dimension(:), pointer :: frazilSurfacePressure
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceMask, landIceFloatingMask
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
@@ -391,7 +391,7 @@ contains
       integer :: indexSalinity !< index in tracers array for salinity
       integer :: kBottomFrazil  ! k index where testing for frazil begins
 
-      logical :: underLandIce ! indicates if we are under land ice
+      logical :: underFloatingLandIce, underLandIce ! indicates if we are under land ice
 
       real (kind=RKIND) :: potential  ! scalar holding freezing/melt potential
       real (kind=RKIND) :: freezingEnergy  ! energy available for freezing, positive definite
@@ -435,6 +435,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       ! get time step in units of seconds
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err)
@@ -451,7 +452,7 @@ contains
       ! loop over all columns
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
+      !$omp private(underFloatingLandIce, underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
       !$omp         sumNewThicknessWeightedSaltContent, oceanFreezingTemperature, potential, &
       !$omp         freezingEnergy, meltingEnergy, frazilSalinity, newFrazilIceThickness, &
       !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, &
@@ -463,13 +464,23 @@ contains
            underLandIce = (landIceMask(iCell) == 1)
         end if
 
-        if (underLandIce .and. .not. config_frazil_under_land_ice) then
-          ! skip this cell because we're not doing frazil under land ice
+        underFloatingLandIce = .false.
+        if ( associated(landIceFloatingMask) ) then
+           underFloatingLandIce = (landIceFloatingMask(iCell) == 1)
+        end if
+
+        if (underFloatingLandIce .and. .not. config_frazil_under_land_ice) then
+          ! skip this cell because we're not doing frazil under floating land ice
           cycle
         end if
 
         if (.not. underLandIce .and. .not. config_frazil_in_open_ocean) then
           ! skip this cell because we're not doing frazil in the open ocean
+          cycle
+        end if
+
+        if (underLandIce .and. .not. underFloatingLandIce) then
+          ! skip this cell because we're not doing frazil under grounded land ice
           cycle
         end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -429,7 +429,7 @@ contains
 
       real (kind=RKIND) :: freshwaterFlux, heatFlux
 
-      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFloatingFraction, &
                                                   landIceSurfaceTemperature, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce
@@ -438,7 +438,7 @@ contains
                                                   accumulatedLandIceHeatOld, &
                                                   accumulatedLandIceHeatNew
 
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceFloatingMask
 
       real (kind=RKIND), dimension(:,:), pointer :: &
                                                     landIceInterfaceTracers
@@ -468,8 +468,8 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
-      call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
       call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
@@ -506,7 +506,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
             ! linearized equaiton for the S and p dependent potential freezing temperature
             landIceInterfaceTracers(indexIT,iCell) = ocn_freezing_temperature( &
@@ -521,14 +521,14 @@ contains
             freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*freshwaterFlux
 
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
             heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
                               + rho_sw*ISOMIPgammaT &
                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*heatFlux
 
             heatFluxToLandIce(iCell) = 0.0_RKIND
 
@@ -541,7 +541,7 @@ contains
          if(useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -563,7 +563,7 @@ contains
 
             ! freezing solution
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -583,7 +583,7 @@ contains
             end if
 
             do iCell = 1, nCells
-               if ((landIceMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
+               if ((landIceFloatingMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
 
                landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
                landIceInterfaceTracers(indexIT,iCell) = freezeInterfaceTemperature(iCell)
@@ -593,7 +593,7 @@ contains
             end do
          else ! not using Holland and Jenkins advection/diffusion
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -613,13 +613,13 @@ contains
             end if
          end if
 
-         ! modulate the fluxes by the landIceFraction
+         ! modulate the fluxes by the landIceFloatingFraction
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*landIceFreshwaterFlux(iCell)
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*landIceHeatFlux(iCell)
-            heatFluxToLandIce(iCell) = landIceFraction(iCell)*heatFluxToLandIce(iCell)
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*landIceFreshwaterFlux(iCell)
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*landIceHeatFlux(iCell)
+            heatFluxToLandIce(iCell) = landIceFloatingFraction(iCell)*heatFluxToLandIce(iCell)
          end do
 
       endif ! jenkinsOn or hollandJenkinsOn

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -351,7 +351,7 @@ contains
       !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
       !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
       !$acc               layerThickEdgeFlux, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
-      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity)
+      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocityFactor)
       !$acc enter data &
       !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
       !$acc    ssh, normalVelocity, &
@@ -452,15 +452,14 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop collapse(2) &
-      !$acc    present(tendVel, wettingVelocity)
+      !$acc    present(tendVel, wettingVelocityFactor)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
 #endif
       do iEdge = 1, nEdgesAll
       do k=1,nVertLevels
-         tendVel(k,iEdge) = tendVel(k,iEdge)* &
-                            (1.0_RKIND - wettingVelocity(k,iEdge))
+         tendVel(k,iEdge) = tendVel(k,iEdge) * (1.0_RKIND - wettingVelocityFactor(k,iEdge))
       end do
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -443,6 +443,10 @@ contains
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
     call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIceFloatingFraction", "land_ice_forcing", "timeVaryingForcing", "landIceFloatingFractionForcing", "linear", &
+         config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
          "landIceDraft", "land_ice_forcing", "timeVaryingForcing", "landIceDraftForcing", "linear", &
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
@@ -495,6 +499,8 @@ contains
     real(kind=RKIND), dimension(:), pointer :: &
          landIceFractionForcing, &
          landIceFraction, &
+         landIceFloatingFractionForcing, &
+         landIceFloatingFraction, &
          landIcePressureForcing, &
          landIcePressure, &
          landIceDraftForcing, &
@@ -525,15 +531,18 @@ contains
        call MPAS_pool_get_dimension(mesh, "nCells", nCells)
    
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFractionForcing", landIceFractionForcing)
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFloatingFractionForcing", landIceFloatingFractionForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIcePressureForcing", landIcePressureForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceDraftForcing", landIceDraftForcing)
        call MPAS_pool_get_array(forcingPool, "landIceFraction", landIceFraction)
+       call MPAS_pool_get_array(forcingPool, "landIceFloatingFraction", landIceFloatingFraction)
        call MPAS_pool_get_array(forcingPool, "landIcePressure", landIcePressure)
        call MPAS_pool_get_array(forcingPool, "landIceDraft", landIceDraft)
    
        do iCell = 1, nCells
    
           landIceFraction(iCell) = landIceFractionForcing(iCell)
+          landIceFloatingFraction(iCell) = landIceFloatingFractionForcing(iCell)
           landIcePressure(iCell) = landIcePressureForcing(iCell)
           landIceDraft(iCell) = landIceDraftForcing(iCell)
    

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -189,7 +189,7 @@ contains
 
       if (config_use_idealAgeTracers_idealAge_forcing) then
          ! set mask = 0 for open ocean
-         ! set mask = 1 under ice shelves
+         ! set mask = 1 under land ice
          idealAgeMask = 0.0_RKIND
          if (associated(landIceMask)) then
             where (landIceMask /= 0) idealAgeMask(1,:) = 1.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -32,6 +32,7 @@ module ocn_wetting_drying
    use ocn_diagnostics
    use ocn_diagnostics_variables
    use ocn_gm
+   use ocn_mesh
 
    implicit none
    private
@@ -108,16 +109,13 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer :: statePool, meshPool, tendPool
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND), dimension(:), pointer :: sshSubcycleNew
-      real (kind=RKIND), dimension(:), pointer :: bottomDepth
       integer, pointer :: nCellsSolve
       integer :: iCell, k
       integer :: debugUnit
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessCur
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessNew
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessTend
-      real (kind=RKIND), dimension(:), pointer :: lonCell, latCell
       real (kind=RKIND) :: minThickness, layerThick
       character (len=StrKIND) :: debugFilename
 
@@ -134,13 +132,8 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, timeLevel=1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, timeLevel=2)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(tendPool, 'layerThickness', layerThicknessTend)
       call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-      call mpas_pool_get_array(meshPool, 'latCell', latCell)
 
       err = 0
 
@@ -151,8 +144,11 @@ contains
       do iCell = 1, nCellsSolve
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           ! use ssh as a proxy too for baroclinic mode
-          if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'split_implicit') then
-            layerThick = min(layerThicknessNew(k, iCell), (sshSubcycleNew(iCell)+bottomDepth(iCell))/maxLevelCell(iCell))
+          ! Note: wetting-drying currently not supported for either of these time integration methods
+          if (trim(config_time_integrator) == 'split_explicit' .or. &
+              trim(config_time_integrator) == 'split_implicit') then
+            layerThick = min(layerThicknessNew(k, iCell), &
+                             (sshSubcycleNew(iCell) + bottomDepth(iCell))/maxLevelCell(iCell))
           else
             layerThick = layerThicknessNew(k, iCell)
           end if
@@ -237,23 +233,17 @@ contains
 
 
       type (mpas_pool_type), pointer :: tendPool
-      type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: provisStatePool
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessProvis
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
 
-      integer, dimension(:), pointer :: minLevelEdgeTop
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:), pointer :: maxLevelEdgeBot
-      integer, pointer :: nEdges
       integer :: iEdge, k
 
       err = 0
 
      call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-     call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
      call mpas_pool_get_subpool(block % structs, 'state', statePool)
      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
@@ -262,47 +252,37 @@ contains
      call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
      call mpas_pool_get_array(provisStatePool, 'layerThickness', layerThicknessProvis, 1)
 
-     call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
-     call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
-     call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-     call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
 
      !$omp parallel
      !$omp do schedule(runtime)
-     do iEdge = 1, nEdges
-       wettingVelocity(:, iEdge) = 0.0_RKIND
+     do iEdge = 1, nEdgesAll
+       wettingVelocityFactor(:, iEdge) = 0.0_RKIND
      end do
      !$omp end do
      !$omp end parallel
 
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
-     call ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
-                                             normalTransportVelocity, rkSubstepWeight, wettingVelocity, err)
+     call ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
+                                             normalTransportVelocity, rkSubstepWeight, wettingVelocityFactor, err)
 
-     ! prevent drying from happening with selective wettingVelocity
-     !$omp parallel
-     !$omp do schedule(runtime) private(k)
-     do iEdge = 1, nEdges
-       do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
-         if (abs(normalTransportVelocity(k,iEdge) + wettingVelocity(k,iEdge)) < eps)  then
-           ! prevent spurious flux for close to zero values
-           normalTransportVelocity(k, iEdge) = 0.0_RKIND
-           normalVelocity(k, iEdge) = 0.0_RKIND
-         else if (abs(normalTransportVelocity(k,iEdge) + wettingVelocity(k,iEdge)) <= abs(normalTransportVelocity(k,iEdge))) then
-           normalTransportVelocity(k, iEdge) = normalTransportVelocity(k, iEdge) + wettingVelocity(k, iEdge)
-           normalVelocity(k, iEdge) = normalVelocity(k, iEdge) + wettingVelocity(k, iEdge)
-         end if
+     ! prevent drying from happening with selective wettingVelocityFactor
+     if (config_zero_drying_velocity) then
+       !$omp parallel
+       !$omp do schedule(runtime) private(k)
+       do iEdge = 1, nEdgesAll
+         do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
 
-         if (abs(wettingVelocity(k, iEdge)) > 0.0_RKIND .and. config_zero_drying_velocity) then
-           normalTransportVelocity(k, iEdge) = 0.0_RKIND
-           normalVelocity(k, iEdge) = 0.0_RKIND
-         end if
+           if (abs(wettingVelocityFactor(k, iEdge)) > 0.0_RKIND) then
+             normalTransportVelocity(k, iEdge) = 0.0_RKIND
+             normalVelocity(k, iEdge) = 0.0_RKIND
+           end if
 
+         end do
        end do
-     end do
-     !$omp end do
-     !$omp end parallel
+       !$omp end do
+       !$omp end parallel
+     end if
 
    end subroutine ocn_prevent_drying_rk4 !}}}
 
@@ -319,18 +299,15 @@ contains
 !>  to prevent cells from drying.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
+   subroutine ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
 
-       normalVelocity, dt, wettingVelocity, err)!{{{
+       normalVelocity, dt, wettingVelocityFactor, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: horizonal mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThicknessCur    !< Input: layer thickness at old time
@@ -354,7 +331,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         wettingVelocity          !< Input/Output: velocity wettingVelocityency
+         wettingVelocityFactor          !< Input/Output: velocity wettingVelocityFactor
 
       !-----------------------------------------------------------------
       !
@@ -371,73 +348,49 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iEdge, iCell, k, i
-      integer, pointer :: nVertLevels, nCells
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
-      integer, dimension(:), pointer :: minLevelEdgeTop, maxLevelEdgeBot
-      integer, dimension(:,:), pointer :: edgesOnCell
-      integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND) :: divOutFlux
-      real (kind=RKIND) :: invAreaCell
       real (kind=RKIND) :: layerThickness
-      real (kind=RKIND), dimension(:), pointer :: dvEdge
-      real (kind=RKIND), dimension(:), pointer :: areaCell
 
       err = 0
 
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      if (.not. config_zero_drying_velocity ) return
 
       ! need predicted transport velocity to limit drying flux
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, divOutFlux, layerThickness)
-      do iCell = 1, nCells
-        invAreaCell = 1.0_RKIND / areaCell(iCell)
+      !$omp do schedule(runtime) private(i, iEdge, k, divOutFlux, layerThickness)
+      do iCell = 1, nCellsAll
         ! can switch with maxLevelEdgeBot(iEdge)
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           divOutFlux = 0.0_RKIND
           layerThickness = min(layerThicknessProvis(k, iCell), layerThicknessCur(k, iCell))
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
+            if (k <= maxLevelEdgeTop(iEdge) .and. k >= minLevelEdgeBot(iEdge)) then
               ! only consider divergence flux leaving the cell
               if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) < 0.0_RKIND ) then
-                divOutFlux = divOutFlux + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) &
-                  * layerThickEdgeFlux(k, iEdge) * dvEdge(iEdge)  * invAreaCell
+                divOutFlux = divOutFlux &
+                             + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) * &
+                               layerThickEdgeFlux(k, iEdge) * dvEdge(iEdge) * &
+                               invAreaCell(iCell)
               end if
             end if
           end do
 
           ! if layer thickness is too small, limit divergence flux outwards with opposite velocity
-          if ((layerThickness + dt*divOutFlux ) <= (config_drying_min_cell_height + config_drying_safety_height))  then
-            ! limit divOutFlux out of cell to keep it wet
-            divOutFlux = abs(divOutFlux)
-            divOutFlux = (layerThickness - (config_drying_min_cell_height + eps)) / (dt*divOutFlux + eps)
+          if ((layerThickness + dt * divOutFlux ) <= &
+              (config_drying_min_cell_height + config_drying_safety_height)) then
 
             do i = 1, nEdgesOnCell(iCell)
               iEdge = edgesOnCell(i, iCell)
-              if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
+              if (k <= maxLevelEdgeBot(iEdge) .and. k >= minLevelEdgeTop(iEdge)) then
                 if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
-                  ! each outgoing velocity is penalized (but not the incoming, wetting velocities)
-                  ! square the fractional term to make values near zero go to zero much quicker (to prevent threshold from being hit)
-                  wettingVelocity(k, iEdge) =  - (min(max(0.0_RKIND, 1.0_RKIND - (divOutFlux*divOutFlux)), 1.0_RKIND)) * normalVelocity(k, iEdge)
                   ! just go with simple boolean approach for zero wetting velocity for debugging purposes
-                  if (config_zero_drying_velocity) then
-                    wettingVelocity(k, iEdge) = 1.0_RKIND
-                  end if
+                  wettingVelocityFactor(k, iEdge) = 1.0_RKIND
                 end if
               end if
             end do
+
           end if
 
         end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -235,6 +235,7 @@ contains
       type (mpas_pool_type), pointer :: tendPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: provisStatePool
+      real (kind=RKIND), dimension(:), pointer :: ssh
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessProvis
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
@@ -247,6 +248,7 @@ contains
      call mpas_pool_get_subpool(block % structs, 'state', statePool)
      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
+     call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
      ! use thickness at n because constraint is h_n + dt*T_h > h_min
      call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
@@ -261,10 +263,11 @@ contains
      !$omp end do
      !$omp end parallel
 
-     ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
+     ! ensure cells stay wet by selectively damping cells with a damping tendency to make 
+     ! sure tendency doesn't dry cells
 
      call ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
-                                             normalTransportVelocity, rkSubstepWeight, wettingVelocityFactor, err)
+                                             normalTransportVelocity, ssh, rkSubstepWeight, wettingVelocityFactor, err)
 
      ! prevent drying from happening with selective wettingVelocityFactor
      if (config_zero_drying_velocity) then
@@ -274,8 +277,10 @@ contains
          do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
 
            if (abs(wettingVelocityFactor(k, iEdge)) > 0.0_RKIND) then
-             normalTransportVelocity(k, iEdge) = 0.0_RKIND
-             normalVelocity(k, iEdge) = 0.0_RKIND
+             normalTransportVelocity(k, iEdge) = (1.0_RKIND - &
+               wettingVelocityFactor(k, iEdge)) * normalTransportVelocity(k, iEdge)
+             normalVelocity(k, iEdge) = (1.0_RKIND - &
+               wettingVelocityFactor(k, iEdge)) * normalVelocity(k, iEdge)
            end if
 
          end do
@@ -301,7 +306,7 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
 
-       normalVelocity, dt, wettingVelocityFactor, err)!{{{
+       normalVelocity, ssh, dt, wettingVelocityFactor, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -320,6 +325,8 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity     !< Input: transport
+
+      real (kind=RKIND), dimension(:), intent(in) :: ssh
 
       real (kind=RKIND), intent(in) :: &
          dt     !< Input: time step
@@ -347,20 +354,24 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, iCell, k, i
+      integer :: cell1, cell2, iEdge, iCell, k, i
 
-      real (kind=RKIND) :: divOutFlux
+      real (kind=RKIND) :: divFlux, divOutFlux
       real (kind=RKIND) :: layerThickness
+      real (kind=RKIND) :: hCrit, hEdgeTotal
+
+      character (len=100) :: log_string
 
       err = 0
 
-      if (.not. config_zero_drying_velocity ) return
+      hCrit = config_drying_min_cell_height
+
+      if (.not. config_zero_drying_velocity) return
 
       ! need predicted transport velocity to limit drying flux
       !$omp parallel
       !$omp do schedule(runtime) private(i, iEdge, k, divOutFlux, layerThickness)
       do iCell = 1, nCellsAll
-        ! can switch with maxLevelEdgeBot(iEdge)
         do k = minLevelCell(iCell), maxLevelCell(iCell)
           divOutFlux = 0.0_RKIND
           layerThickness = min(layerThicknessProvis(k, iCell), layerThicknessCur(k, iCell))
@@ -369,24 +380,40 @@ contains
             if (k <= maxLevelEdgeTop(iEdge) .and. k >= minLevelEdgeBot(iEdge)) then
               ! only consider divergence flux leaving the cell
               if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) < 0.0_RKIND ) then
-                divOutFlux = divOutFlux &
-                             + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) * &
-                               layerThickEdgeFlux(k, iEdge) * dvEdge(iEdge) * &
-                               invAreaCell(iCell)
+                divOutFlux = divOutFlux + &
+                             normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) * &
+                             layerThickEdgeFlux(k, iEdge) * dvEdge(iEdge) * &
+                             invAreaCell(iCell)
               end if
             end if
           end do
+          layerThickness = layerThickness + dt * divOutFlux
 
-          ! if layer thickness is too small, limit divergence flux outwards with opposite velocity
-          if ((layerThickness + dt * divOutFlux ) <= &
-              (config_drying_min_cell_height + config_drying_safety_height)) then
-
+          ! if layer thickness is too small, limit divergence flux outwards with
+          ! opposite velocity
+          if (layerThickness <= &
+              hCrit + config_drying_safety_height) then
             do i = 1, nEdgesOnCell(iCell)
               iEdge = edgesOnCell(i, iCell)
               if (k <= maxLevelEdgeBot(iEdge) .and. k >= minLevelEdgeTop(iEdge)) then
                 if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
-                  ! just go with simple boolean approach for zero wetting velocity for debugging purposes
                   wettingVelocityFactor(k, iEdge) = 1.0_RKIND
+                end if
+              end if
+            end do
+          elseif (config_zero_drying_velocity_ramp .and. &
+                 (layerThickness > &
+                 hCrit + config_drying_safety_height) .and. &
+                 (layerThickness <= config_zero_drying_velocity_ramp_hmax)) then
+
+            ! Following O'Dea et al. (2021), if total upwinded wct is less than
+            ! 2*critical thickness, apply damping at each edge
+            do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
+                if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
+                  wettingVelocityFactor(k, iEdge) = 1.0_RKIND - &
+                    tanh(50.0_RKIND * (layerThickness - hCrit)/hCrit)
                 end if
               end if
             end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -267,7 +267,7 @@ contains
      ! sure tendency doesn't dry cells
 
      call ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
-                                             normalTransportVelocity, ssh, rkSubstepWeight, wettingVelocityFactor, err)
+                                             normalTransportVelocity, rkSubstepWeight, wettingVelocityFactor, err)
 
      ! prevent drying from happening with selective wettingVelocityFactor
      if (config_zero_drying_velocity) then
@@ -306,7 +306,7 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_wetting_drying_wettingVelocity(layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
 
-       normalVelocity, ssh, dt, wettingVelocityFactor, err)!{{{
+       normalVelocity, dt, wettingVelocityFactor, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -325,8 +325,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity     !< Input: transport
-
-      real (kind=RKIND), dimension(:), intent(in) :: ssh
 
       real (kind=RKIND), intent(in) :: &
          dt     !< Input: time step
@@ -358,7 +356,7 @@ contains
 
       real (kind=RKIND) :: divFlux, divOutFlux
       real (kind=RKIND) :: layerThickness
-      real (kind=RKIND) :: hCrit, hEdgeTotal
+      real (kind=RKIND) :: hCrit, hRampMin, hEdgeTotal
 
       character (len=100) :: log_string
 
@@ -406,6 +404,7 @@ contains
                  hCrit + config_drying_safety_height) .and. &
                  (layerThickness <= config_zero_drying_velocity_ramp_hmax)) then
 
+            hRampMin = config_zero_drying_velocity_ramp_hmin
             ! Following O'Dea et al. (2021), if total upwinded wct is less than
             ! 2*critical thickness, apply damping at each edge
             do i = 1, nEdgesOnCell(iCell)
@@ -413,7 +412,7 @@ contains
               if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
                 if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
                   wettingVelocityFactor(k, iEdge) = 1.0_RKIND - &
-                    tanh(50.0_RKIND * (layerThickness - hCrit)/hCrit)
+                    tanh(50.0_RKIND * (layerThickness - hRampMin)/hRampMin)
                 end if
               end if
             end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -409,7 +409,7 @@ contains
             ! 2*critical thickness, apply damping at each edge
             do i = 1, nEdgesOnCell(iCell)
               iEdge = edgesOnCell(i, iCell)
-              if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
+              if (k <= maxLevelEdgeBot(iEdge) .and. k >= minLevelEdgeTop(iEdge)) then
                 if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
                   wettingVelocityFactor(k, iEdge) = 1.0_RKIND - &
                     tanh(50.0_RKIND * (layerThickness - hRampMin)/hRampMin)


### PR DESCRIPTION
This PR enhances the existing wetting-and-drying algorithm using an approach from O'Dea et al. 2020 (doi:10.1016/j.ocemod.2020.101708). Instead of zeroing out `normalVelocity` and `normalVelocity` tendencies in cells where the projected `layerThickness` drops below the user-defined minimum, this method ramps down the `normalVelocity` and its tendencies between a range of `layerThickness`es. 

[BFB][stealth]