### PR TITLE
Add new NARRM14to30E3r1 and NARRM14to30E3r2 ocean and sea-ice meshes

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5278,8 +5278,8 @@
     </gridmap>
 
     <gridmap ocn_grid="NARRM14to30E3r1" rof_grid="r025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240320.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240320.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -406,6 +406,16 @@
       <mask>IcoswISC30E3r5</mask>
     </model_grid>
 
+    <model_grid alias="T62_NARRM14to30E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">NARRM14to30E3r1</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NARRM14to30E3r1</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -604,6 +614,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>IcosXISC30E3r7</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_NARRM14to30E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">NARRM14to30E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NARRM14to30E3r1</mask>
     </model_grid>
 
     <model_grid alias="TL319_oRRS18to6v3" compset="(DATM|XATM|SATM)">
@@ -1100,6 +1120,16 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="northamericax4v1pg2_r025_NARRM14to30E3r1" compset="(DOCN|XOCN|SOCN|AQP1|EAM.+ELM.+MPASO)">
+      <grid name="atm">ne0np4_northamericax4v1.pg2</grid>
+      <grid name="lnd">r025</grid>
+      <grid name="ocnice">NARRM14to30E3r1</grid>
+      <grid name="rof">r025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NARRM14to30E3r1</mask>
+    </model_grid>
+
     <model_grid alias="northamericax4v1pg2_WC14to60E2r3" compset="(DOCN|EAM.+ELM.+MPASO)">
       <grid name="atm">ne0np4_northamericax4v1.pg2</grid>
       <grid name="lnd">ne0np4_northamericax4v1.pg2</grid>
@@ -1328,6 +1358,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg2_NARRM14to30E3r1">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">NARRM14to30E3r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NARRM14to30E3r1</mask>
     </model_grid>
 
     <model_grid alias="northamericax4v1_r0125_northamericax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -2271,6 +2311,16 @@
       <mask>IcosXISC30E3r7</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_r05_NARRM14to30E3r1">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">NARRM14to30E3r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NARRM14to30E3r1</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_r05_WC14to60E2r3">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -2581,6 +2631,7 @@
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E2r4.210119.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_IcoswISC30E3r5.231121.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_NARRM14to30E3r1.240228.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2635,6 +2686,8 @@
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm|lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcosXISC30E3r7.240326.nc</file>
       <file grid="ice|ocn" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_IcosXISC30E3r7.240326.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_NARRM14to30E3r1.240228.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_NARRM14to30E3r1.240228.nc</file>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oRRS18to6v3.220124.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oRRS18to6v3.220124.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
@@ -2746,6 +2799,8 @@
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm|lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_IcosXISC30E3r7.240326.nc</file>
       <file grid="ice|ocn" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_IcosXISC30E3r7.240326.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_NARRM14to30E3r1.240228.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_NARRM14to30E3r1.240228.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -3055,6 +3110,13 @@
       <desc>IcosXISC30E3r7 is a MPAS ocean grid generated with the jigsaw/compass process using a dual mesh that is a subdivided icosahedron, resulting in a nearly uniform resolution of 30 km.:</desc>
     </domain>
 
+    <domain name="NARRM14to30E3r1">
+      <nx>662141</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.NARRM14to30E3r1.240228.nc</file>
+      <desc>NARRM14to30E3r1 is a MPAS ocean grid generated with the jigsaw/compass process XXXX TODO:</desc>
+    </domain>
+
     <!-- ROF (river) grids-->
 
     <domain name="r2">
@@ -3089,6 +3151,8 @@
       <file grid="lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcosXISC30E3r7.240326.nc</file>
       <file grid="lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcosXISC30E3r7.240326.nc</file>
+      <file grid="atm" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240228.nc</file>
+      <file grid="lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240228.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3254,6 +3318,8 @@
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_EC30to60E2r2.220428.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.northamericax4v1pg2_IcoswISC30E3r5.240416.nc</file>
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_IcoswISC30E3r5.240416.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.northamericax4v1pg2_NARRM14to30E3r1.240304.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_NARRM14to30E3r1.240304.nc</file>
       <desc>1-deg with 1/4-deg over North America (version 1) pg2:</desc>
     </domain>
 
@@ -3577,6 +3643,16 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcosXISC30E3r7/map_IcosXISC30E3r7_to_ne30pg2_traave.20240326.nc</map>
       <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcosXISC30E3r7_trfvnp2.20240326.nc</map>
       <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcosXISC30E3r7_trfvnp2.20240326.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="NARRM14to30E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_traave.20240228.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240228.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240228.nc</map>
