### PR TITLE
Update global ocean init mode for meshes with ice-shelf cavities

### DIFF
--- a/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
@@ -136,7 +136,7 @@
 			possible_values="Any real positive number."
 		/>
 		<nml_option name="config_global_ocean_topography_source" type="character" default_value="latlon_file" units="unitless"
-			description="If 'latlon_file', reads in topography from file specified in config_global_ocean_topography_file. If 'mpas_variable', reads in topography from mpas variable bed_elevation, and optionally oceanFracObserved, landIceDraftObserved, landIceThkObserved, landIceFracObserved, and landIceGroundedFracObserved"
+			description="If 'latlon_file', reads in topography from file specified in config_global_ocean_topography_file. If 'mpas_variable', reads in topography from mpas variable bed_elevation, and optionally oceanFracObserved, landIceDraftObserved, landIceThkObserved, landIceFracObserved, and landIceFloatingFracObserved"
 			possible_values="'latlon_file' or 'mpas_variable'"
 		/>
 		<nml_option name="config_global_ocean_topography_file" type="character" default_value="none" units="unitless"
@@ -366,8 +366,8 @@
 		<var name="landIceFracObserved" type="real" dimensions="nCells" units="unitless"
 			 description="Fraction of land ice, read in from data file"
 		/>
-		<var name="landIceGroundedFracObserved" type="real" dimensions="nCells" units="unitless"
-			 description="Fraction of grounded land ice, read in from data file"
+		<var name="landIceFloatingFracObserved" type="real" dimensions="nCells" units="unitless"
+			 description="Fraction of floating land ice, read in from data file"
 		/>
 	</var_struct>
 	<var_struct name="criticalPassages" time_levs="1" mode="init" packages="criticalPassages">

--- a/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
@@ -357,6 +357,9 @@
 		<var name="landIceDraftObserved" type="real" dimensions="nCells" units="m"
 			 description="z-coordinate of land ice bottom, read in from data file"
 		/>
+		<var name="landIcePressureObserved" type="real" dimensions="nCells" units="m"
+			 description="Pressure of land ice on the ocean surface, read in from data file"
+		/>
 		<var name="landIceThkObserved" type="real" dimensions="nCells" units="m"
 			 description="Thickness of land ice, read in from data file"
 		/>

--- a/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
@@ -199,46 +199,6 @@
 			description="Logical flag that controls if sea surface pressure and layer thicknesses should be altered by an overlying ice sheet/shelf."
 			possible_values=".true. or .false."
 		/>
-		<nml_option name="config_global_ocean_land_ice_topo_file" type="character" default_value="none" units="unitless"
-			description="Path to the land ice topography initial condition file."
-			possible_values="path/to/land_ice_topography/file.nc"
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_nlat_dimname" type="character" default_value="none" units="unitless"
-			description="Dimension name for the latitude in the land ice topography file."
-			possible_values="Dimension name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_nlon_dimname" type="character" default_value="none" units="unitless"
-			description="Dimension name for the longitude in the land ice topography file."
-			possible_values="Dimension name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_latlon_degrees" type="logical" default_value=".true." units="unitless"
-			description="Logical flag that controls if the Lat/Lon fields for land ice topography should be converted to radians. True means input is degrees, false means input is radians."
-			possible_values=".true. or .false."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_lat_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the latitude in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_lon_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the longitude in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_thickness_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the land ice thickness in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_draft_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the land ice draft in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_ice_frac_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the land ice fraction in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
-		<nml_option name="config_global_ocean_land_ice_topo_grounded_frac_varname" type="character" default_value="none" units="unitless"
-			description="Variable name for the grounded land ice fraction in the land ice topography file."
-			possible_values="Variable name from input file."
-		/>
 		<nml_option name="config_global_ocean_use_constant_land_ice_cavity_temperature" type="logical" default_value=".false." units="unitless"
 					description="Logical flag that controls if ocean temperature in land-ice cavities is set to a constant temperature."
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -34,6 +34,7 @@ module ocn_init_global_ocean
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
+   use ocn_equation_of_state
    use ocn_init_cell_markers
    use ocn_init_vertical_grids
    use ocn_init_interpolation
@@ -123,7 +124,7 @@ contains
       real (kind=RKIND), dimension(:, :), pointer :: PH_PREV_3D, PH_PREV_ALT_CO2_3D
       real (kind=RKIND), dimension(:, :), pointer :: FESEDFLUX
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
       real (kind=RKIND), dimension(:, :, :), pointer :: ecosysTracers, activeTracers, debugTracers, &
