### PR TITLE
Adds a porosity parameter for internal frazil salinity

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -783,6 +783,7 @@ add_default($nl, 'config_frazil_in_open_ocean');
 add_default($nl, 'config_frazil_under_land_ice');
 add_default($nl, 'config_frazil_heat_of_fusion');
 add_default($nl, 'config_frazil_ice_density');
+add_default($nl, 'config_frazil_ice_porosity');
 add_default($nl, 'config_frazil_fractional_thickness_limit');
 add_default($nl, 'config_specific_heat_sea_water');
 add_default($nl, 'config_frazil_maximum_depth');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -291,6 +291,7 @@ add_default($nl, 'config_frazil_in_open_ocean');
 add_default($nl, 'config_frazil_under_land_ice');
 add_default($nl, 'config_frazil_heat_of_fusion');
 add_default($nl, 'config_frazil_ice_density');
+add_default($nl, 'config_frazil_ice_porosity');
 add_default($nl, 'config_frazil_fractional_thickness_limit');
 add_default($nl, 'config_specific_heat_sea_water');
 add_default($nl, 'config_frazil_maximum_depth');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -394,6 +394,7 @@
 <config_frazil_under_land_ice>.true.</config_frazil_under_land_ice>
 <config_frazil_heat_of_fusion>3.337e5</config_frazil_heat_of_fusion>
 <config_frazil_ice_density>1000.0</config_frazil_ice_density>
+<config_frazil_ice_porosity>0.85</config_frazil_ice_porosity>
 <config_frazil_fractional_thickness_limit>0.1</config_frazil_fractional_thickness_limit>
 <config_specific_heat_sea_water>3.996e3</config_specific_heat_sea_water>
 <config_frazil_maximum_depth>100.0</config_frazil_maximum_depth>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -394,7 +394,7 @@
 <config_frazil_under_land_ice>.true.</config_frazil_under_land_ice>
 <config_frazil_heat_of_fusion>3.337e5</config_frazil_heat_of_fusion>
 <config_frazil_ice_density>1000.0</config_frazil_ice_density>
-<config_frazil_ice_porosity>0.85</config_frazil_ice_porosity>
+<config_frazil_ice_porosity>-1.0</config_frazil_ice_porosity>
 <config_frazil_fractional_thickness_limit>0.1</config_frazil_fractional_thickness_limit>
 <config_specific_heat_sea_water>3.996e3</config_specific_heat_sea_water>
 <config_frazil_maximum_depth>100.0</config_frazil_maximum_depth>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1541,9 +1541,9 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_frazil_ice_porosity" type="real"
 	category="frazil_ice" group="frazil_ice">
-Assumed porosity of frazil
+Internal porosity of frazil
 
-Valid values: Any positive real number from 0 to 1.
+Valid values: Positive real number from 0 to 1. Negative value reverts to using the reference salinity for internal frazil.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1539,6 +1539,14 @@ Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_frazil_ice_porosity" type="real"
+	category="frazil_ice" group="frazil_ice">
+Assumed porosity of frazil
+
+Valid values: Any positive real number from 0 to 1.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_frazil_fractional_thickness_limit" type="real"
 	category="frazil_ice" group="frazil_ice">
 maximum fraction of layer thickness than can be used or created at an instant by frazil.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -4076,6 +4076,10 @@
 			 description="surface pressure forcing due to weight of frazil ice"
 			 packages="frazilIce"
 		/>
+		<var name="lowSalinityFrazilIce" type="real" dimensions="nCells Time" units="kg m^-2"
+			 description="min(0,AccumulatedFrazilIceMass * reference salinity - accumulatedFrazilIceSalinity), non-zero indicates possible non-conservation"
+			 packages="frazilIce"
+		/>
 		<var name="frazilIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			description="Flux of frazil ice mass through the ocean surface. Negative is defined as mass leaving the ocean."
 			packages="frazilIce"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -984,10 +984,14 @@
 		<nml_option name="config_frazil_heat_of_fusion" type="real" default_value="3.34e5" units="J kg^-1"
 					description="Energy per kilogram released when sea water freezes. NOTE: test and make consistent with E3SM."
 					possible_values="Any positive real number."
-		/>
+		/> 
 		<nml_option name="config_frazil_ice_density" type="real" default_value="1000.0" units="kg m^-3"
 					description="Assumed density of frazil. NOTE: test and make consistent with E3SM."
 					possible_values="Any positive real number."
