### PR TITLE
Add ocean linearization options

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1149,7 +1149,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_thickness_flux_type" type="character" default_value="centered"
-					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'. For 'constant', use constant thickness in time from restingThickness, for linear test problems"
+					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'. For 'constant', uses constant thickness in time from restingThickness, for linear test problems. Note that these two flags are set together for linearized test cases: config_thickness_flux_type = 'constant' linearizes the thickness equation, and config_disable_vel_hadv = .true. linearizes the momentum equation if there is no assumed mean background velocity."
 					possible_values="'upwind', 'centered', 'constant'"
 		/>
 		<nml_option name="config_drying_safety_height" type="real" default_value="1.0e-10" units="m"
@@ -1435,7 +1435,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_hadv" type="logical" default_value=".false."
-					description="Disables tendencies on the velocity field from the horizontal momentum advection."
+					description="Disables tendencies on the velocity field from the horizontal momentum advection. Note that these two flags are set together for linearized test cases: config_thickness_flux_type = 'constant' linearizes the thickness equation, and config_disable_vel_hadv = .true. linearizes the momentum equation if there is no assumed mean background velocity."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_coriolis" type="logical" default_value=".false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1079,6 +1079,10 @@
 					description="Slope limiter for the vertical remap advection scheme."
 					possible_values="'none','monotonic','weno'"
 		/>
+		<nml_option name="config_linearize_thick_hadv" type="logical" default_value=".false."
+					description="Change horizontal thickness advection from div(hu) to div(Hu) where h was the full velocity field, and H is the mean total depth."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
 		<nml_option name="config_use_implicit_bottom_drag" type="logical" default_value=".true."
@@ -1434,8 +1438,12 @@
 					description="Disables all tendencies on the velocity field."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_disable_vel_hadv" type="logical" default_value=".false."
+					description="Disables tendencies on the velocity field from the horizontal momentum advection."
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_disable_vel_coriolis" type="logical" default_value=".false."
-					description="Disables tendencies on the velocity field from the Coriolis force and momentum advection."
+					description="Disables tendencies on the velocity field from the Coriolis force."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_pgrad" type="logical" default_value=".false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1079,10 +1079,6 @@
 					description="Slope limiter for the vertical remap advection scheme."
 					possible_values="'none','monotonic','weno'"
 		/>
-		<nml_option name="config_linearize_thick_hadv" type="logical" default_value=".false."
-					description="Change horizontal thickness advection from div(hu) to div(Hu) where h was the full velocity field, and H is the mean total depth."
-					possible_values=".true. or .false."
-		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
 		<nml_option name="config_use_implicit_bottom_drag" type="logical" default_value=".true."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1153,8 +1153,8 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_thickness_flux_type" type="character" default_value="centered"
-					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'."
-					possible_values="'upwind', 'centered'"
+					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'. For 'constant', use constant thickness in time from restingThickness, for linear test problems"
+					possible_values="'upwind', 'centered', 'constant'"
 		/>
 		<nml_option name="config_drying_safety_height" type="real" default_value="1.0e-10" units="m"
 					description="Safety factor on minimum cell height to ensure the minimum height is not violated due to round-off."

--- a/components/mpas-ocean/src/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/components/mpas-ocean/src/mode_analysis/mpas_ocn_analysis_mode.F
@@ -277,6 +277,7 @@ module ocn_analysis_mode
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: verticalMeshPool
       type (mpas_pool_type), pointer :: scratchPool
 
       type (MPAS_timeInterval_type) :: timeStep
@@ -315,6 +316,7 @@ module ocn_analysis_mode
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
          call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