@@ -501,6 +502,33 @@ contains
          call mpas_log_write( 'ocn_compute_Haney_number failed.', MPAS_LOG_CRIT)
          call mpas_dmpar_finalize(domain % dminfo)
       end if
+
+      call mpas_log_write( 'Compute density')
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+
+          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+          call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+
+          do iCell = 1, nCells
+             do iTracer = 1,size(tracersSurfaceValue,1)
+                tracersSurfaceValue(iTracer, iCell) = activeTracers(iTracer, minLevelCell(iCell), iCell)
+             enddo
+          end do
+
+          call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
+             nCells, 0, 'relative', density, iErr, &
+             timeLevelIn=1)
+
+         if(iErr .ne. 0) then
+            call mpas_log_write( 'ocn_equation_of_state_density failed.', MPAS_LOG_CRIT)
+            return
+         end if
+
+          block_ptr => block_ptr % next
+       end do
 
       if (config_global_ocean_cull_inland_seas) then
          call mpas_log_write( 'Removing inland seas.')

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -941,7 +941,9 @@ contains
                                          statePool
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
-       real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, landIceDraftObserved, &
+       real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, &
+                                                   landIceDraftObserved, &
+                                                   landIcePressureObserved, &
                                                    landIceFracObserved, &
                                                    landIceFloatingFracObserved, &
                                                    landIceGroundedFracObserved
@@ -961,6 +963,10 @@ contains
        ! and landIceGroundedFracObserved before using them to adjust SSH, compute
        ! land-ice pressure, etc.
        call ocn_init_smooth_field(domain, 'landIceDraftObserved', 'landIceInit', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       call ocn_init_smooth_field(domain, 'landIcePressureObserved', 'landIceInit', &
                                   config_global_ocean_topography_smooth_iterations, &
                                   config_global_ocean_topography_smooth_weight)
 
@@ -987,6 +993,7 @@ contains
 
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIcePressureObserved', landIcePressureObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFloatingFracObserved)

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -75,7 +75,6 @@ module ocn_init_global_ocean
    integer :: nLatWind, nLonWind
    integer :: nLatTopo, nLonTopo
    integer :: nLonSW, nLatSW
-   integer :: nLatLandIceThk, nLonLandIceThk
 
    type (field1DReal) :: depthOutput
    type (field1DReal) :: tracerLat, tracerLon, tracerDepth
@@ -85,8 +84,7 @@ module ocn_init_global_ocean
    type (field1DReal) :: landIceThkLat, landIceThkLon
 
    type (field2DReal) :: topoIC, zonalWindIC, meridionalWindIC, chlorophyllIC, zenithAngleIC, clearSkyIC
-   type (field2DReal) :: landIceThkIC, landIceDraftIC
-   type (field2DReal) :: oceanFracIC, landIceFracIC, groundedFracIC
+   type (field2DReal) :: oceanFracIC
 
    type (field3DReal) :: tracerIC, ecosysForcingIC
 
@@ -196,10 +194,6 @@ contains
       !***********************************************************************
 
       if (config_global_ocean_depress_by_land_ice) then
-         if (config_global_ocean_topography_source == "latlon_file") then
-            call mpas_log_write( 'Reading land ice topography data.')
-            call ocn_init_setup_global_ocean_read_land_ice_topography(domain, iErr)
-         end if
          call mpas_log_write( 'Interpolating land ice topography data.')
          call ocn_init_setup_global_ocean_interpolate_land_ice_topography(domain, iErr)
       end if
@@ -507,10 +501,6 @@ contains
             call mpas_dmpar_finalize(domain % dminfo)
          end if
 
-         if (config_global_ocean_topography_source == "latlon_file") then
-            call mpas_log_write( 'Cleaning up land ice topography IC fields')
-            call ocn_init_global_ocean_destroy_land_ice_topography_fields()
-         end if
       end if
 
       call mpas_log_write( 'Copying restoring fields')
@@ -637,127 +627,6 @@ contains
        end if
 
     end subroutine ocn_init_setup_global_ocean_read_topo!}}}