+      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240228.nc</map>
+      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240228.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -4075,6 +4151,16 @@
       <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_IcoswISC30E3r5_trfvnp2.20240331.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne0np4_northamericax4v1.pg2" ocn_grid="NARRM14to30E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_traave.20240304.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240304.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240304.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240304.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240304.nc</map>
+      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240304.nc</map>
+      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240304.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne0np4_northamericax4v1.pg2" lnd_grid="r0125">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_r0125_mono.20200401.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_r0125_bilin.20200401.nc</map>
@@ -4346,6 +4432,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_T62_traave.20231121.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="NARRM14to30E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_traave.20240228.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_esmfpatch.20240228.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240228.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240228.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
@@ -4480,6 +4574,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_IcosXISC30E3r7_esmfpatch.20240326.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/IcosXISC30E3r7/map_IcosXISC30E3r7_to_TL319_traave.20240326.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcosXISC30E3r7/map_IcosXISC30E3r7_to_TL319_traave.20240326.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="NARRM14to30E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_traave.20240228.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_esmfpatch.20240228.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240228.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240228.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oRRS18to6v3">
@@ -4862,6 +4964,14 @@
       <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/IcosXISC30E3r7/map_IcosXISC30E3r7_to_r05_traave.20240326.nc</map>
     </gridmap>
 
+    <gridmap rof_grid="r05" ocn_grid="NARRM14to30E3r1">
+      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r05_traave.20240228.nc</map>
+    </gridmap>
+
+    <gridmap rof_grid="r025" ocn_grid="NARRM14to30E3r1">
+      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r025_traave.20240304.nc</map>
+    </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="EC30to60E2r2">
       <map name="OCN2ROF_SMAPNAME">cpl/cpl6/map_EC30to60E2r2_to_r05_neareststod.220728.nc</map>
     </gridmap>
@@ -4972,6 +5082,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_IcoswISC30E3r5_cstmnn.r150e300.20231121.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="NARRM14to30E3r1" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
@@ -5055,6 +5170,11 @@
     <gridmap ocn_grid="IcosXISC30E3r7" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_IcosXISC30E3r7_cstmnn.r150e300.20240326.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_IcosXISC30E3r7_cstmnn.r150e300.20240326.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="NARRM14to30E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oRRS18to6v3" rof_grid="JRA025">
@@ -5150,6 +5270,16 @@
     <gridmap ocn_grid="IcoswISC30E3r5" rof_grid="r025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_IcoswISC30E3r5_cstmnn.r150e300.20240401.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_IcoswISC30E3r5_cstmnn.r150e300.20240401.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="NARRM14to30E3r1" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="NARRM14to30E3r1" rof_grid="r025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_NARRM14to30E3r1_cstmnn.r150e300.20240228.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">
@@ -5363,21 +5493,21 @@
     <!-- ====================    -->
     <!-- GLC: mpas.gis1to10kmR2  -->
     <!-- ====================    -->
-      
+
     <gridmap glc_grid="mpas.gis1to10kmR2" lnd_grid="r05">
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r05/map_r05_to_gis1to10kmR2_traave.20240403.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/map_r05_to_gis1to10kmR2_trbilin.20240403.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r05_traave.20240403.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r05_traave.20240403.nc</map>
     </gridmap>
- 
+
     <gridmap glc_grid="mpas.gis1to10kmR2" lnd_grid="ne30np4.pg2">
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10kmR2_traave.20240403.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis1to10kmR2_trbilin.20240403.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_ne30pg2_traave.20240403.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_ne30pg2_traave.20240403.nc</map>
     </gridmap>
- 
+
     <gridmap glc_grid="mpas.gis1to10kmR2" lnd_grid="TL319">
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_gis1to10kmR2_traave.20240404.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_gis1to10kmR2_trbilin.20240404.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2631,7 +2631,7 @@
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E2r4.210119.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_IcoswISC30E3r5.231121.nc</file>
-      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_NARRM14to30E3r1.240228.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_NARRM14to30E3r1.240326.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2686,8 +2686,8 @@
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm|lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcosXISC30E3r7.240326.nc</file>
       <file grid="ice|ocn" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_IcosXISC30E3r7.240326.nc</file>
-      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_NARRM14to30E3r1.240228.nc</file>
-      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_NARRM14to30E3r1.240228.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_NARRM14to30E3r1.240326.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_NARRM14to30E3r1.240326.nc</file>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oRRS18to6v3.220124.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oRRS18to6v3.220124.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
@@ -2799,8 +2799,8 @@
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm|lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_IcosXISC30E3r7.240326.nc</file>
       <file grid="ice|ocn" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_IcosXISC30E3r7.240326.nc</file>
