### PR TITLE
Fix support for `maxLevelCell = 0` in MPAS-Ocean

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -246,7 +246,7 @@ contains
 
                !Initialize RefIndex for cases of very shallow columns
                refIndex = maxLevelCell(iCell)
-
+               if (refIndex == 0) cycle
                found_temp_mld = .false.
 
                do k=1, maxLevelCell(iCell)-1

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1763,6 +1763,7 @@ contains
             enddo
 
             k = min(ksfc+1, kmax)
+            if (k == 0) cycle
             do n=1,nTracers
                tracersSurfaceLayerValue(n,iCell) = &
               (tracersSurfaceLayerValue(n,iCell) + &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -2589,6 +2589,8 @@ contains
          ! Note the negative sign, since bottomDepth is positive
          ! and z-coordinates are negative below the surface.
          k = maxLevelCell(iCell)
+         if (k == 0) cycle
+
          zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
          zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -47,9 +47,9 @@ module ocn_eddy_parameterization_helpers
   !
   !  routine ocn_eddy_compute_buoyancy_gradient
   !
-  !> \brief Computes fixed depth horizontal buoyancy gradient 
+  !> \brief Computes fixed depth horizontal buoyancy gradient
   !> \details
-  !>  Computes the horizontal buoyancy gradient on fixed depth levels. 
+  !>  Computes the horizontal buoyancy gradient on fixed depth levels.
   !>  This quantity is extracted from mpas_ocn_gm as it is needed for both
   !>  the GM eddy parameterization and the submesoscale eddy parameterization
   !***********************************************************************
@@ -185,7 +185,7 @@ module ocn_eddy_parameterization_helpers
   !
   !> \brief   Computes the density threshold based mixed layer depth
   !> \details
-  !>   Computes the density threshold based mixed layer depth.  This 
+  !>   Computes the density threshold based mixed layer depth.  This
   !>   quantity is required by the submesoscale and redi parameterizations
   !>   The calculation is moved out of analysis members for this reason
   !***********************************************************************
@@ -233,6 +233,8 @@ module ocn_eddy_parameterization_helpers
 
           !Initialize RefIndex for cases of very shallow columns
           refIndex = maxLevelCell(iCell)
+          if (refIndex == 0) cycle
+
           found_den_mld = .false.
 
           do k=1, maxLevelCell(iCell)-1

--- a/components/mpas-ocean/src/shared/mpas_ocn_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_forcing.F
@@ -151,6 +151,7 @@ contains
         nCells = nCellsArray( 2 )
 
         do iCell = 1, nCells
+           if (maxLevelCell(iCell) == 0) cycle
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, sfcFlxAttCoeff(iCell))
            do k = minLevelCell(iCell), maxLevelCell(iCell)
@@ -167,6 +168,7 @@ contains
 !  now do river runoff separately
 
         do iCell = 1, nCells
+           if (maxLevelCell(iCell) == 0) cycle
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, surfaceFluxAttenuationCoefficientRunoff(iCell))
            do k = minLevelCell(iCell), maxLevelCell(iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -712,7 +712,7 @@ contains
                tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
                                  /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw* &
-                                            gradDensityEddy(k,iEdge) 
+                                            gradDensityEddy(k,iEdge)
 
                ! Second to next to the last rows
                do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
@@ -841,9 +841,9 @@ contains
 !
 !  routine ocn_GM_add_to_transport_velocity
 !
-!> \brief   Adds GM to transportVel 
+!> \brief   Adds GM to transportVel
 !> \details
-!>  Adds the GM bolus velocity to the normal transport velocity if enabled  
+!>  Adds the GM bolus velocity to the normal transport velocity if enabled
 !
 !-----------------------------------------------------------------------
 
@@ -859,7 +859,7 @@ contains
 
        if (.not. config_use_gm) return
 
-       !$omp parallel 
+       !$omp parallel
        !$omp do schedule(runtime) &
        !$omp private(k)
        do iEdge = 1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -177,11 +177,11 @@ module ocn_tracer_advection_mono
       !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
       !$acc            layerThickness, normalThicknessFlux, w, &
       !$acc            hProv, hProvInv, hNewInv) &