-
-!***********************************************************************
-!
-!  routine ocn_init_setup_global_ocean_read_land_ice_topography
-!
-!> \brief   Read the ice sheet thickness IC file
-!> \author  Jeremy Fyke, Xylar Asay-Davis, Mark Petersen (modified from Doug Jacobsen code)
-!> \date    06/15/2015
-!> \details
-!>  This routine reads the ice sheet topography IC file, including latitude and longitude
-!>   information for ice sheet topography data.
-!
-!-----------------------------------------------------------------------
-
-    subroutine ocn_init_setup_global_ocean_read_land_ice_topography(domain, iErr)!{{{
-       type (domain_type), intent(inout) :: domain
-       integer, intent(out) :: iErr
-
-       type (MPAS_Stream_type) :: landIceThicknessStream
-
-       iErr = 0
-
-       ! Define stream for depth levels
-       call MPAS_createStream(landIceThicknessStream, domain % iocontext, config_global_ocean_land_ice_topo_file, &
-            MPAS_IO_NETCDF, MPAS_IO_READ, ierr=iErr)
-
-       ! Setup landIceThkLat, landIceThkLon, and landIceThkIC fields for stream to be read in
-       landIceThkLat % fieldName = trim(config_global_ocean_land_ice_topo_lat_varname)
-       landIceThkLat % dimSizes(1) = nLatLandIceThk
-       landIceThkLat % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlat_dimname)
-       landIceThkLat % isVarArray = .false.
-       landIceThkLat % isPersistent = .true.
-       landIceThkLat % isActive = .true.
-       landIceThkLat % hasTimeDimension = .false.
-       landIceThkLat % block => domain % blocklist
-       allocate(landIceThkLat % attLists(1))
-       allocate(landIceThkLat % array(nLatLandIceThk))
-
-       landIceThkLon % fieldName = trim(config_global_ocean_land_ice_topo_lon_varname)
-       landIceThkLon % dimSizes(1) = nLonLandIceThk
-       landIceThkLon % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlon_dimname)
-       landIceThkLon % isVarArray = .false.
-       landIceThkLon % isPersistent = .true.
-       landIceThkLon % isActive = .true.
-       landIceThkLon % hasTimeDimension = .false.
-       landIceThkLon % block => domain % blocklist
-       allocate(landIceThkLon % attLists(1))
-       allocate(landIceThkLon % array(nLonLandIceThk))
-
-       landIceThkIC % fieldName = trim(config_global_ocean_land_ice_topo_thickness_varname)
-       landIceThkIC % dimSizes(1) = nLonLandIceThk
-       landIceThkIC % dimSizes(2) = nLatLandIceThk
-       landIceThkIC % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlon_dimname)
-       landIceThkIC % dimNames(2) = trim(config_global_ocean_land_ice_topo_nlat_dimname)
-       landIceThkIC % isVarArray = .false.
-       landIceThkIC % isPersistent = .true.
-       landIceThkIC % isActive = .true.
-       landIceThkIC % hasTimeDimension = .false.
-       landIceThkIC % block => domain % blocklist
-       allocate(landIceThkIC % attLists(1))
-       allocate(landIceThkIC % array(nLonLandIceThk, nLatLandIceThk))
-
-       landIceDraftIC % fieldName = trim(config_global_ocean_land_ice_topo_draft_varname)
-       landIceDraftIC % dimSizes(1) = nLonLandIceThk
-       landIceDraftIC % dimSizes(2) = nLatLandIceThk
-       landIceDraftIC % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlon_dimname)
-       landIceDraftIC % dimNames(2) = trim(config_global_ocean_land_ice_topo_nlat_dimname)
-       landIceDraftIC % isVarArray = .false.
-       landIceDraftIC % isPersistent = .true.
-       landIceDraftIC % isActive = .true.
-       landIceDraftIC % hasTimeDimension = .false.
-       landIceDraftIC % block => domain % blocklist
-       allocate(landIceDraftIC % attLists(1))
-       allocate(landIceDraftIC % array(nLonLandIceThk, nLatLandIceThk))
-
-       landIceFracIC % fieldName = trim(config_global_ocean_land_ice_topo_ice_frac_varname)
-       landIceFracIC % dimSizes(1) = nLonLandIceThk
-       landIceFracIC % dimSizes(2) = nLatLandIceThk
-       landIceFracIC % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlon_dimname)
-       landIceFracIC % dimNames(2) = trim(config_global_ocean_land_ice_topo_nlat_dimname)
-       landIceFracIC % isVarArray = .false.
-       landIceFracIC % isPersistent = .true.
-       landIceFracIC % isActive = .true.
-       landIceFracIC % hasTimeDimension = .false.
-       landIceFracIC % block => domain % blocklist
-       allocate(landIceFracIC % attLists(1))
-       allocate(landIceFracIC % array(nLonLandIceThk, nLatLandIceThk))
-
-       groundedFracIC % fieldName = trim(config_global_ocean_land_ice_topo_grounded_frac_varname)
-       groundedFracIC % dimSizes(1) = nLonLandIceThk
-       groundedFracIC % dimSizes(2) = nLatLandIceThk
-       groundedFracIC % dimNames(1) = trim(config_global_ocean_land_ice_topo_nlon_dimname)
-       groundedFracIC % dimNames(2) = trim(config_global_ocean_land_ice_topo_nlat_dimname)
-       groundedFracIC % isVarArray = .false.
-       groundedFracIC % isPersistent = .true.
-       groundedFracIC % isActive = .true.
-       groundedFracIC % hasTimeDimension = .false.
-       groundedFracIC % block => domain % blocklist
-       allocate(groundedFracIC % attLists(1))
-       allocate(groundedFracIC % array(nLonLandIceThk, nLatLandIceThk))
-
-       ! Add landIceThkLat, landIceThkLon, and landIceThkIC fields to stream
-       call MPAS_streamAddField(landIceThicknessStream, landIceThkLat, iErr)
-       call MPAS_streamAddField(landIceThicknessStream, landIceThkLon, iErr)
-       call MPAS_streamAddField(landIceThicknessStream, landIceThkIC, iErr)
-       call MPAS_streamAddField(landIceThicknessStream, landIceDraftIC, iErr)
-       call MPAS_streamAddField(landIceThicknessStream, landIceFracIC, iErr)
-       call MPAS_streamAddField(landIceThicknessStream, groundedFracIC, iErr)
-
-       ! Read stream
-       call MPAS_readStream(landIceThicknessStream, 1, iErr)
-
-       ! Close stream
-       call MPAS_closeStream(landIceThicknessStream)
-
-       if (config_global_ocean_land_ice_topo_latlon_degrees) then
-          landIceThkLat % array(:) = landIceThkLat % array(:) * pii / 180.0_RKIND
-          landIceThkLon % array(:) = landIceThkLon % array(:) * pii / 180.0_RKIND
-       end if
-
-    end subroutine ocn_init_setup_global_ocean_read_land_ice_topography!}}}
 
 !***********************************************************************
 !
