### PR TITLE
Add cryo terms to coupler budget

### DIFF
--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -25,6 +25,8 @@ module mpaso_cpl_indices
   integer :: index_o2x_Foxo_ismw
   integer :: index_o2x_Foxo_rrofl
   integer :: index_o2x_Foxo_rrofi
+  integer :: index_o2x_Foxo_ismh
+  integer :: index_o2x_Foxo_rrofih
 
   ! ocn -> drv for calculation of ocean-ice sheet interactions
 
@@ -189,10 +191,13 @@ contains
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
-!DC P needed since in ice-shelf ocean domain?
+
     index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw')
     index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl')
     index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi')
+
+    index_o2x_Foxo_ismh     = mct_avect_indexra(o2x,'Foxo_ismh')
+    index_o2x_Foxo_rrofih   = mct_avect_indexra(o2x,'Foxo_rrofih')
 
     index_o2x_So_blt        = mct_avect_indexra(o2x,'So_blt')
     index_o2x_So_bls        = mct_avect_indexra(o2x,'So_bls')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -22,7 +22,9 @@ module mpaso_cpl_indices
   integer :: index_o2x_Faoo_fco2_ocn
   integer :: index_o2x_Faoo_fdms_ocn
   integer :: index_o2x_So_ssh
-
+  integer :: index_o2x_Foxo_ismw
+  integer :: index_o2x_Foxo_rrofl
+  integer :: index_o2x_Foxo_rrofi
 
   ! ocn -> drv for calculation of ocean-ice sheet interactions
 
@@ -187,6 +189,10 @@ contains
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
+!DC P needed since in ice-shelf ocean domain?
+    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'PFoxo_ismw')
+    index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl')
+    index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi')
 
     index_o2x_So_blt        = mct_avect_indexra(o2x,'So_blt')
     index_o2x_So_bls        = mct_avect_indexra(o2x,'So_bls')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -190,7 +190,7 @@ contains
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
 !DC P needed since in ice-shelf ocean domain?
-    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'PFoxo_ismw')
+    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw')
     index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl')
     index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi')
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2696,6 +2696,7 @@ contains
                                                avgOceanSurfaceFeDissolved, &
                                                ssh, &
                                                landIceFreshwaterFlux, &
+                                               dataLandIceFreshwaterFlux, &
                                                removedRiverRunoffFlux, &
                                                removedIceRunoffFlux
 
@@ -2766,9 +2767,12 @@ contains
         call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
      end if
 
-     !DC Cryo fields , 0 when data
-     if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+     !DC Cryo fields
+     if (config_land_ice_flux_mode == 'standalone') then
         call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+     endif
+     if (config_land_ice_flux_mode == 'data') then
+        call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', dataLandIceFreshwaterFlux)
      endif
      if (config_remove_AIS_coupler_runoff) then
         call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
@@ -2826,9 +2830,12 @@ contains
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
-!DC landIceFreshwaterFlux seems to be 0 when data
-       if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+!DC
+       if (config_land_ice_flux_mode == 'standalone') then
           o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = landIceFreshwaterFlux(i)
+       endif
+       if (config_land_ice_flux_mode == 'data') then
+          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = dataLandIceFreshwaterFlux(i)
        endif
        if (config_remove_AIS_coupler_runoff) then
           o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = removedRiverRunoffFlux(i)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3619,7 +3619,6 @@ contains
         endif
 
         if ( landIceFreshwaterFluxField % isActive ) then
-!DC is this ok with proposed implementation? think so since different coupling field
            !landIceFreshwaterFlux(i) = x2o_om(n, index_x2o_Fogx_qicelo)
         end if
         if ( landIceHeatFluxField % isActive ) then
@@ -4140,7 +4139,6 @@ contains
    
             o2x_om(n, index_o2x_Faoo_h2otemp) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
-!DC, blindly following pattern
             if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
                o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
                o2x_om(n, index_o2x_Foxo_ismh)  = avgLandIceHeatFlux(i)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2697,7 +2697,9 @@ contains
                                                ssh, &
                                                avgLandIceFreshwaterFlux, &
                                                avgRemovedRiverRunoffFlux, &
-                                               avgRemovedIceRunoffFlux
+                                               avgRemovedIceRunoffFlux, &
+                                               avgLandIceHeatFlux, &
+                                               avgRemovedIceRunoffHeatFlux
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -2769,10 +2771,12 @@ contains
      ! Cryo fields
      if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
         call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+        call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
      endif
      if (config_remove_AIS_coupler_runoff) then
         call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
         call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
      endif
 
      ! BGC fields
@@ -2829,10 +2833,12 @@ contains
        ! Cryo fields
        if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
           o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = avgLandIceFreshwaterFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_ismh, n)  = avgLandIceHeatFlux(i)
        endif
        if (config_remove_AIS_coupler_runoff) then
           o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = avgRemovedRiverRunoffFlux(i)
           o2x_o % rAttr(index_o2x_Foxo_rrofi, n) = avgRemovedIceRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofih, n) = avgRemovedIceRunoffHeatFlux(i)
        endif
 
        if ( frazilIceActive ) then
@@ -4002,7 +4008,9 @@ contains
                                                    ssh, &
                                                    avgLandIceFreshwaterFlux, &
                                                    avgRemovedRiverRunoffFlux, &
-                                                   avgRemovedIceRunoffFlux
+                                                   avgRemovedIceRunoffFlux, &
+                                                   avgLandIceHeatFlux, &
+                                                   avgRemovedIceRunoffHeatFlux
    
       real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                       avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -4073,10 +4081,12 @@ contains
 
         if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
         endif
         if (config_remove_AIS_coupler_runoff) then
            call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
            call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
         endif
    
          ! BGC fields