-      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_NARRM14to30E3r1.240228.nc</file>
-      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_NARRM14to30E3r1.240228.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_NARRM14to30E3r1.240326.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_NARRM14to30E3r1.240326.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -3113,7 +3113,7 @@
     <domain name="NARRM14to30E3r1">
       <nx>662141</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.NARRM14to30E3r1.240228.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.NARRM14to30E3r1.240326.nc</file>
       <desc>NARRM14to30E3r1 is a MPAS ocean grid generated with the jigsaw/compass process XXXX TODO:</desc>
     </domain>
 
@@ -3151,8 +3151,8 @@
       <file grid="lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcoswISC30E3r5.231121.nc</file>
       <file grid="atm" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcosXISC30E3r7.240326.nc</file>
       <file grid="lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcosXISC30E3r7.240326.nc</file>
-      <file grid="atm" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240228.nc</file>
-      <file grid="lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240228.nc</file>
+      <file grid="atm" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240326.nc</file>
+      <file grid="lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_NARRM14to30E3r1.240326.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3318,8 +3318,8 @@
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_EC30to60E2r2.220428.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.northamericax4v1pg2_IcoswISC30E3r5.240416.nc</file>
       <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_IcoswISC30E3r5.240416.nc</file>
-      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.northamericax4v1pg2_NARRM14to30E3r1.240304.nc</file>
-      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_NARRM14to30E3r1.240304.nc</file>
+      <file grid="atm|lnd" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.northamericax4v1pg2_NARRM14to30E3r1.240326.nc</file>
+      <file grid="ice|ocn" mask="NARRM14to30E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.northamericax4v1pg2_NARRM14to30E3r1.240326.nc</file>
       <desc>1-deg with 1/4-deg over North America (version 1) pg2:</desc>
     </domain>
 
@@ -3646,13 +3646,13 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="NARRM14to30E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_traave.20240228.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240228.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240228.nc</map>
-      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240228.nc</map>
-      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240228.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_traave.20240326.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240326.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_ne30pg2_traave.20240326.nc</map>
+      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240326.nc</map>
+      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_NARRM14to30E3r1_trfvnp2.20240326.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -4152,13 +4152,13 @@
     </gridmap>
 
     <gridmap atm_grid="ne0np4_northamericax4v1.pg2" ocn_grid="NARRM14to30E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_traave.20240304.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240304.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240304.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240304.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240304.nc</map>
-      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240304.nc</map>
-      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240304.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_traave.20240326.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240326.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_northamericax4v1pg2_traave.20240326.nc</map>
+      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240326.nc</map>
+      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/northamericax4v1np4/map_northamericax4v1pg2_to_NARRM14to30E3r1_trfvnp2.20240326.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_northamericax4v1.pg2" lnd_grid="r0125">
@@ -4433,11 +4433,11 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="NARRM14to30E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_traave.20240228.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_esmfpatch.20240228.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240228.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240228.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_traave.20240326.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_NARRM14to30E3r1_esmfpatch.20240326.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240326.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_T62_traave.20240326.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
@@ -4577,11 +4577,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="NARRM14to30E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_traave.20240228.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_trbilin.20240228.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_esmfpatch.20240228.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240228.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240228.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_traave.20240326.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_trbilin.20240326.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_NARRM14to30E3r1_esmfpatch.20240326.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240326.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_TL319_traave.20240326.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oRRS18to6v3">
@@ -4965,11 +4965,11 @@
     </gridmap>
 
     <gridmap rof_grid="r05" ocn_grid="NARRM14to30E3r1">
-      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r05_traave.20240228.nc</map>
+      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r05_traave.20240326.nc</map>
     </gridmap>
 
     <gridmap rof_grid="r025" ocn_grid="NARRM14to30E3r1">
-      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r025_traave.20240304.nc</map>
+      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/NARRM14to30E3r1/map_NARRM14to30E3r1_to_r025_traave.20240326.nc</map>
     </gridmap>
 
     <gridmap rof_grid="r05" ocn_grid="EC30to60E2r2">

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1423,7 +1423,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10,IcoswISC30E3r5,IcosXISC30E3r7">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10,IcoswISC30E3r5,IcosXISC30E3r7,NARRM14to30E3r1,NARRM14to30E3r2">
 Land mask description
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -54,6 +54,8 @@
 <config_dt ocn_grid="FRISwISC04to60E3r1">'00:04:00'</config_dt>
 <config_dt ocn_grid="FRISwISC02to60E3r1">'00:02:00'</config_dt>
 <config_dt ocn_grid="FRISwISC01to60E3r1">'00:01:00'</config_dt>