@@ -1087,76 +956,6 @@ contains
        integer :: iCell
 
        iErr = 0
-
-       if (config_global_ocean_topography_source == "latlon_file") then
-          block_ptr => domain % blocklist
-          do while(associated(block_ptr))
-
-             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-             call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
-             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-             call mpas_pool_get_array(meshPool, 'latCell', latCell)
-             call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-             call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
-             call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
-             call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
-             call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
-
-             if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
-
-                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                          landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                          lonCell, latCell, landIceThkObserved, nCells, &
-                                                          inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                          landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                          lonCell, latCell, landIceDraftObserved, nCells, &
-                                                          inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                          landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                          lonCell, latCell, landIceFracObserved, nCells, &
-                                                          inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                          groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                          lonCell, latCell, landIceGroundedFracObserved, nCells, &
-                                                          inXPeriod = 2.0_RKIND * pii)
-
-             elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
-
-                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                           landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                           lonCell, latCell, landIceThkObserved, nCells, &
-                                                           inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                           landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                           lonCell, latCell, landIceDraftObserved, nCells, &
-                                                           inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                           landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                           lonCell, latCell, landIceFracObserved, nCells, &
-                                                           inXPeriod = 2.0_RKIND * pii)
-
-                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                           groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                           lonCell, latCell, landIceGroundedFracObserved, nCells, &
-                                                           inXPeriod = 2.0_RKIND * pii)
-
-             else
-                call mpas_log_write( 'Invalid choice of config_global_ocean_topography_method.', MPAS_LOG_CRIT)
-                iErr = 1
-                call mpas_dmpar_finalize(domain % dminfo)
-             endif
-
-             block_ptr => block_ptr % next
-          end do
-       end if
-
 
        ! Iteratively smooth landIceDraftObserved, landIceThkObserved, landIceFracObserved,
        ! and landIceGroundedFracObserved before using them to adjust SSH, compute
@@ -2728,26 +2527,6 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
 
 !***********************************************************************
 !