+		/>
+		<nml_option name="config_frazil_ice_porosity" type="real" default_value="0.85" units="1"
+					description="Assumed porosity of frazil"
+					possible_values="Any positive real number from 0 to 1."
 		/>
 		<nml_option name="config_frazil_fractional_thickness_limit" type="real" default_value="0.1" units="non-dimensional"
 					description="maximum fraction of layer thickness than can be used or created at an instant by frazil."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -989,9 +989,9 @@
 					description="Assumed density of frazil. NOTE: test and make consistent with E3SM."
 					possible_values="Any positive real number."
 		/>
-		<nml_option name="config_frazil_ice_porosity" type="real" default_value="0.85" units="1"
-					description="Assumed porosity of frazil"
-					possible_values="Any positive real number from 0 to 1."
+		<nml_option name="config_frazil_ice_porosity" type="real" default_value="-1.0" units="1"
+					description="Internal porosity of frazil"
+					possible_values="Positive real number from 0 to 1. Negative value reverts to using the reference salinity for internal frazil."
 		/>
 		<nml_option name="config_frazil_fractional_thickness_limit" type="real" default_value="0.1" units="non-dimensional"
 					description="maximum fraction of layer thickness than can be used or created at an instant by frazil."

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -391,7 +391,9 @@ contains
       integer, pointer :: indexSalinityPtr !< index in tracers array for salinity
       integer :: indexTemperature !< index in tracers array for temperature
       integer :: indexSalinity !< index in tracers array for salinity
-      integer :: kBottomFrazil  ! k index where testing for frazil begins
+      integer :: kBottomFrazil ! k index where testing for frazil begins
+      integer :: usePorosity   ! 1 when computing internal frazil salinity using porosity
+                               ! 0 when using config_frazil_sea_ice_reference_salinity
 
       logical :: underFloatingLandIce, underLandIce ! indicates if we are under land ice
 
@@ -453,6 +455,10 @@ contains
       ! initialize frazil salinity conservation field
       lowSalinityFrazilIce = 0.0_RKIND
 
+      ! Determine if using porosity to compute internal frazilSalinity
+      usePorosity = 1
+      if (config_frazil_ice_porosity < 0.0_RKIND) usePorosity = 0 ! use config_frazil_sea_ice_reference_salinity
+
       ! frazil fields are needed only over 0 and 1 halos
       nCells = nCellsArray( 2 )
 
@@ -500,8 +506,6 @@ contains
             exit
           endif
         enddo
-        !NJ: Compute frazil all through the column
-        !kBottomFrazil=max(maxLevelCell(iCell)-1,kBottomFrazil)
 
         ! find minimum temperature between 1:kBottomFrazil
         columnTemperatureMin = 1.0e30_RKIND
@@ -532,14 +536,14 @@ contains
           freezingEnergy = max(0.0_RKIND, -potential)
           meltingEnergy = max(0.0_RKIND, potential)
 
-          !NJ:  Assume frazil ice retains salt until precipitating at the surface
           if (freezingEnergy > 0) then
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell) !0.0_RKIND
+              frazilSalinity = usePorosity * config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell)
             else
-              frazilSalinity = config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell) !config_frazil_sea_ice_reference_salinity
+              frazilSalinity = usePorosity * config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell) &
+                 + config_frazil_sea_ice_reference_salinity * (1 - usePorosity)
             end if
             frazilSalinity = min( frazilSalinity, activeTracers(indexSalinity, k, iCell) )
 
@@ -615,15 +619,18 @@ contains
 
         enddo   ! do k=kBottom,minLevelCell,-1
 
-        ! frazilIceFreshwaterFlux forms part of the landIceFreshwaterFluxTotal computed in surface land ice fluxes
-        frazilIceFreshwaterFlux(iCell) = - (sumNewFrazilIceThickness * config_frazil_ice_density) / dt
         ! accumulate frazil mass to column total
         ! note: the accumulatedFrazilIceMass (at both time levels) is reset to zero after being sent to the coupler
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
            * config_frazil_ice_density
 
+        accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + &
+           (1-usePorosity) * sumNewThicknessWeightedSaltContent
+
         !NJ: Assume frazil salinity is the coupling salinity
         if ( underLandIce ) then
+           ! frazilIceFreshwaterFlux forms part of the landIceFreshwaterFluxTotal computed in surface land ice fluxes
+           frazilIceFreshwaterFlux(iCell) = - (sumNewFrazilIceThickness * config_frazil_ice_density) / dt
            ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