@@ -348,7 +350,7 @@ module ocn_analysis_mode
             !$acc enter data copyin(landIceDraft)
          endif
 #endif
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool, 1)
 #ifdef MPAS_OPENACC
          !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
          !$acc update host(relativeVorticity, circulation)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -741,7 +741,7 @@ module ocn_time_integration_rk4
             !$acc enter data copyin(landIceDraft)
          endif
 #endif
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(forcingPool, &
@@ -1167,7 +1167,7 @@ module ocn_time_integration_rk4
       integer, pointer :: nCells, nEdges, nVertLevels
       integer :: iCell, iEdge, k
 
-      type (mpas_pool_type), pointer :: statePool, tendPool, meshPool, scratchPool
+      type (mpas_pool_type), pointer :: statePool, tendPool, meshPool, verticalMeshPool, scratchPool
       type (mpas_pool_type), pointer :: provisStatePool, forcingPool
       type (mpas_pool_type), pointer :: tracersPool, tracersTendPool, provisTracersPool
 
@@ -1207,6 +1207,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
@@ -1350,7 +1351,7 @@ module ocn_time_integration_rk4
          !$acc enter data copyin(landIceDraft)
       endif
 #endif
-      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
+      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool, 1)
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
@@ -1555,7 +1556,7 @@ module ocn_time_integration_rk4
       integer, pointer :: nCells, nEdges
       integer :: iCell, iEdge, k
 
-      type (mpas_pool_type), pointer :: statePool, meshPool, forcingPool
+      type (mpas_pool_type), pointer :: statePool, meshPool, verticalMeshPool, forcingPool
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: tracersPool
 
@@ -1590,6 +1591,7 @@ module ocn_time_integration_rk4
 
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
@@ -1652,7 +1654,7 @@ module ocn_time_integration_rk4
          !$acc enter data copyin(landIceDraft)
       endif
 #endif
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool, 2)
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -2365,7 +2365,7 @@ module ocn_time_integration_si
             ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
-                                      meshPool, scratchPool, &
+                                      meshPool, verticalMeshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2836,7 +2836,7 @@ module ocn_time_integration_si
          !$acc enter data copyin(landIceDraft)
       endif
 #endif
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, &
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
@@ -3021,7 +3021,7 @@ module ocn_time_integration_si
 #endif
       end if
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, &
                                 scratchPool, tracersPool, 2)
 
       ! Update the effective desnity in land ice if we're coupling to

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1905,7 +1905,7 @@ module ocn_time_integration_split
             ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
-                                      meshPool, scratchPool, &
+                                      meshPool, verticalMeshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2370,7 +2370,7 @@ module ocn_time_integration_split
          !$acc enter data copyin(landIceDraft)
       endif
 #endif
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, &
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
@@ -2554,7 +2554,7 @@ module ocn_time_integration_split
 #endif
       end if
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, &
                                 scratchPool, tracersPool, 2)
 
       ! Update the effective desnity in land ice if we're coupling to

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -4261,6 +4261,13 @@ contains
          thickEdgeFluxChoice = thickEdgeFluxCenter
       elseif (trim(config_thickness_flux_type) == 'constant') then
          thickEdgeFluxChoice = thickEdgeFluxConstant
+         if (.not.config_disable_vel_hadv) then
+            call mpas_log_write('config_thickness_flux_type set to ' //&
+                 & trim(config_thickness_flux_type) // ' but '//&
+                 & 'config_disable_vel_hadv is false. '//&
+                 & 'Set config_disable_vel_hadv to true for a linear test case. ', &
+                 MPAS_LOG_CRIT)
+         end if
       else
          if (config_use_wetting_drying .and. &
              (trim(config_thickness_flux_type) /= 'centered')) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -81,9 +81,11 @@ module ocn_diagnostics
    ! Methods for computing thickness at edges for flux calculations
    integer :: thickEdgeFluxChoice  ! choice of thickness flux type
    integer, parameter :: &
-      thickEdgeFluxUnknown = 0, &! type unknown or unset
-      thickEdgeFluxCenter  = 1, &! use mean thickness of cell neighbors
-      thickEdgeFluxUpwind  = 2   ! use upwind cell thickness at edge
+      thickEdgeFluxUnknown  = 0, &! type unknown or unset
+      thickEdgeFluxCenter   = 1, &! use mean thickness of cell neighbors
+      thickEdgeFluxUpwind   = 2, &! use upwind cell thickness at edge
+      thickEdgeFluxConstant = 3   ! use constant thickness in time from
+                                  ! RestingThickness, for linear test problems
 
 !***********************************************************************
 