-!  routine ocn_init_global_ocean_destroy_land_ice_topography_fields
-!
-!> \brief   Topography field cleanup routine
-!> \author  Jeremy Fyke, Xylar Asay-Davis, Mark Petersen
-!> \date    06/23/2015
-!> \details
-!>  This routine destroys the fields created to hold land ice topography
-!>  initial condition information
-!
-!-----------------------------------------------------------------------
-
-    subroutine ocn_init_global_ocean_destroy_land_ice_topography_fields()!{{{
-        deallocate(landIceThkIC % array)
-        deallocate(landIceDraftIC % array)
-        deallocate(landIceThkLat % array)
-        deallocate(landIceThkLon % array)
-    end subroutine ocn_init_global_ocean_destroy_land_ice_topography_fields!}}}
-
-!***********************************************************************
-!
 !  routine ocn_init_global_ocean_destroy_windstress_fields
 !
 !> \brief   Windstress field cleanup routine
@@ -2840,9 +2619,6 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
                                           config_global_ocean_windstress_file, &
                                           config_global_ocean_windstress_nlat_dimname, &
                                           config_global_ocean_windstress_nlon_dimname, &
-                                          config_global_ocean_land_ice_topo_file, &
-                                          config_global_ocean_land_ice_topo_nlat_dimname, &
-                                          config_global_ocean_land_ice_topo_nlon_dimname, &
                                           config_global_ocean_swData_file, &
                                           config_global_ocean_swData_nlon_dimname, &
                                           config_global_ocean_swData_nlat_dimname, &
@@ -2894,12 +2670,6 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
                                 config_global_ocean_depress_by_land_ice)
       call mpas_pool_get_config(configPool, 'config_use_ecosysTracers', &
                                 config_use_ecosysTracers)
