### PR TITLE
Add new SO12to60E3r2 ocean and sea-ice mesh

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -340,7 +340,7 @@ Toggle to turn on plant hydraulics (only relevant if FATES is on).
 </entry>
 
 <entry id="use_fates_tree_damage" type="logical" category="physics"
-        group="elm_inparm" valid_values="" value=".false."> 
+        group="elm_inparm" valid_values="" value=".false.">
 Toggle to turn on the tree damage module in FATES
 (Only relevant if FATES is on)
 </entry>
@@ -1022,7 +1022,7 @@ by getco2_historical.ncl
 <!--                                                   -->
 <!-- files needed for tools/ncl_scripts                -->
 <!--                                                   -->
-<entry id="faerdep" type="char*256"  category="tools" 
+<entry id="faerdep" type="char*256"  category="tools"
        input_pathname="abs" group="elmexp" valid_values="" >
 Aerosol deposition file name (only used for aerdepregrid.ncl)
 </entry>
@@ -1309,8 +1309,8 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 </entry>
 
 <entry id="mask" type="char*20" category="default_settings"
-       group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10">
+       group="default_settings"
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10,SO12to60E3r2">
 Land mask description
 </entry>
 
@@ -1860,7 +1860,7 @@ Runtime flag to turn on/off variable soil thickness.
 <!-- Namelist options for lake water storage                                                  -->
 <!-- ======================================================================================== -->
 
-<entry id="use_lake_wat_storage" type="logical" category="default_settings" 
+<entry id="use_lake_wat_storage" type="logical" category="default_settings"
         group="elm_inparm" valid_values="">
 Runtime flag to turn on/off lake water storage.
 </entry>
@@ -1869,21 +1869,21 @@ Runtime flag to turn on/off lake water storage.
 <!-- Namelist options for downscaling from grid to topounit                                    -->
 <!-- ========================================================================================  -->
 
-<entry id="use_atm_downscaling_to_topunit" 
-       type="logical" 
+<entry id="use_atm_downscaling_to_topunit"
+       type="logical"
        category="physics"
        group="elm_inparm"
-       valid_values=".true.,.false." 
+       valid_values=".true.,.false."
        value=".false.">
 Runtime flag to turn on/off downscaling of atmosphric forcing from grid to topounit.
 </entry>
-<entry id="precip_downscaling_method" 
-       type="char*32" 
+<entry id="precip_downscaling_method"
+       type="char*32"
        category="physics"
-       group="elm_inparm"       
-       valid_values="ERMM,FNM" 
+       group="elm_inparm"
+       valid_values="ERMM,FNM"
        value="ERMM" >
-Flag to switch between ERMM (Elevation Range with Maximum Elevation Method) and FNM (Froude Number Method) precipitation downscaling methods. 
+Flag to switch between ERMM (Elevation Range with Maximum Elevation Method) and FNM (Froude Number Method) precipitation downscaling methods.
 </entry>
 
 <!-- ========================================================================================  -->
@@ -2010,14 +2010,14 @@ Type of snow grain shape
 
 <entry id="snicar_atm_type" type="char*256" category="elm_physics"
        group="elm_inparm" valid_values="default,mid-latitude_winter,mid-latitude_summer,sub-Arctic_winter,sub-Arctic_summer,summit_Greenland,high_mountain">
-Atmospheric types: 'default' represents the default mid-latitude winter type 
-without considering SZA dependenece of direct irradiance, and the other types 
+Atmospheric types: 'default' represents the default mid-latitude winter type
+without considering SZA dependenece of direct irradiance, and the other types
 explain the SZA dependence of direct irradiance.
 </entry>
 
 <entry id="use_dust_snow_internal_mixing" type="logical" category="elm_physics"
        group="elm_inparm" valid_values="" value=".false.">
-Toggle to turn on the internal mixing of dust-snow. 
+Toggle to turn on the internal mixing of dust-snow.
 </entry>
 
 <!-- ========================================================================================  -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -48,6 +48,7 @@
 <config_dt ocn_grid="WCAtl12to45E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
+<config_dt ocn_grid="SO12to60E3r2">'00:10:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
@@ -71,6 +72,7 @@
 <config_hmix_scaleWithMesh ocn_grid="WCAtl12to45E2r4">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="SOwISC12to60E2r4">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="ECwISC30to60E2r1">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="SO12to60E3r2">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -86,6 +88,7 @@
 <config_use_mom_del2 ocn_grid="WCAtl12to45E2r4">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="SOwISC12to60E2r4">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E2r1">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="SO12to60E3r2">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
@@ -95,6 +98,7 @@
 <config_mom_del2 ocn_grid="WCAtl12to45E2r4">462.0</config_mom_del2>
 <config_mom_del2 ocn_grid="SOwISC12to60E2r4">462.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E2r1">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="SO12to60E3r2">462.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -119,6 +123,7 @@
 <config_mom_del4 ocn_grid="WCAtl12to45E2r4">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="SOwISC12to60E2r4">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="ECwISC30to60E2r1">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="SO12to60E3r2">1.18e10</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -149,6 +154,7 @@
 <config_Redi_horizontal_taper>'ramp'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_taper ocn_grid="SOwISC12to60E2r4">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="SO12to60E3r2">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