@@ -101,13 +103,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, &
+   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool, &
                                    timeLevelIn, full)!{{{
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+      type (mpas_pool_type), intent(in) :: verticalMeshPool !< Input: vertical mesh information
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
@@ -122,7 +125,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: &
         ssh,  seaIcePressure, atmosphericPressure
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThickness, layerThicknessLag, normalVelocity
+        layerThickness, layerThicknessLag, normalVelocity, restingThickness
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
@@ -166,6 +169,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
@@ -233,7 +237,7 @@ contains
       ! inputs: layerThickness, normalVelocity
       ! output: layerThickEdgeMean, layerThickEdgeFlux
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, &
-                                                   layerThickness)
+                                                   layerThickness, restingThickness)
 
       ! inputs: normalVelocity
       ! outputs: relativeVorticity, circulation
@@ -672,7 +676,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, &
-                                                      layerThickness)!{{{
+                                                      layerThickness, restingThickness)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -680,7 +684,8 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,  &!< [in] transport
-         layerThickness    !< [in] layer thickness at cell center
+         layerThickness,  &!< [in] layer thickness at cell center
+         restingThickness  !< [in] initial layer thickness at cell center
 
       !-----------------------------------------------------------------
       ! output variables
@@ -793,6 +798,40 @@ contains
                                       max(layerThickness(k,cell1), &
                                           layerThickness(k,cell2))
                end if
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+
+      case (thickEdgeFluxConstant)
+         ! Use linearized version H*u where H is constant in time
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(restingThickness, &
+         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+         !$acc            layerThickEdgeFlux, cellsOnEdge) &
+         !$acc    private(k, kmin, kmax, cell1, cell2)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+#endif
+         do iEdge = 1, nEdgesAll
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k=1,nVertLevels
+               ! initialize layerThicknessEdgeFlux to avoid divide by
+               ! zero and NaN problems.
+               layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
+            end do
+            do k = kmin,kmax
+               layerThickEdgeFlux(k,iEdge) = 0.5_RKIND * &
+                                         (restingThickness(k,cell1) + &
+                                          restingThickness(k,cell2))
             end do
          end do
 #ifndef MPAS_OPENACC
@@ -4220,6 +4259,8 @@ contains
       ! Initialize choice for computing thickness at edges for fluxes
       if (trim(config_thickness_flux_type) == 'centered') then
          thickEdgeFluxChoice = thickEdgeFluxCenter
+      elseif (trim(config_thickness_flux_type) == 'constant') then
+         thickEdgeFluxChoice = thickEdgeFluxConstant
       else
          if (config_use_wetting_drying .and. &
              (trim(config_thickness_flux_type) /= 'centered')) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -96,7 +96,7 @@ contains
       real (kind=RKIND), intent(in) :: dt
       integer, intent(out) :: err
 
-      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
       type (mpas_pool_type), pointer :: statePool, tracersPool
       type (mpas_pool_type), pointer :: forcingPool, scratchPool
       integer :: iEdge, iCell
@@ -128,6 +128,7 @@ contains
       call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
 
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
@@ -169,7 +170,7 @@ contains
          !$acc enter data copyin(landIceDraft)
       endif
 #endif
-      call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, scratchPool, tracersPool)
+      call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, verticalMeshPool, scratchPool, tracersPool)
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -52,7 +52,7 @@ module ocn_thick_hadv
    !
    !--------------------------------------------------------------------
 
-   logical :: thickHadvOn, linearizeHadv
+   logical :: thickHadvOn
 
 !***********************************************************************
 
@@ -126,7 +126,6 @@ contains
 
       call mpas_timer_start("thick hadv")
 