-      call mpas_pool_get_config(configPool, 'config_global_ocean_land_ice_topo_file', &
-                                config_global_ocean_land_ice_topo_file)
-      call mpas_pool_get_config(configPool, 'config_global_ocean_land_ice_topo_nlat_dimname', &
-                                config_global_ocean_land_ice_topo_nlat_dimname)
-      call mpas_pool_get_config(configPool, 'config_global_ocean_land_ice_topo_nlon_dimname', &
-                                config_global_ocean_land_ice_topo_nlon_dimname)
       call mpas_pool_get_config(configPool, 'config_global_ocean_deepen_critical_passages', &
                                 config_global_ocean_deepen_critical_passages)
       call mpas_pool_get_config(configPool, 'config_global_ocean_windstress_file', &
@@ -3017,6 +2787,14 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
          return
       end if
 
+      if (config_global_ocean_topography_source == 'latlon_file' .and. &
+          config_global_ocean_depress_by_land_ice) then
+         call mpas_log_write( 'Land ice topography can no longer be read from ' &
+             // 'a lat-lon file', MPAS_LOG_CRIT)
+         iErr = 1
+         return
+      end if
+
       if (config_global_ocean_topography_source == 'latlon_file') then
          inputFile = MPAS_io_open(config_global_ocean_topography_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
          if (iErr /= 0) then
@@ -3073,29 +2851,6 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
             iErr = 1
          end if
 
-      end if
-
-      if (config_global_ocean_depress_by_land_ice) then
-         if (config_global_ocean_land_ice_topo_file == 'none' .and. &
-             config_global_ocean_topography_source == 'latlon_file') then
-            call mpas_log_write( 'Validation failed for global ocean. '// &
-               'Invalid filename for config_global_ocean_land_ice_topo_file', MPAS_LOG_CRIT)
-            iErr = 1
-            return
-         end if
-
-         if(config_global_ocean_topography_source == 'latlon_file') then
-            inputFile = MPAS_io_open(config_global_ocean_land_ice_topo_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
-            if (iErr /= 0) then
-               call mpas_log_write( 'could not open file '// trim(config_global_ocean_land_ice_topo_file), MPAS_LOG_CRIT)
-               return
-            end if
-
-            call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlat_dimname, nLatLandIceThk, iErr)
-            call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlon_dimname, nLonLandIceThk, iErr)
-
-            call MPAS_io_close(inputFile, iErr)
-         end if
       end if
 
    !--------------------------------------------------------------------

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -37,7 +37,6 @@ module ocn_init_global_ocean
    use ocn_init_cell_markers
    use ocn_init_vertical_grids
    use ocn_init_interpolation
-   use ocn_init_ssh_and_landIcePressure
    use ocn_init_smoothing
 
    implicit none
@@ -491,21 +490,9 @@ contains
       if (config_global_ocean_depress_by_land_ice) then
          call mpas_log_write('Modifying temperature and surface restoring under land ice.')
          call ocn_init_setup_global_ocean_modify_temp_under_land_ice(domain, iErr)
-
-         call mpas_log_write('Calculating land-ice pressure from the weight of ice shelves')
-         ! compute the land-ice pressure, also computing density along the way.
-         call ocn_init_ssh_and_landIcePressure_balance(domain, iErr)
-
-         if(iErr .ne. 0) then
-            call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_balance failed.', MPAS_LOG_CRIT)
-            call mpas_dmpar_finalize(domain % dminfo)
-         end if
-
       end if
 
       call mpas_log_write( 'Copying restoring fields')
-      ! this occurs after ocn_init_ssh_and_landIcePressure_balance because activeTracers may have been remapped
-      ! to a new vertical coordinate
       call ocn_init_setup_global_ocean_interpolate_restoring(domain, iErr)
 
       call mpas_log_write( 'Compute Haney number')
@@ -941,16 +928,16 @@ contains
                                          statePool
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
-       real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, &
-                                                   landIceDraftObserved, &
+       real (kind=RKIND), dimension(:), pointer :: landIceDraftObserved, &
                                                    landIcePressureObserved, &
                                                    landIceFracObserved, &
-                                                   landIceFloatingFracObserved, &
-                                                   landIceGroundedFracObserved
+                                                   landIceFloatingFracObserved
 
-       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
-                                                   landIceFloatingFraction, ssh, &
-                                                   bottomDepth
+       real (kind=RKIND), dimension(:), pointer :: landIceDraft, &
+                                                   landIcePressure, &
+                                                   landIceFraction, &
+                                                   landIceFloatingFraction, &
+                                                   ssh
 
        integer, pointer :: nCells
        integer, dimension(:), pointer :: maxLevelCell, landIceMask, landIceFloatingMask
@@ -959,28 +946,24 @@ contains
 
        iErr = 0
 
-       ! Iteratively smooth landIceDraftObserved, landIceThkObserved, landIceFracObserved,
-       ! and landIceGroundedFracObserved before using them to adjust SSH, compute
-       ! land-ice pressure, etc.
-       call ocn_init_smooth_field(domain, 'landIceDraftObserved', 'landIceInit', &
-                                  config_global_ocean_topography_smooth_iterations, &
-                                  config_global_ocean_topography_smooth_weight)
+       ! Iteratively smooth land ice topography variables
+       if (config_global_ocean_topography_smooth_weight > 0) then
+          call ocn_init_smooth_field(domain, 'landIceDraftObserved', 'landIceInit', &
+                                     config_global_ocean_topography_smooth_iterations, &
+                                     config_global_ocean_topography_smooth_weight)
 
-       call ocn_init_smooth_field(domain, 'landIcePressureObserved', 'landIceInit', &
-                                  config_global_ocean_topography_smooth_iterations, &
-                                  config_global_ocean_topography_smooth_weight)
+          call ocn_init_smooth_field(domain, 'landIcePressureObserved', 'landIceInit', &
+                                     config_global_ocean_topography_smooth_iterations, &
+                                     config_global_ocean_topography_smooth_weight)
 
-       call ocn_init_smooth_field(domain, 'landIceThkObserved', 'landIceInit', &
-                                  config_global_ocean_topography_smooth_iterations, &
-                                  config_global_ocean_topography_smooth_weight)
+          call ocn_init_smooth_field(domain, 'landIceFracObserved', 'landIceInit', &
+                                     config_global_ocean_topography_smooth_iterations, &
+                                     config_global_ocean_topography_smooth_weight)
 
-       call ocn_init_smooth_field(domain, 'landIceFracObserved', 'landIceInit', &
-                                  config_global_ocean_topography_smooth_iterations, &
-                                  config_global_ocean_topography_smooth_weight)
-
-       call ocn_init_smooth_field(domain, 'landIceGroundedFracObserved', 'landIceInit', &
-                                  config_global_ocean_topography_smooth_iterations, &
-                                  config_global_ocean_topography_smooth_weight)
+          call ocn_init_smooth_field(domain, 'landIceFloatingFracObserved', 'landIceInit', &
+                                     config_global_ocean_topography_smooth_iterations, &
+                                     config_global_ocean_topography_smooth_weight)
+       end if
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
@@ -994,13 +977,12 @@ contains
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIcePressureObserved', landIcePressureObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFloatingFracObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFloatingFracObserved', landIceFloatingFracObserved)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
           call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
+          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
           call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
           call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
@@ -1012,26 +994,25 @@ contains
           endif
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
-          modifyLandIcePressureMask(:) = 0
+          landIceDraft(:) = 0.0_RKIND
           landIcePressure(:) = 0.0_RKIND
+          modifyLandIcePressureMask(:) = 0
           do iCell = 1, nCells
+             ! nothing to do here if the cell is land
+             if (maxLevelCell(iCell) <= 0) cycle
 
              if (landIceMask(iCell) == 1) then
                 landIceFraction(iCell) = landIceFracObserved(iCell)
              end if
 
-             ! this implicitly assumes that when a cell is considered floating, the
-             ! full landIceFracObserved is floating
              if (landIceFloatingMask(iCell) == 1) then
                 landIceFloatingFraction(iCell) = landIceFloatingFracObserved(iCell)
              end if
 
-             ! nothing to do here if the cell is land
-             if (maxLevelCell(iCell) <= 0) cycle
-
-             ! we compute the SSH first and find out the land-ice pressure
-             ssh(iCell) = min(0.0_RKIND, landIceDraftObserved(iCell))
-             if (ssh(iCell) < 0.0_RKIND) then
+             landIceDraft(iCell) = landIceDraftObserved(iCell)
+             ssh(iCell) = landIceDraft(iCell)
+             landIcePressure(iCell) = landIcePressureObserved(iCell)
+             if (landIcePressure(iCell) > 0.0_RKIND) then
                 modifyLandIcePressureMask(iCell) = 1
              end if
           end do

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -129,7 +129,7 @@ contains
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
       real (kind=RKIND), dimension(:, :, :), pointer :: ecosysTracers, activeTracers, debugTracers, &
            DMSTracers, MacroMoleculesTracers
-      integer, pointer :: nVertLevels, nCellsSolve, tracerIndex
+      integer, pointer :: nVertLevels, nCellsSolve, nCells, tracerIndex
       integer :: iCell, k, iTracer
       integer, dimension(3) :: indexField
 
@@ -964,8 +964,7 @@ contains
        real (kind=RKIND), dimension(:), pointer :: landIceDraft, &
                                                    landIcePressure, &
                                                    landIceFraction, &
-                                                   landIceFloatingFraction, &
-                                                   ssh
+                                                   landIceFloatingFraction
 
        integer, pointer :: nCells
        integer, dimension(:), pointer :: maxLevelCell, landIceMask, landIceFloatingMask
@@ -1007,7 +1006,6 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIcePressureObserved', landIcePressureObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFloatingFracObserved', landIceFloatingFracObserved)
-          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
           call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
           call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
@@ -1020,7 +1018,6 @@ contains
                'indicates that this field is missing in the initial condition file (e.g. ' // &
                'because it is meant for an older E3SM version).', MPAS_LOG_CRIT)
           endif