@@ -4133,10 +4143,12 @@ contains
 !DC, blindly following pattern
             if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
                o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
+               o2x_om(n, index_o2x_Foxo_ismh)  = avgLandIceHeatFlux(i)
             endif
             if (config_remove_AIS_coupler_runoff) then
                o2x_om(n, index_o2x_Foxo_rrofl) = avgRemovedRiverRunoffFlux(i)
                o2x_om(n, index_o2x_Foxo_rrofi) = avgRemovedIceRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofih) = avgRemovedIceRunoffHeatFlux(i)
             endif
 
             if ( frazilIceActive ) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2695,10 +2695,9 @@ contains
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved, &
                                                ssh, &
-                                               landIceFreshwaterFlux, &
-                                               dataLandIceFreshwaterFlux, &
-                                               removedRiverRunoffFlux, &
-                                               removedIceRunoffFlux
+                                               avgLandIceFreshwaterFlux, &
+                                               avgRemovedRiverRunoffFlux, &
+                                               avgRemovedIceRunoffFlux
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -2767,16 +2766,13 @@ contains
         call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
      end if
 
-     !DC Cryo fields
-     if (config_land_ice_flux_mode == 'standalone') then
-        call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-     endif
-     if (config_land_ice_flux_mode == 'data') then
-        call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', dataLandIceFreshwaterFlux)
+     ! Cryo fields
+     if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+        call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
      endif
      if (config_remove_AIS_coupler_runoff) then
-        call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
-        call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
      endif
 
      ! BGC fields
@@ -2830,16 +2826,13 @@ contains
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
-!DC
-       if (config_land_ice_flux_mode == 'standalone') then
-          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = landIceFreshwaterFlux(i)
-       endif
-       if (config_land_ice_flux_mode == 'data') then
-          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = dataLandIceFreshwaterFlux(i)
+       ! Cryo fields
+       if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = avgLandIceFreshwaterFlux(i)
        endif
        if (config_remove_AIS_coupler_runoff) then
-          o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = removedRiverRunoffFlux(i)
-          o2x_o % rAttr(index_o2x_Foxo_rrofi, n) = removedIceRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = avgRemovedRiverRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofi, n) = avgRemovedIceRunoffFlux(i)
        endif
 
        if ( frazilIceActive ) then
@@ -4006,7 +3999,10 @@ contains
                                                    avgOceanSurfaceDOCSemiLabile, &
                                                    avgOceanSurfaceFeParticulate, &
                                                    avgOceanSurfaceFeDissolved, &
-                                                   ssh
+                                                   ssh, &
+                                                   avgLandIceFreshwaterFlux, &
+                                                   avgRemovedRiverRunoffFlux, &
+                                                   avgRemovedIceRunoffFlux
    
       real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                       avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -4076,11 +4072,11 @@ contains
          end if
 
         if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
-           call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
         endif
         if (config_remove_AIS_coupler_runoff) then
-           call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
-           call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
         endif
    
          ! BGC fields
@@ -4136,11 +4132,11 @@ contains
 
 !DC, blindly following pattern
             if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
-               o2x_om(n, index_o2x_Foxo_ismw)  = landIceFreshwaterFlux(i)
+               o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
             endif
             if (config_remove_AIS_coupler_runoff) then
-               o2x_om(n, index_o2x_Foxo_rrofl) = removedRiverRunoffFlux(i)
-               o2x_om(n, index_o2x_Foxo_rrofi) = removedIceRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofl) = avgRemovedRiverRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofi) = avgRemovedIceRunoffFlux(i)
             endif
 
             if ( frazilIceActive ) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2767,7 +2767,7 @@ contains
      end if
 
      ! Cryo fields
-     if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+     if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
         call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
      endif
      if (config_remove_AIS_coupler_runoff) then
@@ -2827,7 +2827,7 @@ contains
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
        ! Cryo fields
-       if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+       if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
           o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = avgLandIceFreshwaterFlux(i)
        endif
        if (config_remove_AIS_coupler_runoff) then
@@ -4071,7 +4071,7 @@ contains
             call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
          end if
 
-        if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+        if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
         endif
         if (config_remove_AIS_coupler_runoff) then
@@ -4131,7 +4131,7 @@ contains
             o2x_om(n, index_o2x_Faoo_h2otemp) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
 !DC, blindly following pattern
-            if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+            if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
                o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
             endif
             if (config_remove_AIS_coupler_runoff) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2694,7 +2694,10 @@ contains
                                                avgOceanSurfaceDOCSemiLabile, &
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved, &
-                                               ssh
+                                               ssh, &
+                                               landIceFreshwaterFlux, &
+                                               removedRiverRunoffFlux, &
+                                               removedIceRunoffFlux
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -2703,6 +2706,7 @@ contains
    real (kind=RKIND) :: surfaceFreezingTemp
 
    logical, pointer :: frazilIceActive,          &
+                       config_remove_AIS_coupler_runoff, &
                        config_use_ecosysTracers, &
                        config_use_DMSTracers,    &
                        config_use_MacroMoleculesTracers,  &
@@ -2719,6 +2723,7 @@ contains
    call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
    call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+   call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
    call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers', config_use_MacroMoleculesTracers)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers_sea_ice_coupling',  &
@@ -2760,6 +2765,15 @@ contains
         call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
         call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
      end if
+
+     !DC Cryo fields , 0 when data
+     if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+        call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+     endif
+     if (config_remove_AIS_coupler_runoff) then
+        call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+     endif
 
      ! BGC fields
      if (config_use_ecosysTracers) then