@@ -634,21 +641,19 @@ contains
            frazilSalinity = config_frazil_sea_ice_reference_salinity
         end if
 
-        !NJ: Determine salt expelled in the upper layer to arrive at the assumed frazil salt for coupling
-        if (sumNewFrazilIceThickness > 0.0_RKIND) then
+        !Determine salt expelled in the upper layer to arrive at the assumed frazil salt for coupling
+        if (sumNewFrazilIceThickness > 0.0_RKIND .and. usePorosity .ge. 1) then
            newThicknessWeightedSaltContent = sumNewFrazilIceThickness * frazilSalinity
            if (newThicknessWeightedSaltContent > sumNewThicknessWeightedSaltContent) then
-            !NJ:  Warning: salt conservation error. Track with lowSalinityFrazilIce
+            !Warning: salt conservation error. Track with lowSalinityFrazilIce
             lowSalinityFrazilIce(iCell) = newThicknessWeightedSaltContent - sumNewThicknessWeightedSaltContent
             accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + max(0.0_RKIND, sumNewThicknessWeightedSaltContent)
            else
-            !NJ: salt expelled at the surface
+            !salt expelled at the surface
             frazilSalinityTendency(minLevelCell(iCell),iCell) = frazilSalinityTendency(minLevelCell(iCell),iCell) + &
                 max(0.0_RKIND,(sumNewThicknessWeightedSaltContent -  newThicknessWeightedSaltContent) ) / dt
             accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + newThicknessWeightedSaltContent
            endif
-         else
-            accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell)
          endif ! if frazil ice is formed
       enddo   ! do iCell = 1, nCells
       !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -493,13 +493,15 @@ contains
 
         ! find deepest level where frazil can be created
         kBottomFrazil=maxLevelCell(iCell)
-        do k=maxLevelCell(iCell), minLevelCell(iCell), -1
+        !do k=maxLevelCell(iCell), minLevelCell(iCell), -1
           ! add the ssh so frazil can form below land ice, where the ssh is depressed
-          if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
-            kBottomFrazil=k
-            exit
-          endif
-        enddo
+        !  if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
+        !    kBottomFrazil=k
+        !    exit
+        !  endif
+        !enddo
+        !NJ: Compute frazil all through the column
+        kBottomFrazil=maxLevelCell(iCell)
 
         ! find minimum temperature between 1:kBottomFrazil
         columnTemperatureMin = 1.0e30_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -360,6 +360,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
       real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
       real (kind=RKIND), dimension(:), pointer :: frazilSurfacePressure
+      real (kind=RKIND), dimension(:), pointer :: lowSalinityFrazilIce
       integer, dimension(:), pointer :: landIceMask, landIceFloatingMask
 
       integer :: iCell, k, nCells
@@ -435,6 +436,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array(forcingPool, 'lowSalinityFrazilIce', lowSalinityFrazilIce)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
       call mpas_pool_get_array(forcingPool, 'frazilIceFreshwaterFlux', frazilIceFreshwaterFlux)
@@ -448,6 +450,9 @@ contains
       frazilSalinityTendency = 0.0_RKIND
       frazilLayerThicknessTendency = 0.0_RKIND
 
+      ! initialize frazil salinity conservation field
+      lowSalinityFrazilIce = 0.0_RKIND
+
       ! frazil fields are needed only over 0 and 1 halos
       nCells = nCellsArray( 2 )
 
@@ -457,7 +462,7 @@ contains
       !$omp private(underFloatingLandIce, underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
       !$omp         sumNewThicknessWeightedSaltContent, oceanFreezingTemperature, potential, &
       !$omp         freezingEnergy, meltingEnergy, frazilSalinity, newFrazilIceThickness, &
-      !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, &
+      !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, lowSalinityFrazilIce, &
       !$omp         meltedThicknessWeightedSaltContent)
       do iCell=1,nCells
 
@@ -525,13 +530,14 @@ contains
           freezingEnergy = max(0.0_RKIND, -potential)
           meltingEnergy = max(0.0_RKIND, potential)
 
+          !NJ:  Assume frazil ice retains salt until precipitating at the surface
           if (freezingEnergy > 0) then
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = 0.0_RKIND
+              frazilSalinity = 0.0_RKIND ! activeTracers(indexSalinity, k, iCell) !0.0_RKIND
             else