-      if (.not.linearizeHadv) then
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc     present(tend, normalVelocity, dvEdge, &
@@ -151,32 +150,6 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
-      else ! linearize the thickness advection, i.e. constant H*u rather than dynamic h*u
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc     present(tend, normalVelocity, dvEdge, &
-      !$acc             layerThickEdgeFlux, edgeSignOnCell, &
-      !$acc             minLevelEdgeBot, maxLevelEdgeBot) &
-      !$acc     private(i, k, invAreaCell, flux)
-#else
-      !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux)
-#endif
-      do iCell = 1, nCellsOwned
-        invAreaCell = 1.0_RKIND / areaCell(iCell)
-        do i = 1, nEdgesOnCell(iCell)
-          iEdge = edgesOnCell(i, iCell)
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThickEdgeFlux(k, iEdge)
-            tend(k, iCell) = tend(k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell
-          end do
-        end do
-      end do
-#ifndef MPAS_OPENACC
-      !$omp end do
-      !$omp end parallel
-#endif
-      endif
 
       call mpas_timer_stop("thick hadv")
 
@@ -212,7 +185,6 @@ contains
       thickHadvOn = .true.
 
       if(config_disable_thick_hadv) thickHadvOn = .false.
-      if(config_linearize_thick_hadv) linearizeHadv = .true.
 
       err = 0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -52,7 +52,7 @@ module ocn_thick_hadv
    !
    !--------------------------------------------------------------------
 
-   logical :: thickHadvOn
+   logical :: thickHadvOn, linearizeHadv
 
 !***********************************************************************
 
@@ -126,6 +126,7 @@ contains
 
       call mpas_timer_start("thick hadv")
 
+      if (.not.linearizeHadv) then
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc     present(tend, normalVelocity, dvEdge, &
@@ -150,6 +151,32 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+      else ! linearize the thickness advection, i.e. constant H*u rather than dynamic h*u
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc     present(tend, normalVelocity, dvEdge, &
+      !$acc             layerThickEdgeFlux, edgeSignOnCell, &
+      !$acc             minLevelEdgeBot, maxLevelEdgeBot) &
+      !$acc     private(i, k, invAreaCell, flux)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux)
+#endif
+      do iCell = 1, nCellsOwned
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThickEdgeFlux(k, iEdge)
+            tend(k, iCell) = tend(k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell
+          end do
+        end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+      endif
 
       call mpas_timer_stop("thick hadv")
 
@@ -185,6 +212,7 @@ contains
       thickHadvOn = .true.
 
       if(config_disable_thick_hadv) thickHadvOn = .false.
+      if(config_linearize_thick_hadv) linearizeHadv = .true.
 
       err = 0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -164,7 +164,7 @@ contains
 #ifndef MPAS_OPENACC
          !$omp end do
 #endif
-      elseif (useRelVorticity) then
+      elseif (useRelVorticity.and.(.not.usePlanetVorticity)) then
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(tmpVorticity, normRelVortEdge) &
@@ -181,7 +181,7 @@ contains
 #ifndef MPAS_OPENACC
          !$omp end do
 #endif
-      elseif (usePlanetVorticity) then
+      elseif (usePlanetVorticity.and.(.not.useRelVorticity)) then
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(tmpVorticity, normPlanetVortEdge) &
@@ -344,7 +344,6 @@ contains
 
       !*** Reset module variables based in input configuration
 
-      if ( config_disable_vel_hadv .and. config_disable_vel_coriolis ) hadvCoriolisDisabled = .true.
       if ( config_disable_vel_hadv ) then
           useRelVorticity = .false.
           useGradKineticEnergy = .false.
@@ -381,6 +380,11 @@ contains
       ! override usePlanetVorticity to false if coriolis term is disabled.
       if ( config_disable_vel_coriolis ) then
          usePlanetVorticity = .false.
+      endif
+
+      ! If all three terms are off, then disable the whole subroutine upon entry
+      if ( (.not.useRelVorticity).and.(.not.useGradKineticEnergy).and.(.not.usePlanetVorticity) ) then
+          hadvCoriolisDisabled = .true.
       endif
 
    !--------------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -118,7 +118,7 @@ contains
 
       real (kind=RKIND) :: &
          avgVorticity, &! vorticity averaged across edge
-         invLength,    &! temp variable for 1/dcedge
+         invLength,    &! temp variable for 1/dcEdge
          edgeWeight     ! weight for summing over edges
 
       real (kind=RKIND), dimension(:,:), allocatable :: &
@@ -243,62 +243,61 @@ contains
 
       if (useGradKineticEnergy) then
 #ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
-      !$acc            dcEdge, tend, qArr, kineticEnergyCell) &
-      !$acc    private(cell1, cell2, invLength, k, kmin, kmax)
+         !$acc parallel loop &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
+         !$acc            dcEdge, tend, qArr, kineticEnergyCell) &
+         !$acc    private(cell1, cell2, invLength, k, kmin, kmax)
 #else