@@ -2811,6 +2825,15 @@ contains
        o2x_o % rAttr(index_o2x_So_dhdy, n) = avgSSHGradient(index_avgMeridionalSSHGradient, i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
+
+!DC landIceFreshwaterFlux seems to be 0 when data
+       if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = landIceFreshwaterFlux(i)
+       endif
+       if (config_remove_AIS_coupler_runoff) then
+          o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = removedRiverRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofi, n) = removedIceRunoffFlux(i)
+       endif
 
        if ( frazilIceActive ) then
           ! negative when frazil ice can be melted
@@ -3590,6 +3613,7 @@ contains
         endif
 
         if ( landIceFreshwaterFluxField % isActive ) then
+!DC is this ok with proposed implementation? think so since different coupling field
            !landIceFreshwaterFlux(i) = x2o_om(n, index_x2o_Fogx_qicelo)
         end if
         if ( landIceHeatFluxField % isActive ) then
@@ -3984,6 +4008,7 @@ contains
       real (kind=RKIND) :: surfaceFreezingTemp
    
       logical, pointer :: frazilIceActive,          &
+                           config_remove_AIS_coupler_runoff, &
                            config_use_ecosysTracers, &
                            config_use_DMSTracers,    &
                            config_use_MacroMoleculesTracers,  &
@@ -4000,6 +4025,7 @@ contains
       call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
       call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
       call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
       call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)
       call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers', config_use_MacroMoleculesTracers)
       call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers_sea_ice_coupling',  &
@@ -4041,6 +4067,14 @@ contains
             call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
             call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
          end if
+
+        if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+           call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+        endif
+        if (config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+        endif
    
          ! BGC fields
          if (config_use_ecosysTracers) then
@@ -4092,7 +4126,16 @@ contains
             o2x_om(n, index_o2x_So_dhdy) = avgSSHGradient(index_avgMeridionalSSHGradient, i)
    
             o2x_om(n, index_o2x_Faoo_h2otemp) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
-   
+
+!DC, blindly following pattern
+            if (config_land_ice_flux_mode == 'standalone' .or. 'data') then
+               o2x_om(n, index_o2x_Foxo_ismw)  = landIceFreshwaterFlux(i)
+            endif
+            if (config_remove_AIS_coupler_runoff) then
+               o2x_om(n, index_o2x_Foxo_rrofl) = removedRiverRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofi) = removedIceRunoffFlux(i)
+            endif
+
             if ( frazilIceActive ) then
                ! negative when frazil ice can be melted
                keepFrazil = .true.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3691,13 +3691,19 @@
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgLandIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
-			 description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+		         description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgLandIceHeatFlux" type="real" dimensions="nCells Time" units="J m^-2 s^-1"
+			 description="Time-averaged sum of heat fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgRemovedRiverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Time-averaged sum of freshwater fluxes associated with removed liquid runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgRemovedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Time-averaged sum of freshwater fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
+	        />
+		<var name="avgRemovedIceRunoffHeatFlux" type="real" dimensions="nCells Time" units="J m^-2 s^-1"
+			 description="Time-averaged sum of heat fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 
 		<!-- Input fields from coupler or initial condition for forcing under land ice -->

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3608,6 +3608,7 @@
 			 packages="activeTracersBulkRestoringPKG;thicknessBulkPKG"
 		/>
 
+
 		<!-- Misc. coupling fields -->
 		<var name="iceFraction" type="real" dimensions="nCells Time" units="fractional"
 			 description="Fraction of sea ice coverage at cell centers from coupler. Positive into the ocean."
@@ -3688,6 +3689,15 @@
 		</var_array>
 		<var name="avgTotalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgLandIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+			 description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgRemovedRiverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+			 description="Time-averaged sum of freshwater fluxes associated with removed liquid runoff fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgRemovedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+			 description="Time-averaged sum of freshwater fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 
 		<!-- Input fields from coupler or initial condition for forcing under land ice -->

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3693,7 +3693,7 @@
 		<var name="avgLandIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 		         description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
-		<var name="avgLandIceHeatFlux" type="real" dimensions="nCells Time" units="J m^-2 s^-1"
+		<var name="avgLandIceHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
 			 description="Time-averaged sum of heat fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgRemovedRiverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
@@ -3702,7 +3702,7 @@
 		<var name="avgRemovedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Time-averaged sum of freshwater fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 	        />
-		<var name="avgRemovedIceRunoffHeatFlux" type="real" dimensions="nCells Time" units="J m^-2 s^-1"
+		<var name="avgRemovedIceRunoffHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
 			 description="Time-averaged sum of heat fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 

--- a/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
@@ -129,43 +129,43 @@
 		<var name="relativeMassError" type="real" dimensions="Time" units="1"
 			description="Relative mass conservation error"
 		/>
-		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from rain from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from snow from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Evaporation flux from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from sea ice from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from river runoff from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from ice runoff from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from river runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from ice runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
 		/>
-		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from iceberg melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from frazil freezing under sea ice. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from land ice melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from frazil freezing under land ice. Positive into the ocean."
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
@@ -2432,7 +2432,8 @@ v=accumulatedLandIceFrazilSalinityFlux; write(m,"('LandIceFrazilSalinityFlux',es
       err = 0
 
       if ( trim(config_land_ice_flux_mode) == 'standalone' .or. &
-           trim(config_land_ice_flux_mode) == 'coupled' ) then
+           trim(config_land_ice_flux_mode) == 'coupled' .or. &
+           trim(config_land_ice_flux_mode) == 'data' ) then
          landIceFreshwaterFluxesOn = .true.
       end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -53,7 +53,9 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, avgSSHGradient, &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
 