-              frazilSalinity = config_frazil_sea_ice_reference_salinity
+              frazilSalinity = activeTracers(indexSalinity, k, iCell) !config_frazil_sea_ice_reference_salinity
             end if
             frazilSalinity = min( frazilSalinity, activeTracers(indexSalinity, k, iCell) )
 
@@ -564,7 +570,6 @@ contains
             sumNewThicknessWeightedSaltContent = sumNewThicknessWeightedSaltContent + newThicknessWeightedSaltContent
 
           else
-
             ! ocean water is warm enough to melt frazil
 
             ! test to see if there is frazil to be melted
@@ -600,8 +605,8 @@ contains
                                                  / dt
 
               ! keep track of new frazil ice
-              sumNewThicknessWeightedSaltContent = sumNewThicknessWeightedSaltContent - meltedThicknessWeightedSaltContent
-              sumNewFrazilIceThickness = sumNewFrazilIceThickness - meltedFrazilIceThickness
+              sumNewThicknessWeightedSaltContent = max(0.0_RKIND,sumNewThicknessWeightedSaltContent - meltedThicknessWeightedSaltContent)
+              sumNewFrazilIceThickness = max(0.0_RKIND,sumNewFrazilIceThickness - meltedFrazilIceThickness)
 
             endif  ! if (sumNewFrazilIceThickness > 0.0_RKIND)
 
@@ -615,16 +620,36 @@ contains
         ! note: the accumulatedFrazilIceMass (at both time levels) is reset to zero after being sent to the coupler
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
                                            * config_frazil_ice_density
-        accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
+        !accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
 
+        !accumulatedFrazilIceSalinityTmp = sumNewThicknessWeightedSaltContent
         if ( underLandIce ) then
            ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
                                                   + sumNewFrazilIceThickness * config_frazil_ice_density
            ! There is no accumulatedLandIceFrazilSalinity because it is always 0
+           frazilSalinity = 0.0_RKIND
+        else
+           frazilSalinity = config_frazil_sea_ice_reference_salinity
         end if
 
+        ! Determine true salt in frazil
+        if (sumNewFrazilIceThickness > 0.0_RKIND) then
+           newThicknessWeightedSaltContent = sumNewFrazilIceThickness * frazilSalinity
+           if (newThicknessWeightedSaltContent > sumNewThicknessWeightedSaltContent) then
+            lowSalinityFrazilIce(iCell) = newThicknessWeightedSaltContent - sumNewThicknessWeightedSaltContent
+            ! Warning: May lead to a salt conservation error
+            accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + max(0.0_RKIND, sumNewThicknessWeightedSaltContent)
+           else
+            ! salt expelled at the surface
+            frazilSalinityTendency(minLevelCell(iCell),iCell) = frazilSalinityTendency(minLevelCell(iCell),iCell) + &
+                max(0.0_RKIND,(sumNewThicknessWeightedSaltContent -  newThicknessWeightedSaltContent) ) / dt
+            accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + newThicknessWeightedSaltContent
+           endif
+         else
+            accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell)
+         endif ! if frazil ice is formed
       enddo   ! do iCell = 1, nCells
       !$omp end do
       !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -535,7 +535,7 @@ contains
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = 0.0_RKIND ! activeTracers(indexSalinity, k, iCell) !0.0_RKIND
+              frazilSalinity = activeTracers(indexSalinity, k, iCell) !0.0_RKIND
             else
               frazilSalinity = activeTracers(indexSalinity, k, iCell) !config_frazil_sea_ice_reference_salinity
             end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -493,15 +493,15 @@ contains
 
         ! find deepest level where frazil can be created
         kBottomFrazil=maxLevelCell(iCell)
-        !do k=maxLevelCell(iCell), minLevelCell(iCell), -1
-          ! add the ssh so frazil can form below land ice, where the ssh is depressed
-        !  if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
-        !    kBottomFrazil=k
-        !    exit
-        !  endif
-        !enddo
+        do k=maxLevelCell(iCell), minLevelCell(iCell), -1
+         ! add the ssh so frazil can form below land ice, where the ssh is depressed
+          if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
+            kBottomFrazil=k
+            exit
+          endif
+        enddo
         !NJ: Compute frazil all through the column
-        kBottomFrazil=maxLevelCell(iCell)
+        !kBottomFrazil=max(maxLevelCell(iCell)-1,kBottomFrazil)
 
         ! find minimum temperature between 1:kBottomFrazil
         columnTemperatureMin = 1.0e30_RKIND