@@ -173,6 +179,7 @@
 <config_GM_closure ocn_grid="WCAtl12to45E2r4">'constant'</config_GM_closure>
 <config_GM_closure ocn_grid="SOwISC12to60E2r4">'N2_dependent'</config_GM_closure>
 <config_GM_closure ocn_grid="ECwISC30to60E2r1">'N2_dependent'</config_GM_closure>
+<config_GM_closure ocn_grid="SO12to60E3r2">'N2_dependent'</config_GM_closure>
 <config_GM_constant_kappa>900.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
@@ -181,6 +188,7 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WCAtl12to45E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SO12to60E3r2">600.0</config_GM_constant_kappa>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -188,6 +196,7 @@
 <config_GM_spatially_variable_baroclinic_mode>3.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="SOwISC12to60E2r4">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="ECwISC30to60E2r1">1.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="SO12to60E3r2">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_Visbeck_alpha>0.13</config_GM_Visbeck_alpha>
 <config_GM_Visbeck_max_depth>1000.0</config_GM_Visbeck_max_depth>
 <config_GM_EG_riMin>200.0</config_GM_EG_riMin>
@@ -197,6 +206,7 @@
 <config_GM_horizontal_taper>'ramp'</config_GM_horizontal_taper>
 <config_GM_horizontal_taper ocn_grid="SOwISC12to60E2r4">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="SO12to60E3r2">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_ramp_min>20e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
@@ -456,6 +466,7 @@
 <config_btr_dt ocn_grid="WCAtl12to45E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="SO12to60E3r2">'0000_00:00:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -1012,6 +1023,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="WCAtl12to45E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="SO12to60E3r2">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -283,6 +283,17 @@ def buildnml(case, caseroot, compname):
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.ECwISC30to60E2r1.230429.nc'
 
+    elif ocn_grid == 'SO12to60E3r2':
+        decomp_date = '20230920'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.SO12to60E3r2.20230920.nc'
+        analysis_mask_file = 'SO12to60E3r2_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230920'
+        ic_prefix = 'mpaso.SO12to60E3r2'
+        if ocn_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     #--------------------------------------------------------------------
     # Set OCN_FORCING = datm_forced_restoring if restoring file is available
     #--------------------------------------------------------------------

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -24,6 +24,7 @@
 <config_dt ice_grid="WCAtl12to45E2r4">1800.0</config_dt>
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
+<config_dt ice_grid="SO12to60E3r2">1800.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -76,6 +77,7 @@
 <config_initial_latitude_north ice_grid="ARRM10to60E2r1">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS18to6v3">85.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="SO12to60E3r2">85.0</config_initial_latitude_north>
 <config_initial_latitude_south>-60.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oEC60to30v3wLI">-75.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="ECwISC30to60E1r2">-75.0</config_initial_latitude_south>
@@ -84,6 +86,7 @@
 <config_initial_latitude_south ice_grid="ARRM10to60E2r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS18to6v3">-85.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="SO12to60E3r2">-85.0</config_initial_latitude_south>
 <config_initial_velocity_type>'uniform'</config_initial_velocity_type>
 <config_initial_uvelocity>0.0</config_initial_uvelocity>
 <config_initial_vvelocity>0.0</config_initial_vvelocity>
@@ -140,6 +143,7 @@
 <config_dynamics_subcycle_number ice_grid="WCAtl12to45E2r4">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="SOwISC12to60E2r4">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="ECwISC30to60E2r1">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="SO12to60E3r2">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -253,6 +253,16 @@ def buildnml(case, caseroot, compname):
             grid_date = '210414'
             grid_prefix = 'mpassi.ECwISC30to60E2r1.rstFromG-anvil'
 
+    elif ice_grid == 'SO12to60E3r2':
+        grid_date = '20230920'
+        grid_prefix = 'mpassi.SO12to60E3r2'
+        decomp_date = '20230920'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        data_iceberg_file = 'Iceberg_Climatology_Merino.SO12to60E3r2.20230920.nc'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     elif ice_grid == 'ICOS10':
         grid_date = '211015'
         grid_prefix = 'seaice.ICOS10'


### PR DESCRIPTION
Long name: SO12to60kmL64E3SMv3r2

This version of the Southern Ocean Regionally Refined Mesh (SORRM) has the same distribution of resolution as in the E3SM v2 version of the mesh and the E3SM v3 [SOwISC12to60E3r1](https://github.com/E3SM-Project/E3SM/pull/5935) mesh, including:
* 12 km resolution around Antarctica
* 45 km resolution at southern mid-latitudes
* 30 km resolution at the equator and the north Atlantic
* 60 km resolution in the north Pacific
* 35 km resolution in the Arctic

It matches the EC30to60 (https://github.com/E3SM-Project/E3SM/pull/5927) mesh except in the Southern Ocean and north Atlantic.

This is revision 2 (r2) of the mesh, which does not have ice-shelf cavities around Antarctica, like revision 1 (r1) does.

The mesh was created using [compass](https://github.com/MPAS-Dev/compass), at:
https://github.com/MPAS-Dev/compass/pull/701
and will be tagged as:
https://github.com/MPAS-Dev/compass/releases/tag/mesh_SO12to60E3r2

The mesh is being reviewed here:
https://acme-climate.atlassian.net/wiki/spaces/OO/pages/3924820421/Review+SO12to60E3r2

G- and B-case will begin shortly and analysis will be posted on the review page as soon as it is available.