-        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux
+        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux, &
+                                                    avgLandIceFreshwaterFlux, &
+                                                    avgRemovedRiverRunoffFlux, avgRemovedIceRunoffFlux
 
         integer :: iCell
         integer, pointer :: nAccumulatedCoupled, nCells
@@ -111,6 +113,33 @@ module ocn_time_average_coupled
               avgLandIceBoundaryLayerTracers(:, iCell) = 0.0_RKIND
               avgLandIceTracerTransferVelocities(:, iCell) = 0.0_RKIND
               avgEffectiveDensityInLandIce(iCell) = 0.0_RKIND
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        ! Set up polar fields if necessary
+        if(trim(config_land_ice_flux_mode)=='standalone' .or. 'data') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceFreshwaterFlux(iCell) = 0.0_RKIND
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        if(config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgRemovedRiverRunoffFlux(iCell) = 0.0_RKIND
+              avgRemovedIceRunoffFlux(iCell) = 0.0_RKIND
            end do
            !$omp end do
            !$omp end parallel
@@ -215,7 +244,10 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
-                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux
+                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux, &
+                                                    landIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
+                                                    removedRiverRunoffFlux, avgRemovedRiverRunoffFlux, &
+                                                    removedIceRunoffFlux, avgRemovedIceRunoffFlux
 
         type (mpas_pool_type), pointer :: tracersPool
 
@@ -309,6 +341,48 @@ module ocn_time_average_coupled
            end do
            !$omp end do
            !$omp end parallel
+        end if
+
+        ! Accumulate polar fields if necessary
+        if(trim(config_land_ice_flux_mode) == 'standalone' .or. 'data') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+
+           if(trim(config_land_ice_flux_mode) == 'standalone') then
+              call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+           endif
+
+          ! load data melt rates if used
+          if(trim(config_land_ice_flux_mode) == 'data') then
+            call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', landIceFreshwaterFlux)
+          endif
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
+                                              + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        if (config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgRemovedRiverRunoffFlux(iCell) = ( avgRemovedRiverRunoffFlux(iCell) * nAccumulatedCoupled &
+                                               + removedRiverRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgRemovedIceRunoffFlux(iCell) = ( avgRemovedIceRunoffFlux(iCell) * nAccumulatedCoupled &
+                                             + removedIceRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+
         end if
 
         !  accumulate BGC coupling fields if necessary

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -245,7 +245,7 @@ module ocn_time_average_coupled
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
                                                     totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux, &
-                                                    landIceFreshwaterFlux, dataLandIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
+                                                    landIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
                                                     removedRiverRunoffFlux, avgRemovedRiverRunoffFlux, &
                                                     removedIceRunoffFlux, avgRemovedIceRunoffFlux
 
@@ -346,34 +346,17 @@ module ocn_time_average_coupled
         ! Accumulate polar fields if necessary
         if(trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
 
-           ! load prognostic melt rates
-           if(trim(config_land_ice_flux_mode) == 'standalone') then
-              call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
+                                              + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
 
-             !$omp parallel
-             !$omp do schedule(runtime)
-             do iCell = 1, nCells
-                avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
-                                                + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
-             end do
-             !$omp end do
-             !$omp end parallel
-           end if
-
-           ! load data melt rates if used
-           if(trim(config_land_ice_flux_mode) == 'data') then
-             call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', dataLandIceFreshwaterFlux)
-
-              !$omp parallel
-              !$omp do schedule(runtime)
-              do iCell = 1, nCells
-                 avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
-                                                 + dataLandIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
-              end do
-              !$omp end do
-              !$omp end parallel
-           end if
         end if
 
         if (config_remove_AIS_coupler_runoff) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -119,7 +119,7 @@ module ocn_time_average_coupled
         end if
 
         ! Set up polar fields if necessary
-        if(trim(config_land_ice_flux_mode)=='standalone' .or. 'data') then
+        if(trim(config_land_ice_flux_mode)=='standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
 
            !$omp parallel
@@ -344,7 +344,7 @@ module ocn_time_average_coupled
         end if
 
         ! Accumulate polar fields if necessary
-        if(trim(config_land_ice_flux_mode) == 'standalone' .or. 'data') then
+        if(trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
 
            if(trim(config_land_ice_flux_mode) == 'standalone') then
@@ -353,7 +353,8 @@ module ocn_time_average_coupled
 
           ! load data melt rates if used
           if(trim(config_land_ice_flux_mode) == 'data') then
-            call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', landIceFreshwaterFlux)
+!            call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', landIceFreshwaterFlux)
+            call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
           endif
 
            !$omp parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -245,7 +245,7 @@ module ocn_time_average_coupled
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
                                                     totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux, &
-                                                    landIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
+                                                    landIceFreshwaterFlux, dataLandIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
                                                     removedRiverRunoffFlux, avgRemovedRiverRunoffFlux, &
                                                     removedIceRunoffFlux, avgRemovedIceRunoffFlux
 
@@ -347,24 +347,33 @@ module ocn_time_average_coupled
         if(trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
 
+           ! load prognostic melt rates
            if(trim(config_land_ice_flux_mode) == 'standalone') then
               call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-           endif
 
-          ! load data melt rates if used
-          if(trim(config_land_ice_flux_mode) == 'data') then
-!            call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', landIceFreshwaterFlux)
-            call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-          endif
+             !$omp parallel
+             !$omp do schedule(runtime)
+             do iCell = 1, nCells
+                avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
+                                                + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+             end do
+             !$omp end do
+             !$omp end parallel
+           end if
 
-           !$omp parallel
-           !$omp do schedule(runtime)
-           do iCell = 1, nCells
-              avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
-                                              + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
-           end do
-           !$omp end do
-           !$omp end parallel
+           ! load data melt rates if used
+           if(trim(config_land_ice_flux_mode) == 'data') then
+             call mpas_pool_get_array(forcingPool, 'dataLandIceFreshwaterFlux', dataLandIceFreshwaterFlux)
+
+              !$omp parallel
+              !$omp do schedule(runtime)
+              do iCell = 1, nCells
+                 avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
+                                                 + dataLandIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              end do
+              !$omp end do
+              !$omp end parallel
+           end if
         end if
 
         if (config_remove_AIS_coupler_runoff) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -55,7 +55,8 @@ module ocn_time_average_coupled
 
         real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux, &
                                                     avgLandIceFreshwaterFlux, &
-                                                    avgRemovedRiverRunoffFlux, avgRemovedIceRunoffFlux
+                                                    avgRemovedRiverRunoffFlux, avgRemovedIceRunoffFlux, &
+                                                    avgLandIceHeatFlux, avgRemovedIceRunoffHeatFlux
 
         integer :: iCell
         integer, pointer :: nAccumulatedCoupled, nCells
@@ -121,11 +122,13 @@ module ocn_time_average_coupled
         ! Set up polar fields if necessary
         if(trim(config_land_ice_flux_mode)=='standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
 
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgLandIceFreshwaterFlux(iCell) = 0.0_RKIND
+              avgLandIceHeatFlux(iCell) = 0.0_RKIND
            end do
            !$omp end do
            !$omp end parallel
@@ -134,12 +137,14 @@ module ocn_time_average_coupled
         if(config_remove_AIS_coupler_runoff) then
            call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
            call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
 
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgRemovedRiverRunoffFlux(iCell) = 0.0_RKIND
               avgRemovedIceRunoffFlux(iCell) = 0.0_RKIND
+              avgRemovedIceRunoffHeatFlux(iCell) = 0.0_RKIND
            end do
            !$omp end do
            !$omp end parallel
@@ -230,6 +235,9 @@ module ocn_time_average_coupled
 !
 !-----------------------------------------------------------------------
     subroutine ocn_time_average_coupled_accumulate(statePool, forcingPool, timeLevel)!{{{
+        use ocn_constants, only: &
+             latent_heat_fusion_mks
+
         type (mpas_pool_type), intent(in) :: statePool
         type (mpas_pool_type), intent(inout) :: forcingPool
         integer, intent(in) :: timeLevel
@@ -246,8 +254,10 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
                                                     totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux, &
                                                     landIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
+                                                    landIceHeatFlux, avgLandIceHeatFlux, &
                                                     removedRiverRunoffFlux, avgRemovedRiverRunoffFlux, &
-                                                    removedIceRunoffFlux, avgRemovedIceRunoffFlux
+                                                    removedIceRunoffFlux, avgRemovedIceRunoffFlux, &
+                                                    avgRemovedIceRunoffHeatFlux
 
         type (mpas_pool_type), pointer :: tracersPool
 
@@ -347,12 +357,16 @@ module ocn_time_average_coupled
         if(trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
            call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
+           call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
 
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
                                               + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgLandIceHeatFlux(iCell) = ( avgLandIceHeatFlux(iCell) * nAccumulatedCoupled &
+                                        + landIceHeatFlux(iCell) ) / ( nAccumulatedCoupled + 1)
            end do
            !$omp end do
            !$omp end parallel
@@ -362,6 +376,7 @@ module ocn_time_average_coupled
         if (config_remove_AIS_coupler_runoff) then
            call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
            call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
            call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
            call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
 
@@ -372,6 +387,8 @@ module ocn_time_average_coupled
                                                + removedRiverRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
               avgRemovedIceRunoffFlux(iCell) = ( avgRemovedIceRunoffFlux(iCell) * nAccumulatedCoupled &
                                              + removedIceRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgRemovedIceRunoffHeatFlux(iCell) = ( avgRemovedIceRunoffHeatFlux(iCell) * nAccumulatedCoupled &
+                                             + removedIceRunoffFlux(iCell)*latent_heat_fusion_mks ) / ( nAccumulatedCoupled + 1)
            end do
            !$omp end do
            !$omp end parallel

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1345,7 +1345,7 @@ contains
     integer(in)              :: kArea        ! index of area field in aVect
     integer(in)              :: ko,ki  ! fraction indices
     integer(in)              :: lSize        ! size of aVect
-    real(r8)                 :: ca_i,ca_o  ! area of a grid cell
+    real(r8)                 :: ca_i,ca_o,ca_c  ! area of a grid cell
     logical,save             :: first_time    = .true.
     logical,save             :: flds_wiso_ocn = .false.
 
@@ -1391,13 +1391,14 @@ contains
        do n=1,lSize
           ca_o =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
+          ca_c =  dom_o%data%rAttr(kArea,n) !DC area including ice-shelf cavities
           nf = f_area; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
 !DC do we need only ca_o, if use P above?
 !          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! gives 0, different scaling?
-          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! gives values orders of magnitude too high
+          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! think this is right scaling
           nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
           nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
        end do

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -144,32 +144,35 @@ module seq_diag_mct
   integer(in),parameter :: f_wmelt     =14     ! water: melting
   integer(in),parameter :: f_wrain     =15     ! water: precip, liquid
   integer(in),parameter :: f_wsnow     =16     ! water: precip, frozen
-  integer(in),parameter :: f_wberg     =17     ! water: data icebergs
-  integer(in),parameter :: f_wevap     =18     ! water: evaporation
-  integer(in),parameter :: f_wroff     =19     ! water: runoff/flood
-  integer(in),parameter :: f_wioff     =20     ! water: frozen runoff
-  integer(in),parameter :: f_wirrig    =21     ! water: irrigation
-  integer(in),parameter :: f_wfrz_16O  =22     ! water: freezing
-  integer(in),parameter :: f_wmelt_16O =23     ! water: melting
-  integer(in),parameter :: f_wrain_16O =24     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_16O =25     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_16O =26     ! water: evaporation
-  integer(in),parameter :: f_wroff_16O =27     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_16O =28     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_18O  =29     ! water: freezing
-  integer(in),parameter :: f_wmelt_18O =30     ! water: melting
-  integer(in),parameter :: f_wrain_18O =31     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_18O =32     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_18O =33     ! water: evaporation
-  integer(in),parameter :: f_wroff_18O =34     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_18O =35     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_HDO  =36     ! water: freezing
-  integer(in),parameter :: f_wmelt_HDO =37     ! water: melting
-  integer(in),parameter :: f_wrain_HDO =38     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_HDO =39     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_HDO =40     ! water: evaporation
-  integer(in),parameter :: f_wroff_HDO =41     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_HDO =42     ! water: frozen runoff
+  integer(in),parameter :: f_wevap     =17     ! water: evaporation
+  integer(in),parameter :: f_wroff     =18     ! water: runoff/flood
+  integer(in),parameter :: f_wioff     =19     ! water: frozen runoff
+  integer(in),parameter :: f_wberg     =20     ! water: data icebergs
+  integer(in),parameter :: f_wism      =21     ! water: ice-shelf melt
+  integer(in),parameter :: f_wrrof     =22     ! water: removed liquid runoff
+  integer(in),parameter :: f_wriof     =23     ! water: removed ice runoff
+  integer(in),parameter :: f_wirrig    =24     ! water: irrigation
+  integer(in),parameter :: f_wfrz_16O  =25     ! water: freezing
+  integer(in),parameter :: f_wmelt_16O =26     ! water: melting
+  integer(in),parameter :: f_wrain_16O =27     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_16O =28     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_16O =29     ! water: evaporation
+  integer(in),parameter :: f_wroff_16O =30     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_16O =31     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_18O  =32     ! water: freezing
+  integer(in),parameter :: f_wmelt_18O =33     ! water: melting
+  integer(in),parameter :: f_wrain_18O =34     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_18O =35     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_18O =36     ! water: evaporation
+  integer(in),parameter :: f_wroff_18O =37     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_18O =38     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_HDO  =39     ! water: freezing
+  integer(in),parameter :: f_wmelt_HDO =40     ! water: melting
+  integer(in),parameter :: f_wrain_HDO =41     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_HDO =42     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_HDO =43     ! water: evaporation
+  integer(in),parameter :: f_wroff_HDO =44     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_HDO =45     ! water: frozen runoff
 
   integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
   integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -190,7 +193,8 @@ module seq_diag_mct
        (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
        '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
        '       hberg','    hh2otemp','     wfreeze','       wmelt','       wrain', &
-       '       wsnow','       wberg','       wevap','     wrunoff','     wfrzrof', &
+       '       wsnow','       wevap','     wrunoff','     wfrzrof',                &
+       '       wberg','        wism','       wrrof','       wriof',                &
        '      wirrig',                                                             &
        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O',                &
        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O',                               &
@@ -287,6 +291,10 @@ module seq_diag_mct
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
   integer :: index_o2x_Fioo_q
+!DC - do we want P in front of these fields?
+  integer :: index_o2x_Foxo_ismw
+  integer :: index_o2x_Foxo_rrofl
+  integer :: index_o2x_Foxo_rrofi
 
   integer :: index_xao_Faox_lwup
   integer :: index_xao_Faox_lat
@@ -1373,6 +1381,9 @@ contains
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
+          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'PFoxo_ismw')
+          index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl')
+          index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi')
        end if
 
        lSize = mct_avect_lSize(o2x_o)
@@ -1384,6 +1395,11 @@ contains
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
+!DC do we need only ca_o, if use P above?
+!          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! gives 0, different scaling?
+          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! gives values orders of magnitude too high
+          nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
+          nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
        end do
     end if
 
@@ -1495,6 +1511,10 @@ contains
           nf = f_wrain ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
           nf = f_wsnow ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_snow,n)
           nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+!DC new entries should not be here, done above with o2x
+!          nf = f_wism  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+!          nf = f_wrrof ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+!          nf = f_wriof ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
           nf = f_wroff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofl,n)
           nf = f_wioff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofi,n)
 
@@ -1652,6 +1672,7 @@ contains
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
           nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
+!DC propose removing wberg from ice entry
           nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
 

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -139,40 +139,42 @@ module seq_diag_mct
   integer(in),parameter :: f_hioff     = 9     ! heat : latent, fusion, frozen runoff
   integer(in),parameter :: f_hsen      =10     ! heat : sensible
   integer(in),parameter :: f_hberg     =11     ! heat : data icebergs
-  integer(in),parameter :: f_hh2ot     =12     ! heat : water temperature
-  integer(in),parameter :: f_wfrz      =13     ! water: freezing
-  integer(in),parameter :: f_wmelt     =14     ! water: melting
-  integer(in),parameter :: f_wrain     =15     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow     =16     ! water: precip, frozen
-  integer(in),parameter :: f_wevap     =17     ! water: evaporation
-  integer(in),parameter :: f_wroff     =18     ! water: runoff/flood
-  integer(in),parameter :: f_wioff     =19     ! water: frozen runoff
-  integer(in),parameter :: f_wberg     =20     ! water: data icebergs
-  integer(in),parameter :: f_wism      =21     ! water: ice-shelf melt
-  integer(in),parameter :: f_wrrof     =22     ! water: removed liquid runoff
-  integer(in),parameter :: f_wriof     =23     ! water: removed ice runoff
-  integer(in),parameter :: f_wirrig    =24     ! water: irrigation
-  integer(in),parameter :: f_wfrz_16O  =25     ! water: freezing
-  integer(in),parameter :: f_wmelt_16O =26     ! water: melting
-  integer(in),parameter :: f_wrain_16O =27     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_16O =28     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_16O =29     ! water: evaporation
-  integer(in),parameter :: f_wroff_16O =30     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_16O =31     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_18O  =32     ! water: freezing
-  integer(in),parameter :: f_wmelt_18O =33     ! water: melting
-  integer(in),parameter :: f_wrain_18O =34     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_18O =35     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_18O =36     ! water: evaporation
-  integer(in),parameter :: f_wroff_18O =37     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_18O =38     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_HDO  =39     ! water: freezing
-  integer(in),parameter :: f_wmelt_HDO =40     ! water: melting
-  integer(in),parameter :: f_wrain_HDO =41     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_HDO =42     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_HDO =43     ! water: evaporation
-  integer(in),parameter :: f_wroff_HDO =44     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_HDO =45     ! water: frozen runoff
+  integer(in),parameter :: f_hism      =12     ! heat : ice shelf melt
+  integer(in),parameter :: f_hriof     =13     ! heat : data icebergs
+  integer(in),parameter :: f_hh2ot     =14     ! heat : water temperature
+  integer(in),parameter :: f_wfrz      =15     ! water: freezing
+  integer(in),parameter :: f_wmelt     =16     ! water: melting
+  integer(in),parameter :: f_wrain     =17     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow     =18     ! water: precip, frozen
+  integer(in),parameter :: f_wevap     =19     ! water: evaporation
+  integer(in),parameter :: f_wroff     =20     ! water: runoff/flood
+  integer(in),parameter :: f_wioff     =21     ! water: frozen runoff
+  integer(in),parameter :: f_wberg     =22     ! water: data icebergs
+  integer(in),parameter :: f_wism      =23     ! water: ice-shelf melt
+  integer(in),parameter :: f_wrrof     =24     ! water: removed liquid runoff
+  integer(in),parameter :: f_wriof     =25     ! water: removed ice runoff
+  integer(in),parameter :: f_wirrig    =26     ! water: irrigation
+  integer(in),parameter :: f_wfrz_16O  =27     ! water: freezing
+  integer(in),parameter :: f_wmelt_16O =28     ! water: melting
+  integer(in),parameter :: f_wrain_16O =29     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_16O =30     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_16O =31     ! water: evaporation
+  integer(in),parameter :: f_wroff_16O =32     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_16O =33     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_18O  =34     ! water: freezing
+  integer(in),parameter :: f_wmelt_18O =35     ! water: melting
+  integer(in),parameter :: f_wrain_18O =36     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_18O =37     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_18O =38     ! water: evaporation
+  integer(in),parameter :: f_wroff_18O =39     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_18O =40     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_HDO  =41     ! water: freezing
+  integer(in),parameter :: f_wmelt_HDO =42     ! water: melting
+  integer(in),parameter :: f_wrain_HDO =43     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_HDO =44     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_HDO =45     ! water: evaporation
+  integer(in),parameter :: f_wroff_HDO =46     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_HDO =47     ! water: frozen runoff
 
   integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
   integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -192,7 +194,8 @@ module seq_diag_mct
 
        (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
        '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
-       '       hberg','    hh2otemp','     wfreeze','       wmelt','       wrain', &
+       '       hberg','        hism','       hriof',                               &
+       '    hh2otemp','     wfreeze','       wmelt','       wrain',                &
        '       wsnow','       wevap','     wrunoff','     wfrzrof',                &
        '       wberg','        wism','       wrrof','       wriof',                &
        '      wirrig',                                                             &
@@ -291,10 +294,12 @@ module seq_diag_mct
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
   integer :: index_o2x_Fioo_q
-!DC - do we want P in front of these fields?
+
   integer :: index_o2x_Foxo_ismw
   integer :: index_o2x_Foxo_rrofl
   integer :: index_o2x_Foxo_rrofi
+  integer :: index_o2x_Foxo_ismh
+  integer :: index_o2x_Foxo_rrofih
 
   integer :: index_xao_Faox_lwup
   integer :: index_xao_Faox_lat
@@ -1384,6 +1389,8 @@ contains
           index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw')
           index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl')
           index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi')
+          index_o2x_Foxo_ismh  = mct_aVect_indexRA(o2x_o,'Foxo_ismh')
+          index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih')
        end if
 
        lSize = mct_avect_lSize(o2x_o)
@@ -1401,6 +1408,8 @@ contains
           nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! think this is right scaling
           nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
           nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n) ! think this is right scaling
+          nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
        end do
     end if
 
@@ -1512,10 +1521,6 @@ contains
           nf = f_wrain ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
           nf = f_wsnow ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_snow,n)
           nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
-!DC new entries should not be here, done above with o2x
-!          nf = f_wism  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
-!          nf = f_wrrof ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
-!          nf = f_wriof ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
           nf = f_wroff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofl,n)
           nf = f_wioff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofi,n)
 
@@ -1671,7 +1676,7 @@ contains
           nf = f_hlwup ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lwup,n)
           nf = f_hlatv ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lat,n)
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
-          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
+!          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
 !DC propose removing wberg from ice entry
 !          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1398,17 +1398,15 @@ contains
        do n=1,lSize
           ca_o =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
-          ca_c =  dom_o%data%rAttr(kArea,n) !DC area including ice-shelf cavities
+          ca_c =  dom_o%data%rAttr(kArea,n)
           nf = f_area; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
-!DC do we need only ca_o, if use P above?
-!          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! gives 0, different scaling?
-          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n) ! think this is right scaling
+          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
           nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
           nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n) ! think this is right scaling
+          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
           nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
        end do
     end if
@@ -1639,8 +1637,8 @@ contains
     if (present(do_i2x)) then
        index_i2x_Fioi_melth  = mct_aVect_indexRA(i2x_i,'Fioi_melth')
        index_i2x_Fioi_meltw  = mct_aVect_indexRA(i2x_i,'Fioi_meltw')
-       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh')
-       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw')
+!       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh')
+!       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw')
        index_i2x_Fioi_swpen  = mct_aVect_indexRA(i2x_i,'Fioi_swpen')
        index_i2x_Faii_swnet  = mct_aVect_indexRA(i2x_i,'Faii_swnet')
        index_i2x_Faii_lwup   = mct_aVect_indexRA(i2x_i,'Faii_lwup')
@@ -1678,7 +1676,6 @@ contains
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
 !          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
-!DC propose removing wberg from ice entry
 !          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
 

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1381,7 +1381,7 @@ contains
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
-          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'PFoxo_ismw')
+          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw')
           index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl')
           index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi')
        end if

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1674,7 +1674,7 @@ contains
           nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
 !DC propose removing wberg from ice entry
-          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
+!          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
 
           if ( flds_wiso_ice )then

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1584,7 +1584,7 @@ contains
     call metadata_set(attname, longname, stdname, units)
 !DC ismw needs P, removed runoff terms do not
     ! Water flux from ice shelf melt
-    call seq_flds_add(o2x_fluxes,"PFoxo_ismw")
+    call seq_flds_add(o2x_fluxes,"Foxo_ismw")
     longname = 'Water flux due to basal melting of ice shelves'
     stdname  = 'basal_iceshelf_melt_flux'
     units    = 'kg m-2 s-1'

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1595,7 +1595,7 @@ contains
     call seq_flds_add(o2x_fluxes,"Foxo_ismh")
     longname = 'Heat flux due to basal melting of ice shelves'
     stdname  = 'basal_iceshelf_heat_flux'
-    units    = 'J m-2 s-1'
+    units    = 'W m-2'
     attname  = 'Foxo_ismh'
     call metadata_set(attname, longname, stdname, units)
 
@@ -1619,7 +1619,7 @@ contains
     call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
     longname = 'Heat flux due to removed solid runoff'
     stdname  = 'removed_solid_runoff_heat_flux'
-    units    = 'J m-2 s-1'
+    units    = 'W m-2'
     attname  = 'Foxo_rrofih'
     call metadata_set(attname, longname, stdname, units)
 

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1582,13 +1582,21 @@ contains
     units    = 'kg m-2 s-1'
     attname  = 'PFioi_bergw'
     call metadata_set(attname, longname, stdname, units)
-!DC ismw needs P, removed runoff terms do not
+
     ! Water flux from ice shelf melt
     call seq_flds_add(o2x_fluxes,"Foxo_ismw")
     longname = 'Water flux due to basal melting of ice shelves'
     stdname  = 'basal_iceshelf_melt_flux'
     units    = 'kg m-2 s-1'
     attname  = 'Foxo_ismw'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Heat flux from ice shelf melt
+    call seq_flds_add(o2x_fluxes,"Foxo_ismh")
+    longname = 'Heat flux due to basal melting of ice shelves'
+    stdname  = 'basal_iceshelf_heat_flux'
+    units    = 'J m-2 s-1'
+    attname  = 'Foxo_ismh'
     call metadata_set(attname, longname, stdname, units)
 
     ! Water flux from removed liquid runoff
@@ -1605,6 +1613,14 @@ contains
     stdname  = 'removed_solid_runoff_flux'
     units    = 'kg m-2 s-1'
     attname  = 'Foxo_rrofi'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Heat flux from removed solid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
+    longname = 'Heat flux due to removed solid runoff'
+    stdname  = 'removed_solid_runoff_heat_flux'
+    units    = 'J m-2 s-1'
+    attname  = 'Foxo_rrofih'
     call metadata_set(attname, longname, stdname, units)
 
     ! Salt flux

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1582,6 +1582,30 @@ contains
     units    = 'kg m-2 s-1'
     attname  = 'PFioi_bergw'
     call metadata_set(attname, longname, stdname, units)
+!DC ismw needs P, removed runoff terms do not
+    ! Water flux from ice shelf melt
+    call seq_flds_add(o2x_fluxes,"PFoxo_ismw")
+    longname = 'Water flux due to basal melting of ice shelves'
+    stdname  = 'basal_iceshelf_melt_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_ismw'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Water flux from removed liquid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofl")
+    longname = 'Water flux due to removed liqiud runoff'
+    stdname  = 'removed_liquid_runoff_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_rrofl'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Water flux from removed solid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
+    longname = 'Water flux due to removed solid runoff'
+    stdname  = 'removed_solid_runoff_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_rrofi'
+    call metadata_set(attname, longname, stdname, units)
 
     ! Salt flux
     call seq_flds_add(i2x_fluxes,"Fioi_salt")


### PR DESCRIPTION
Adds five new o2x coupling fields and terms to coupler budget for polar configurations:

`wism` - water from ice shelf basal melting (either prognostic or data)
`wrrof` - water removed from Antarctica liquid runoff
`wriof` - water removed from Antarctica solid runoff

`hism` - heat from ice shelf basal melting
`hriof` - heat from removed ice runoff