@@ -622,7 +622,7 @@ contains
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
            * config_frazil_ice_density
 
-        !NJ: Assumed frazil salinity in coupling with sea ice
+        !NJ: Assume frazil salinity is the coupling salinity
         if ( underLandIce ) then
            ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
            ! for freshwater budgets
@@ -638,11 +638,11 @@ contains
         if (sumNewFrazilIceThickness > 0.0_RKIND) then
            newThicknessWeightedSaltContent = sumNewFrazilIceThickness * frazilSalinity
            if (newThicknessWeightedSaltContent > sumNewThicknessWeightedSaltContent) then
+            !NJ:  Warning: salt conservation error. Track with lowSalinityFrazilIce
             lowSalinityFrazilIce(iCell) = newThicknessWeightedSaltContent - sumNewThicknessWeightedSaltContent
-            ! Warning: May lead to a salt conservation error
             accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + max(0.0_RKIND, sumNewThicknessWeightedSaltContent)
            else
-            ! salt expelled at the surface
+            !NJ: salt expelled at the surface
             frazilSalinityTendency(minLevelCell(iCell),iCell) = frazilSalinityTendency(minLevelCell(iCell),iCell) + &
                 max(0.0_RKIND,(sumNewThicknessWeightedSaltContent -  newThicknessWeightedSaltContent) ) / dt
             accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + newThicknessWeightedSaltContent

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -535,9 +535,9 @@ contains
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = activeTracers(indexSalinity, k, iCell) !0.0_RKIND
+              frazilSalinity = config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell) !0.0_RKIND
             else
-              frazilSalinity = activeTracers(indexSalinity, k, iCell) !config_frazil_sea_ice_reference_salinity
+              frazilSalinity = config_frazil_ice_porosity * activeTracers(indexSalinity, k, iCell) !config_frazil_sea_ice_reference_salinity
             end if
             frazilSalinity = min( frazilSalinity, activeTracers(indexSalinity, k, iCell) )
 
@@ -546,7 +546,6 @@ contains
 
             ! limit the frazil formed appropriately
             newFrazilIceThickness = min(newFrazilIceThickness, layerThickness(k,iCell) * config_frazil_fractional_thickness_limit)
-
 
             ! Determine new salt in frazil
             newThicknessWeightedSaltContent = newFrazilIceThickness * frazilSalinity
@@ -619,10 +618,9 @@ contains
         ! accumulate frazil mass to column total
         ! note: the accumulatedFrazilIceMass (at both time levels) is reset to zero after being sent to the coupler
         accumulatedFrazilIceMassNew(iCell) = accumulatedFrazilIceMassOld(iCell) + sumNewFrazilIceThickness &
-                                           * config_frazil_ice_density
-        !accumulatedFrazilIceSalinityNew(iCell) = accumulatedFrazilIceSalinityOld(iCell) + sumNewThicknessWeightedSaltContent
+           * config_frazil_ice_density
 
-        !accumulatedFrazilIceSalinityTmp = sumNewThicknessWeightedSaltContent
+        !NJ: Assumed frazil salinity in coupling with sea ice
         if ( underLandIce ) then
            ! accumulate frazil formed under land ice in case we're not coupling and we need to keep track of it
            ! for freshwater budgets
@@ -634,7 +632,7 @@ contains
            frazilSalinity = config_frazil_sea_ice_reference_salinity
         end if
 
-        ! Determine true salt in frazil
+        !NJ: Determine salt expelled in the upper layer to arrive at the assumed frazil salt for coupling
         if (sumNewFrazilIceThickness > 0.0_RKIND) then
            newThicknessWeightedSaltContent = sumNewFrazilIceThickness * frazilSalinity
            if (newThicknessWeightedSaltContent > sumNewThicknessWeightedSaltContent) then


### PR DESCRIPTION
Modifies how the  internal frazil salinity is calculated in interior ocean layers.
We currently use the coupling salinity of 4 psu (config_frazil_sea_ice_reference_salinity) or 0 if under ice shelves even in interior ocean layers.
This leads to an unphysically large salt flux at depth and too much freshening in upper layers.
The new approach is to use the local layer salinity times a frazli porosity namelist parameter (config_frazil_ice_porosity)  to estimate the salt content of frazil flocs in the ocean interior.
Any frazil accumulated at the surface is then adjusted so that it's salt content is consistent with 4 psu or 0 if under iceshelves.