-      !$omp do schedule(runtime) &
-      !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
 #endif
-      do iEdge = 1, nEdgesOwned
-         kmin = minLevelEdgeBot(iEdge)
-         kmax = maxLevelEdgeTop(iEdge)
+         do iEdge = 1, nEdgesOwned
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
 
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-         invLength = 1.0_RKIND / dcEdge(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invLength = 1.0_RKIND / dcEdge(iEdge)
 
-         do k = kmin, kmax
-            tend(k,iEdge) = tend(k,iEdge) + &
-                        edgeMask(k,iEdge)* (qArr(k,iEdge) - &
-                           (kineticEnergyCell(k,cell2) &
-                          - kineticEnergyCell(k,cell1))*invLength)
+            do k = kmin, kmax
+               tend(k,iEdge) = tend(k,iEdge) + &
+                           edgeMask(k,iEdge)* (qArr(k,iEdge) - &
+                              (kineticEnergyCell(k,cell2) &
+                             - kineticEnergyCell(k,cell1))*invLength)
+            end do
          end do
-      end do
 #ifndef MPAS_OPENACC
-      !$omp end do
+         !$omp end do
 #endif
 
       else ! .not.useGradKineticEnergy
 #ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
-      !$acc            dcEdge, tend, qArr) &
-      !$acc    private(cell1, cell2, invLength, k, kmin, kmax)
+         !$acc parallel loop &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
+         !$acc            dcEdge, tend, qArr) &
+         !$acc    private(cell1, cell2, k, kmin, kmax)
 #else
-      !$omp do schedule(runtime) &
-      !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
+         !$omp do schedule(runtime) &
+         !$omp    private(cell1, cell2, k, kmin, kmax)
 #endif
-      do iEdge = 1, nEdgesOwned
-         kmin = minLevelEdgeBot(iEdge)
-         kmax = maxLevelEdgeTop(iEdge)
+         do iEdge = 1, nEdgesOwned
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
 
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-         invLength = 1.0_RKIND / dcEdge(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
 
-         do k = kmin, kmax
-            tend(k,iEdge) = tend(k,iEdge) + &
-                        edgeMask(k,iEdge)* qArr(k,iEdge)
+            do k = kmin, kmax
+               tend(k,iEdge) = tend(k,iEdge) + &
+                           edgeMask(k,iEdge)* qArr(k,iEdge)
+            end do
          end do
-      end do
 #ifndef MPAS_OPENACC
-      !$omp end do
+         !$omp end do
 #endif
       endif
 #ifndef MPAS_OPENACC
-         !$omp end parallel
+      !$omp end parallel
 #endif
 
       !$acc exit data delete(tmpVorticity, qArr)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -56,8 +56,9 @@ module ocn_vel_hadv_coriolis
                            ! use disabled since default is on
 
    logical :: &
-      usePlanetVorticity   ! multiplicative mask for including
-                           ! planetary vorticity term
+      usePlanetVorticity,   &! mask for including planetary vorticity term
+      useRelVorticity,      &! mask for including relative vorticity term
+      useGradKineticEnergy   ! mask for including grad kinetic energy term
 
 !***********************************************************************
 
@@ -267,8 +268,8 @@ contains
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
-      !$omp end parallel
 #endif
+
       else ! .not.useGradKineticEnergy
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
@@ -294,7 +295,10 @@ contains
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
-      !$omp end parallel
+#endif
+      endif
+#ifndef MPAS_OPENACC
+         !$omp end parallel
 #endif
 
       !$acc exit data delete(tmpVorticity, qArr)
@@ -349,8 +353,6 @@ contains
           useGradKineticEnergy = .true.
       endif
 
-      if ( config_disable_vel_coriolis ) coriolisDisabled = .true.
-
       select case (trim(config_time_integrator))
       case ('RK4','rk4')
          ! For RK4, coriolis tendency term includes f: (eta+f)/h.
@@ -375,6 +377,11 @@ contains
          usePlanetVorticity = .false.
 
       end select
+
+      ! override usePlanetVorticity to false if coriolis term is disabled.
+      if ( config_disable_vel_coriolis ) then
+         usePlanetVorticity = .false.
+      endif
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -144,7 +144,7 @@ contains
 #ifndef MPAS_OPENACC
       !$omp parallel
 #endif
-      if (usePlanetVorticity) then
+      if (usePlanetVorticity.and.useRelVorticity) then
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(tmpVorticity, normRelVortEdge, &
@@ -163,7 +163,7 @@ contains
 #ifndef MPAS_OPENACC
          !$omp end do
 #endif
-      else
+      elseif (useRelVorticity) then
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(tmpVorticity, normRelVortEdge) &
@@ -175,6 +175,23 @@ contains
          do iEdge = 1, nEdgesAll
          do k=1,nVertLevels
             tmpVorticity(k,iEdge) = normRelVortEdge(k,iEdge)
+         end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+#endif
+      elseif (usePlanetVorticity) then
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(tmpVorticity, normPlanetVortEdge) &
+         !$acc    private(k)
+#else
+         !$omp do schedule(runtime) &
+         !$omp    private(k)
+#endif
+         do iEdge = 1, nEdgesAll
+         do k=1,nVertLevels
+            tmpVorticity(k,iEdge) = normPlanetVortEdge(k,iEdge)
          end do
          end do
 #ifndef MPAS_OPENACC
@@ -223,6 +240,7 @@ contains
       !$omp end do
 #endif
 
+      if (useGradKineticEnergy) then
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
@@ -245,6 +263,33 @@ contains
                         edgeMask(k,iEdge)* (qArr(k,iEdge) - &
                            (kineticEnergyCell(k,cell2) &
                           - kineticEnergyCell(k,cell1))*invLength)
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+      else ! .not.useGradKineticEnergy
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
+      !$acc            dcEdge, tend, qArr) &
+      !$acc    private(cell1, cell2, invLength, k, kmin, kmax)
+#else
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, invLength, k, kmin, kmax)
+#endif
+      do iEdge = 1, nEdgesOwned
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         invLength = 1.0_RKIND / dcEdge(iEdge)
+
+         do k = kmin, kmax
+            tend(k,iEdge) = tend(k,iEdge) + &
+                        edgeMask(k,iEdge)* qArr(k,iEdge)
          end do
       end do
 #ifndef MPAS_OPENACC