+<config_dt ocn_grid="NARRM14to30E3r1">'00:10:00'</config_dt>
+<config_dt ocn_grid="NARRM14to30E3r2">'00:10:00'</config_dt>
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
@@ -83,6 +85,8 @@
 <config_hmix_scaleWithMesh ocn_grid="FRISwISC04to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="FRISwISC02to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="FRISwISC01to60E3r1">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="NARRM14to30E3r1">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="NARRM14to30E3r2">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -104,6 +108,8 @@
 <config_use_mom_del2 ocn_grid="FRISwISC04to60E3r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="FRISwISC02to60E3r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="FRISwISC01to60E3r1">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="NARRM14to30E3r1">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="NARRM14to30E3r2">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
@@ -119,6 +125,8 @@
 <config_mom_del2 ocn_grid="FRISwISC04to60E3r1">154.0</config_mom_del2>
 <config_mom_del2 ocn_grid="FRISwISC02to60E3r1">77.0</config_mom_del2>
 <config_mom_del2 ocn_grid="FRISwISC01to60E3r1">38.5</config_mom_del2>
+<config_mom_del2 ocn_grid="NARRM14to30E3r1">462.0</config_mom_del2>
+<config_mom_del2 ocn_grid="NARRM14to30E3r2">462.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -149,6 +157,8 @@
 <config_mom_del4 ocn_grid="FRISwISC04to60E3r1">4.37e08</config_mom_del4>
 <config_mom_del4 ocn_grid="FRISwISC02to60E3r1">5.46e07</config_mom_del4>
 <config_mom_del4 ocn_grid="FRISwISC01to60E3r1">6.83e06</config_mom_del4>
+<config_mom_del4 ocn_grid="NARRM14to30E3r1">1.18e10</config_mom_del4>
+<config_mom_del4 ocn_grid="NARRM14to30E3r2">1.18e10</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -215,6 +225,8 @@
 <config_GM_closure ocn_grid="FRISwISC04to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_closure ocn_grid="FRISwISC02to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_closure ocn_grid="FRISwISC01to60E3r1">'N2_dependent'</config_GM_closure>
+<config_GM_closure ocn_grid="NARRM14to30E3r1">'constant'</config_GM_closure>
+<config_GM_closure ocn_grid="NARRM14to30E3r2">'constant'</config_GM_closure>
 <config_GM_constant_kappa>900.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
@@ -229,6 +241,8 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC04to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC02to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC01to60E3r1">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="NARRM14to30E3r1">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="NARRM14to30E3r2">600.0</config_GM_constant_kappa>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -553,6 +567,8 @@
 <config_btr_dt ocn_grid="FRISwISC04to60E3r1">'0000_00:00:05'</config_btr_dt>
 <config_btr_dt ocn_grid="FRISwISC02to60E3r1">'0000_00:00:02.5'</config_btr_dt>
 <config_btr_dt ocn_grid="FRISwISC01to60E3r1">'0000_00:00:01.25'</config_btr_dt>
+<config_btr_dt ocn_grid="NARRM14to30E3r1">'0000_00:00:15'</config_btr_dt>
+<config_btr_dt ocn_grid="NARRM14to30E3r2">'0000_00:00:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -1124,6 +1140,8 @@
 <config_AM_mocStreamfunction_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="NARRM14to30E3r1">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="NARRM14to30E3r2">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -373,7 +373,7 @@ def buildnml(case, caseroot, compname):
         ic_date = '20240227'
         ic_prefix = 'mpaso.NARRM14to30E3r1'
         if ocn_ic_mode == 'spunup':
-            ic_date = '20240312'
+            ic_date = '20240328'
             ic_prefix = 'mpaso.NARRM14to30E3r1.rstFromG-chrysalis'
 
     elif ocn_grid == 'NARRM14to30E3r2':

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -365,6 +365,28 @@ def buildnml(case, caseroot, compname):
             ic_date = '20240314'
             ic_prefix = 'mpaso.IcosXISC30E3r7.rstFromPiControlSpinup-chrysalis'
 
