### PR TITLE
Update weights for btr subcycling in split-explicit solver

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1286,11 +1286,11 @@
 					description="Barotropic subcycles proceed from $t$ to $t+n\Delta t$, where $n$ is this configuration option."
 					possible_values="Any positive integer, but typically 1 or 2"
 		/>
-		<nml_option name="config_btr_gam1_velWt1" type="real" default_value="0.5"
+		<nml_option name="config_btr_gam1_velWt1" type="real" default_value="0.5333"
 					description="Weighting of velocity in the SSH predictor step in stage 2. When zero, previous subcycle time is used; when one, new subcycle time is used."
 					possible_values="between 0 and 1"
 		/>
-		<nml_option name="config_btr_gam2_SSHWt1" type="real" default_value="1.0"
+		<nml_option name="config_btr_gam2_SSHWt1" type="real" default_value="0.5333"
 					description="Weighting of SSH in the velocity corrector step in stage 2. When zero, previous subcycle time is used; when one, new subcycle time is used."
 					possible_values="between 0 and 1"
 		/>


### PR DESCRIPTION
This PR updates the default `gamma` weights (`config_btr_gam1_velWt1`, `config_btr_gam2_SSHWt1`) in the barotropic subcycling phase of the split-explicit solver. Based on work with @jeremy-lilly, @gcapodag  and @mark-petersen, a stability analysis of the linearised external mode problem was used to estimate the coefficients that improve the scheme's CFL-limit, while also reducing numerical dissipation. Overall, the new coefficients $\gamma_{1,2} = \frac{8}{15}$ allow larger time-steps to be used; approximately $\frac{4}{3}$ the length of the maximum stable step-size used with the current $\gamma_{1} = \frac{1}{2}$, $\gamma_{2} = 1$ pair. This allows, e.g. `config_btr_dt` to be increased from 60sec to 75sec for QU30km and EC60to30km meshes and overall runtime to be reduced.

Following Shchepetkin et al., the behaviour of a time-stepping scheme can be analysed using a dissipation-dispersion diagram, in which a 'perfect' integration scheme would reproduce the unit-circle exactly, stability requires the scheme to lie inside the circle, dissipative errors are represented by a reduced curve radius and dispersive errors by angular offset. 

Old weights:
![old_btr_weights](https://user-images.githubusercontent.com/10022384/232545522-debe04ad-c5a4-4d30-9d37-cf7acdbfc385.png)

New weights:
![new_btr_weights](https://user-images.githubusercontent.com/10022384/232545547-170961f1-fe2f-427b-93e2-0a05640eff39.png)

The current weights achieve $\mathrm{CFL_{max}} = 1.41$ and the new weights $\mathrm{CFL_{max}} = 1.88$, leading to the $\frac{4}{3}$ time-step extension.

Though there is a third weight `config_btr_gam3_velWt2` available, this is typically not used, with `config_btr_solve_SSH2 = .false.` Initial experiments did not suggest including this step improved either stability or accuracy (the opposite in fact), though additional investigation would be required on this front.

I've confirmed the new weights allow `config_btr_dt = 00:00:75` for QU30km and EC60to30km config.'s (vs the current 60 sec time-step) and that 3yr standalone spin-ups lead to eyeball-norm consistent (but non-BFB) output. Additional testing would be required to validate performance in coupled E3SM runs.

- Shchepetkin, A.F. and McWilliams, J.C., 2009. Computational kernel algorithms for fine-scale, multiprocess, longtime oceanic simulations. In Handbook of Numerical Analysis (Vol. 14, pp. 121-183).