@@ -295,7 +340,16 @@ contains
 
       !*** Reset module variables based in input configuration
 
-      if ( config_disable_vel_coriolis ) hadvCoriolisDisabled = .true.
+      if ( config_disable_vel_hadv .and. config_disable_vel_coriolis ) hadvCoriolisDisabled = .true.
+      if ( config_disable_vel_hadv ) then
+          useRelVorticity = .false.
+          useGradKineticEnergy = .false.
+      else
+          useRelVorticity = .true.
+          useGradKineticEnergy = .true.
+      endif
+
+      if ( config_disable_vel_coriolis ) coriolisDisabled = .true.
 
       select case (trim(config_time_integrator))
       case ('RK4','rk4')


### PR DESCRIPTION
This PR adds two options that may be turned on in order to run the ocean momentum and thickness equation in linearized form.  These two settings are:
1. Momentum equation: Turn off nonlinear advection. This is usually written as `u dot grad(u)` but in the TRiSK formulation, we (equivalently) turn off the terms `grad(KE)` and `eta * uperp` where `eta` is relative vorticity. This is now set with the new flag `config_disable_vel_hadv = .true.`  
2. Thickness equation: The advection term `div(h*u)` is linearized to use a constant layer thickness in time, `div(H*u)`, where `H` is taken from the `restingThickness` variable. This option is set with `config_thickness_flux_type = 'constant'`.
 
Note that the previous flag `config_disable_vel_coriolis` would remain `.false.` for linear tests. Previously the flag `config_disable_vel_coriolis` was inappropriately named and turned off _both_ the coriolis and advection terms. Now `config_disable_vel_coriolis` controls the coriolis term only.

These new options will allow us to compare against analytic solutions to the shallow water equations, such as Kelvin waves and inertia-gravity waves. These are described in [Sid Bishnu's recent paper](https://essopenarchive.org/users/566154/articles/612943-a-verification-suite-of-test-cases-for-the-barotropic-solver-of-ocean-models) and [Sid's thesis](https://diginole.lib.fsu.edu/islandora/object/fsu:795713).

[BFB]