-          ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
           landIceDraft(:) = 0.0_RKIND
           landIcePressure(:) = 0.0_RKIND
@@ -1038,7 +1035,6 @@ contains
              end if
 
              landIceDraft(iCell) = landIceDraftObserved(iCell)
-             ssh(iCell) = landIceDraft(iCell)
              landIcePressure(iCell) = landIcePressureObserved(iCell)
              if (landIcePressure(iCell) > 0.0_RKIND) then
                 modifyLandIcePressureMask(iCell) = 1


### PR DESCRIPTION
This merge updates MPAS-Ocean init mode for `global_ocean` in several ways that are critical for initialization that is compatible with planned coupling to MALI.

The fields `landIcePressure`, `landIceDraft` and `ssh` are now read from a topography file.  This means that `landIcePressure` is no longer computed based on the density at the ocean surface in init mode.  Similarly, `ssh` is not required to be the same as `landIceDraft`.

Support is removed for reading land-ice topography fields from a dataset on a lat-lon grid.  We no longer use this capability and maintaining it is not worth the effort.

The land-ice topography data set is now required to have `landIceFloatingFracObserved` as a field, and this is used to set `landIceFloatingFraction`.  Previously, `landIceFracObserved` was being used to compute both `landIceFraction` and `landIceFloatingFraction` (assuming no grounded ice in the domain).