-      !$acc    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+      !$acc    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+      !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor)
 #endif
       do iCell = 1, nCellsAll
          invAreaCell1 = dt/areaCell(iCell)
@@ -301,7 +301,7 @@ module ocn_tracer_advection_mono
 #ifdef MPAS_OPENACC
         !$acc parallel loop &
         !$acc    present(minLevelCell, maxLevelCell, minLevelEdgeBot, &
-        !$acc            maxLevelEdgeTop, nAdvCellsForEdge, & 
+        !$acc            maxLevelEdgeTop, nAdvCellsForEdge, &
         !$acc            advCellsForEdge, cellsOnEdge, dvEdge, &
         !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
         !$acc            tracerCur, normalThicknessFlux, &
@@ -513,11 +513,11 @@ module ocn_tracer_advection_mono
         !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
         !$acc            workTend, highOrderFlx, layerThickness, &
         !$acc            tracerCur, hProvInv, tend) &
-        !$acc    private(i, k, iEdge, invAreaCell1, signedFactor) 
+        !$acc    private(i, k, iEdge, invAreaCell1, signedFactor)
 #else
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
+        !$omp    private(i, k, iEdge, invAreaCell1, signedFactor)
 #endif
         do iCell = 1, nCellsOwned
            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -683,6 +683,7 @@ module ocn_tracer_advection_mono
         do iCell = 1, nCells
            kmin = minLevelCell(iCell)
            kmax = maxLevelCell(iCell)
+           if (kmax == 0) cycle
 
            ! take care of top cell
            tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
@@ -788,7 +789,7 @@ module ocn_tracer_advection_mono
         !$acc            tracerCur, tracerMax, tracerMin, &
         !$acc            workTend, flxIn, flxOut) &
         !$acc    private(k, tracerMinNew, tracerMaxNew, &
-        !$acc            tracerUpwindNew, scaleFactor) 
+        !$acc            tracerUpwindNew, scaleFactor)
 #else
         !$omp parallel
         !$omp do schedule(runtime) &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -272,6 +272,7 @@ contains
             else  ! cell2 == iCell
                iCellSelf = 2
             endif
+            if (maxLevelCell(cell1) == 0 .or. maxLevelCell(cell2) == 0) cycle
 
             if (use_quasi_monotone) then
                ! expand min/max bnds on edge neighbours

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -133,6 +133,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k, iTracer, fluxTopOfCell, fluxBottomOfCell)
       do iCell = 1, nCells
+        if (maxLevelCell(iCell) == 0) cycle
         do k = minLevelCell(iCell)+1, maxLevelCell(iCell)-1
 
           ! NOTE: at the moment, all tracers are based on the flux-profile used for temperature, i.e. vertNonLocalFlux(1,:,:)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1235,6 +1235,7 @@ contains
       do iCell = 1, nCellsOwned
          Nsurf = minLevelCell(iCell)
          N = maxLevelCell(iCell)
+         if (N == 0) cycle
 
          ! tridiagonal matrix algorithm
          C(Nsurf) = -2.0_RKIND*dt*vertDiffTopOfCell(Nsurf+1,iCell) &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -342,6 +342,8 @@ contains
 !      !$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
       do iCell = 1, nCells
 
+         if (maxLevelCell(iCell) == 0) cycle
+
          ! specify geometry/location
          cvmix_variables % SeaSurfaceHeight = ssh(iCell)
          cvmix_variables % Coriolis = fCell(iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -796,6 +796,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(nEdges, areaSum, edgeCount, iEdge, iNeighbor)
          do iCell=1,nCells
+            if (maxLevelCell(iCell) == 0) cycle
             nEdges = nEdgesOnCell(iCell)
             boundaryLayerDepthSmooth(iCell) = 0.0_RKIND
             areaSum = 0.0_RKIND


### PR DESCRIPTION
There are various locations where `maxLevelCell` was previously assumed to be non-zero that this PR fixes.