### PR TITLE
Add a CRYO1850 test to the e3sm_integration suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -305,6 +305,8 @@ _TESTS = {
             "SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850",
             "SMS_Ln5.ne30pg2_ne30pg2.F2010-SCREAM-LR-DYAMOND2",
             "ERS_Ld3.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-nlmaps",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF",
             )
         },
 


### PR DESCRIPTION
We want a new `CRYO1850` test with the `IcoswISC30E3r5` in part because this configuration is currently broken.  Once we get it fixed, we'd like to make sure it doesn't get broken again.