+    elif ocn_grid == 'NARRM14to30E3r1':
+        decomp_date = '20240227'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.NARRM14to30E3r1.20240227.nc'
+        analysis_mask_file = 'NARRM14to30E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20240227'
+        ic_prefix = 'mpaso.NARRM14to30E3r1'
+        if ocn_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
+    elif ocn_grid == 'NARRM14to30E3r2':
+        decomp_date = '20240228'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.NARRM14to30E3r2.20240228.nc'
+        analysis_mask_file = 'NARRM14to30E3r2_mocBasinsAndTransects20210623.nc'
+        ic_date = '2024022088'
+        ic_prefix = 'mpaso.NARRM14to30E3r2'
+        if ocn_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     #--------------------------------------------------------------------
     # Set OCN_FORCING = datm_forced_restoring if restoring file is available
     #--------------------------------------------------------------------

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -373,8 +373,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '20240227'
         ic_prefix = 'mpaso.NARRM14to30E3r1'
         if ocn_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            ic_date = '20240312'
+            ic_prefix = 'mpaso.NARRM14to30E3r1.rstFromG-chrysalis'
 
     elif ocn_grid == 'NARRM14to30E3r2':
         decomp_date = '20240228'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -30,6 +30,8 @@
 <config_dt ice_grid="FRISwISC04to60E3r1">240.0</config_dt>
 <config_dt ice_grid="FRISwISC02to60E3r1">120.0</config_dt>
 <config_dt ice_grid="FRISwISC01to60E3r1">60.0</config_dt>
+<config_dt ice_grid="NARRM14to30E3r1">1800.0</config_dt>
+<config_dt ice_grid="NARRM14to30E3r2">1800.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -168,6 +170,8 @@
 <config_dynamics_subcycle_number ice_grid="FRISwISC04to60E3r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="FRISwISC02to60E3r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="FRISwISC01to60E3r1">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="NARRM14to30E3r1">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="NARRM14to30E3r2">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -318,6 +318,24 @@ def buildnml(case, caseroot, compname):
             grid_date = '20240314'
             grid_prefix = 'mpassi.IcosXISC30E3r7.rstFromPiControlSpinup-chrysalis'
 
+    elif ice_grid == 'NARRM14to30E3r1':
+        decomp_date = '20240227'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20240227'
+        grid_prefix = 'mpassi.NARRM14to30E3r1'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
+    elif ice_grid == 'NARRM14to30E3r2':
+        decomp_date = '20240228'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20240228'
+        grid_prefix = 'mpassi.NARRM14to30E3r2'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     elif ice_grid == 'ICOS10':
         grid_date = '211015'
         grid_prefix = 'seaice.ICOS10'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -324,8 +324,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '20240227'
         grid_prefix = 'mpassi.NARRM14to30E3r1'
         if ice_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            grid_date = '20240312'
+            grid_prefix = 'mpassi.NARRM14to30E3r1.rstFromG-chrysalis'
 
     elif ice_grid == 'NARRM14to30E3r2':
         decomp_date = '20240228'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -324,7 +324,7 @@ def buildnml(case, caseroot, compname):
         grid_date = '20240227'
         grid_prefix = 'mpassi.NARRM14to30E3r1'
         if ice_ic_mode == 'spunup':
-            grid_date = '20240312'
+            grid_date = '20240328'
             grid_prefix = 'mpassi.NARRM14to30E3r1.rstFromG-chrysalis'
 
     elif ice_grid == 'NARRM14to30E3r2':


### PR DESCRIPTION
Long names: NARRM14to30kmL64E3SMv3r1 and NARRM14to30kmL80E3SMv3r2

These versions of the North American Regionally Refined Mesh (RRM) have the same distribution of resolution as in [WC14to60E2r3](https://github.com/MPAS-Dev/MPAS-Model/pull/628), except for a uniform 30 km background resolution instead of the EC30to60 distribution.  The resolution includes:
* 14 km resolution around North America and in the Arctic
* 30 km elsewhere
This mesh does not have Ice Shelf Cavities. Revision 1 (r1) has 64 vertical levels, with surface levels distributed similarly to those in the E3SM v2 WC14 initial condition.  Revision 2 (r2) has 80 vertical levels that match the [RRSwISC6to18E3r4](https://github.com/E3SM-Project/E3SM/pull/6143).

The meshes and the G-case results will be reviewed here:
https://acme-climate.atlassian.net/wiki/spaces/OO/pages/3924656629/Review+NARRM14to30E3r1
https://acme-climate.atlassian.net/wiki/spaces/OO/pages/4164845569/Review+NARRM14to30E3r2

A G- and B-case will begin shortly and analysis will be posted on the review page as soon as it is available.