### PR TITLE
Possible addition of Brine plume parameterization

### DIFF
--- a/components/elm/src/biogeochem/AllocationMod.F90
+++ b/components/elm/src/biogeochem/AllocationMod.F90
@@ -645,7 +645,7 @@ contains
 
          if (stem_leaf(ivt(p)) < 0._r8) then
              if (stem_leaf(ivt(p)) == -1._r8) then
-                 f3 = (2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4
+                 f3 = max((2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4_r8, 0.2_r8)
              else
                  f3 = max((-1.0_r8*stem_leaf(ivt(p))*2.7_r8)/(1.0_r8+exp(-0.004_r8*(annsum_npp(p) - &
                            300.0_r8))) - 0.4_r8, 0.2_r8)
@@ -2118,7 +2118,7 @@ contains
 
              if (stem_leaf(ivt(p)) < 0._r8) then
                  if (stem_leaf(ivt(p)) == -1._r8) then
-                     f3 = (2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4
+                     f3 = max((2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4_r8, 0.2_r8)
                  else
                      f3 = max((-1.0_r8*stem_leaf(ivt(p))*2.7_r8)/(1.0_r8+exp(-0.004_r8*(annsum_npp(p) - &
                                300.0_r8))) - 0.4_r8, 0.2_r8)

--- a/components/mpas-albany-landice/cime_config/testdefs/testmods_dirs/mali/gis20km/user_nl_mali
+++ b/components/mpas-albany-landice/cime_config/testdefs/testmods_dirs/mali/gis20km/user_nl_mali
@@ -1,1 +1,3 @@
 config_am_globalstats_enable = .false.
+config_adaptive_timestep = .true.
+config_adaptive_timestep_force_interval = '0000-00-01_00:00:00'

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -557,6 +557,13 @@ contains
     call check_clocks_sync(domain % clock, Eclock, err_tmp)
     ierr = ior(ierr,err_tmp)
 
+    ! Reset the alarm for checking for force setting of the adaptive timestep interval
+    if (mpas_is_alarm_ringing(domain % clock, 'adaptiveTimestepForceInterval', ierr=err_tmp)) then
+       ierr = ior(ierr, err_tmp)
+       call mpas_reset_clock_alarm(domain % clock, 'adaptiveTimestepForceInterval', ierr=err_tmp)
+       ierr = ior(ierr, err_tmp)
+    endif
+    ierr = ior(ierr, err_tmp)
 
 !-----------------------------------------------------------------------
 !

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -463,6 +463,16 @@
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
+	<nml_record name="brine_rejection" mode="forward">
+	    <nml_option name="config_use_brine_rejection_parameterization" type="logical" default_value=".true."
+		            description="if true use brine rejection parameterization of Nguyen et al 2009"
+					possible_values=".true. or .false."
+		/>
+	    <nml_option name="config_brine_param_n" type="integer" default_value="5"
+                    description="power in the parameterization for distribution of the salinity flux"
+					possible_values='small integers (0-5)'
+		/>
+	</nml_record>
 	<nml_record name="cvmix" mode="forward">
 		<nml_option name="config_use_cvmix" type="logical" default_value=".true."
 					description="If true, use the Community Vertical MIXing routines to compute vertical diffusivity and viscosity"

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -149,7 +149,7 @@ mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_high_freq_thickness_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_tracer_nonlocalflux.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_nonlocalflux.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
 
 mpas_ocn_tracer_short_wave_absorption.o: mpas_ocn_tracer_short_wave_absorption_jerlov.o mpas_ocn_tracer_short_wave_absorption_variable.o mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -668,22 +668,24 @@ contains
                                                            - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
                                                            * latent_heat_fusion_mks) * hflux_factor
 
-        ! Negative seaIceSalinityFlux is an extraction of salt from the ocean
-        ! So, we negate seaIceSalinityFlux when determining how much salt this flux needs.
-        requiredSalt = - seaIceSalinityFlux(iCell) * sflux_factor * dt / layerThickness(minLevelCell(iCell), iCell)
-        allowedSalt = min( 4.0_RKIND, tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell) )
+        if (.not. config_use_brine_rejection_parameterization) then
+           ! Negative seaIceSalinityFlux is an extraction of salt from the ocean
+           ! So, we negate seaIceSalinityFlux when determining how much salt this flux needs.
+           requiredSalt = - seaIceSalinityFlux(iCell) * sflux_factor * dt / layerThickness(minLevelCell(iCell), iCell)
+           allowedSalt = min( 4.0_RKIND, tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell) )
 
-        if ( allowedSalt < requiredSalt ) then
-           tracersSurfaceFluxRemoved(index_salinity_flux, iCell) = tracersSurfaceFluxRemoved(index_salinity_flux, iCell)  &
-                                                                 + ( 1 - allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
-                                                                 * sflux_factor
+           if ( allowedSalt < requiredSalt ) then
+              tracersSurfaceFluxRemoved(index_salinity_flux, iCell) = tracersSurfaceFluxRemoved(index_salinity_flux, iCell)  &
+                                                                    + ( 1 - allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                                    * sflux_factor
 
-           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
-                                                          + ( allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
-                                                          * sflux_factor
-        else
-           tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+              tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
+                                                             + ( allowedSalt / requiredSalt ) * seaIceSalinityFlux(iCell) &
+                                                             * sflux_factor
+           else
+              tracersSurfaceFlux(index_salinity_flux, iCell) = tracersSurfaceFlux(index_salinity_flux, iCell)  &
                                                           + seaIceSalinityFlux(iCell) * sflux_factor
+           end if
         end if
       end do
       !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -492,168 +492,179 @@ contains
 
       err = 0
 
-      if (.not.landIceStandaloneOn) return
+      if (.not. (landIceStandaloneOn .or. landIceDataOn)) return
 
       call mpas_timer_start("land_ice_build_arrays")
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
-      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-
-      call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
-      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
-
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-      call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
-      call mpas_pool_get_array(forcingPool, 'heatFluxToLandIce', heatFluxToLandIce)
-
       call mpas_pool_get_array(forcingPool, 'frazilIceFreshwaterFlux', frazilIceFreshwaterFlux)
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFluxTotal', landIceFreshwaterFluxTotal)
-
-      call mpas_pool_get_array(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracers)
-      call mpas_pool_get_dimension(forcingPool, &
-                                'index_landIceInterfaceTemperature', &
-                                 indexITPtr)
-      call mpas_pool_get_dimension(forcingPool, &
-                                'index_landIceInterfaceSalinity', &
-                                 indexISPtr)
-      indexIT = indexITPtr
-      indexIS = indexISPtr
-
-      if (useHollandJenkinsAdvDiff) then
-         call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
-
-         allocate(freezeInterfaceSalinity(nCells), &
-                  freezeInterfaceTemperature(nCells), &
-                  freezeFreshwaterFlux(nCells), &
-                  freezeHeatFlux(nCells), &
-                  freezeIceHeatFlux(nCells))
-      end if
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       nCells = nCellsArray( size(nCellsArray) )
 
-      if (isomipOn) then !*** ISOMIP formulation
+      if (landIceStandaloneOn) then
 
-         !$omp parallel
-         !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
-         do iCell = 1, nCells
-            if (landIceFloatingMask(iCell) == 0) cycle
+         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
+         call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
+         call mpas_pool_get_array(forcingPool, 'heatFluxToLandIce', heatFluxToLandIce)
 
-            ! linearized equaiton for the S and p dependent potential freezing temperature
-            landIceInterfaceTracers(indexIT,iCell) = ocn_freezing_temperature( &
-               salinity=landIceBoundaryLayerTracers(indexBLT,iCell), &
-               pressure=landIcePressure(iCell), &
-               inLandIceCavity=.true.)
 
-            ! using (3) and (4) from Hunter (2006)
-            ! or (7) from Jenkins et al. (2001) if gamma constant
-            ! and no heat flux into ice
-            ! freshwater flux = density * melt rate is in kg/m^2/s
-            freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
-                       * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
+         call mpas_pool_get_array(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracers)
+         call mpas_pool_get_dimension(forcingPool, &
+                                 'index_landIceInterfaceTemperature', &
+                                    indexITPtr)
+         call mpas_pool_get_dimension(forcingPool, &
+                                 'index_landIceInterfaceSalinity', &
+                                    indexISPtr)
+         indexIT = indexITPtr
+         indexIS = indexISPtr
 
-            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*freshwaterFlux
+         if (useHollandJenkinsAdvDiff) then
+            call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
 
-            ! Using (13) from Jenkins et al. (2001)
-            ! heat flux is in W/s
-            heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
-                              + rho_sw*ISOMIPgammaT &
-                                * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
-            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*heatFlux
-
-            heatFluxToLandIce(iCell) = 0.0_RKIND
-
-         end do
-         !$omp end do
-         !$omp end parallel
-      endif ! isomipOn
-
-      if (jenkinsOn .or. hollandJenkinsOn) then
-         if(useHollandJenkinsAdvDiff) then
-            ! melting solution
-            call compute_HJ99_melt_fluxes( &
-               landIceFloatingMask, &
-               landIceBoundaryLayerTracers(indexBLT,:), &
-               landIceBoundaryLayerTracers(indexBLS,:), &
-               landIceTracerTransferVelocities(indexHeatTrans,:), &
-               landIceTracerTransferVelocities(indexSaltTrans,:), &
-               landIceSurfaceTemperature, &
-               landIcePressure, &
-               landIceInterfaceTracers(indexIT,:), &
-               landIceInterfaceTracers(indexIS,:), &
-               landIceFreshwaterFlux, &
-               landIceHeatFlux, &
-               heatFluxToLandIce, &
-               nCells, &
-               err)
-            if(err .ne. 0) then
-               call mpas_log_write( &
-                  'compute_HJ99_melt_fluxes failed.', &
-                  MPAS_LOG_CRIT)
-            end if
-
-            ! freezing solution
-            call compute_melt_fluxes( &
-               landIceFloatingMask, &
-               landIceBoundaryLayerTracers(indexBLT,:), &
-               landIceBoundaryLayerTracers(indexBLS,:), &
-               landIceTracerTransferVelocities(indexHeatTrans,:), &
-               landIceTracerTransferVelocities(indexSaltTrans,:), &
-               landIcePressure, &
-               freezeInterfaceTemperature, &
-               freezeInterfaceSalinity, &
-               freezeFreshwaterFlux, &
-               freezeHeatFlux, &
-               freezeIceHeatFlux, &
-               nCells, &
-               err)
-            if(err .ne. 0) then
-               call mpas_log_write( &
-                  'compute_melt_fluxes failed.', &
-                  MPAS_LOG_CRIT)
-            end if
-
-            do iCell = 1, nCells
-               if ((landIceFloatingMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
-
-               landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
-               landIceInterfaceTracers(indexIT,iCell) = freezeInterfaceTemperature(iCell)
-               landIceFreshwaterFlux(iCell) = freezeFreshwaterFlux(iCell)
-               landIceHeatFlux(iCell) = freezeHeatFlux(iCell)
-               heatFluxToLandIce(iCell) = freezeIceHeatFlux(iCell)
-            end do
-         else ! not using Holland and Jenkins advection/diffusion
-            call compute_melt_fluxes( &
-               landIceFloatingMask, &
-               landIceBoundaryLayerTracers(indexBLT,:), &
-               landIceBoundaryLayerTracers(indexBLS,:), &
-               landIceTracerTransferVelocities(indexHeatTrans,:), &
-               landIceTracerTransferVelocities(indexSaltTrans,:), &
-               landIcePressure, &
-               landIceInterfaceTracers(indexIT,:), &
-               landIceInterfaceTracers(indexIS,:), &
-               landIceFreshwaterFlux, &
-               landIceHeatFlux, &
-               heatFluxToLandIce, &
-               nCells, &
-               err)
-            if(err .ne. 0) then
-               call mpas_log_write( &
-                  'compute_melt_fluxes failed.', &
-                  MPAS_LOG_CRIT)
-            end if
+            allocate(freezeInterfaceSalinity(nCells), &
+                     freezeInterfaceTemperature(nCells), &
+                     freezeFreshwaterFlux(nCells), &
+                     freezeHeatFlux(nCells), &
+                     freezeIceHeatFlux(nCells))
          end if
 
-         ! modulate the fluxes by the landIceFloatingFraction
-         do iCell = 1, nCells
-            if (landIceFloatingMask(iCell) == 0) cycle
+         if (isomipOn) then !*** ISOMIP formulation
 
-            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*landIceFreshwaterFlux(iCell)
-            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*landIceHeatFlux(iCell)
-            heatFluxToLandIce(iCell) = landIceFloatingFraction(iCell)*heatFluxToLandIce(iCell)
-         end do
+            !$omp parallel
+            !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
+            do iCell = 1, nCells
+               if (landIceFloatingMask(iCell) == 0) cycle
 
-      endif ! jenkinsOn or hollandJenkinsOn
+               ! linearized equaiton for the S and p dependent potential freezing temperature
+               landIceInterfaceTracers(indexIT,iCell) = ocn_freezing_temperature( &
+                  salinity=landIceBoundaryLayerTracers(indexBLT,iCell), &
+                  pressure=landIcePressure(iCell), &
+                  inLandIceCavity=.true.)
+
+               ! using (3) and (4) from Hunter (2006)
+               ! or (7) from Jenkins et al. (2001) if gamma constant
+               ! and no heat flux into ice
+               ! freshwater flux = density * melt rate is in kg/m^2/s
+               freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
+                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
+
+               landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*freshwaterFlux
+
+               ! Using (13) from Jenkins et al. (2001)
+               ! heat flux is in W/s
+               heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
+                                 + rho_sw*ISOMIPgammaT &
+                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
+               landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*heatFlux
+
+               heatFluxToLandIce(iCell) = 0.0_RKIND
+
+            end do
+            !$omp end do
+            !$omp end parallel
+         end if ! isomipOn
+
+         if (jenkinsOn .or. hollandJenkinsOn) then
+            if(useHollandJenkinsAdvDiff) then
+               ! melting solution
+               call compute_HJ99_melt_fluxes( &
+                  landIceFloatingMask, &
+                  landIceBoundaryLayerTracers(indexBLT,:), &
+                  landIceBoundaryLayerTracers(indexBLS,:), &
+                  landIceTracerTransferVelocities(indexHeatTrans,:), &
+                  landIceTracerTransferVelocities(indexSaltTrans,:), &
+                  landIceSurfaceTemperature, &
+                  landIcePressure, &
+                  landIceInterfaceTracers(indexIT,:), &
+                  landIceInterfaceTracers(indexIS,:), &
+                  landIceFreshwaterFlux, &
+                  landIceHeatFlux, &
+                  heatFluxToLandIce, &
+                  nCells, &
+                  err)
+               if(err .ne. 0) then
+                  call mpas_log_write( &
+                     'compute_HJ99_melt_fluxes failed.', &
+                     MPAS_LOG_CRIT)
+               end if
+
+               ! freezing solution
+               call compute_melt_fluxes( &
+                  landIceFloatingMask, &
+                  landIceBoundaryLayerTracers(indexBLT,:), &
+                  landIceBoundaryLayerTracers(indexBLS,:), &
+                  landIceTracerTransferVelocities(indexHeatTrans,:), &
+                  landIceTracerTransferVelocities(indexSaltTrans,:), &
+                  landIcePressure, &
+                  freezeInterfaceTemperature, &
+                  freezeInterfaceSalinity, &
+                  freezeFreshwaterFlux, &
+                  freezeHeatFlux, &
+                  freezeIceHeatFlux, &
+                  nCells, &
+                  err)
+               if(err .ne. 0) then
+                  call mpas_log_write( &
+                     'compute_melt_fluxes failed.', &
+                     MPAS_LOG_CRIT)
+               end if
+
+               do iCell = 1, nCells
+                  if ((landIceFloatingMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
+
+                  landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
+                  landIceInterfaceTracers(indexIT,iCell) = freezeInterfaceTemperature(iCell)
+                  landIceFreshwaterFlux(iCell) = freezeFreshwaterFlux(iCell)
+                  landIceHeatFlux(iCell) = freezeHeatFlux(iCell)
+                  heatFluxToLandIce(iCell) = freezeIceHeatFlux(iCell)
+               end do
+            else ! not using Holland and Jenkins advection/diffusion
+               call compute_melt_fluxes( &
+                  landIceFloatingMask, &
+                  landIceBoundaryLayerTracers(indexBLT,:), &
+                  landIceBoundaryLayerTracers(indexBLS,:), &
+                  landIceTracerTransferVelocities(indexHeatTrans,:), &
+                  landIceTracerTransferVelocities(indexSaltTrans,:), &
+                  landIcePressure, &
+                  landIceInterfaceTracers(indexIT,:), &
+                  landIceInterfaceTracers(indexIS,:), &
+                  landIceFreshwaterFlux, &
+                  landIceHeatFlux, &
+                  heatFluxToLandIce, &
+                  nCells, &
+                  err)
+               if(err .ne. 0) then
+                  call mpas_log_write( &
+                     'compute_melt_fluxes failed.', &
+                     MPAS_LOG_CRIT)
+               end if
+            end if
+
+            ! modulate the fluxes by the landIceFloatingFraction
+            do iCell = 1, nCells
+               if (landIceFloatingMask(iCell) == 0) cycle
+
+               landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*landIceFreshwaterFlux(iCell)
+               landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*landIceHeatFlux(iCell)
+               heatFluxToLandIce(iCell) = landIceFloatingFraction(iCell)*heatFluxToLandIce(iCell)
+            end do
+
+         end if ! jenkinsOn or hollandJenkinsOn
+
+         if(useHollandJenkinsAdvDiff) then
+            deallocate(freezeInterfaceSalinity, &
+                     freezeInterfaceTemperature, &
+                     freezeFreshwaterFlux, &
+                     freezeHeatFlux, &
+                     freezeIceHeatFlux)
+         end if
+
+      end if ! landIceStandaloneOn
 
       ! Add frazil and interface melt/freeze to get total fresh water flux
       if ( associated(frazilIceFreshwaterFlux) ) then
@@ -664,14 +675,6 @@ contains
           do iCell = 1, nCells
                 landIceFreshwaterFluxTotal(iCell) = landIceFreshwaterFlux(iCell)
           end do
-      end if
-
-      if(useHollandJenkinsAdvDiff) then
-         deallocate(freezeInterfaceSalinity, &
-                    freezeInterfaceTemperature, &
-                    freezeFreshwaterFlux, &
-                    freezeHeatFlux, &
-                    freezeIceHeatFlux)
       end if
 
       call mpas_timer_stop("land_ice_build_arrays")

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -128,6 +128,7 @@ contains
       ! pointers for the actual output variables within the pools above
       real (kind=RKIND), dimension(:), pointer, contiguous :: &
          surfaceThicknessFlux,     &! surface thickness flux
+         seaIceSalinityFlux,       &
          surfaceThicknessFluxRunoff, &! surface thickness flux from runoff
          surfaceThicknessFluxSubglacialRunoff ! surface thickness flux from runoff
 
@@ -627,6 +628,7 @@ contains
 
       real (kind=RKIND), dimension(:), pointer, contiguous :: &
          penetrativeTemperatureFlux, &! heat flux penetrating below sfc
+         seaIceSalinityFlux, &
          tracerGroupExponentialDecayRate ! exp decay rate for forcing
 
       real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
@@ -702,6 +704,8 @@ contains
                                              penetrativeTemperatureFlux)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', &
                                              fractionAbsorbed)
+      call mpas_pool_get_array(forcingPool, 'seaIceSalinityFlux', &
+                                             seaIceSalinityFlux)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', &
                                              fractionAbsorbedRunoff)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbedSubglacialRunoff', &
@@ -1339,15 +1343,21 @@ contains
                endif ! compute budgets
 
                if (isActiveTracer) then
-                  call ocn_tracer_nonlocalflux_tend(meshPool, &
+                  call ocn_tracer_nonlocalflux_tend( &
                                           vertNonLocalFlux, &
                                           nonLocalSurfaceTracerFlux, &
                                           tracerGroupTend, err)
                else ! not active
-                  call ocn_tracer_nonlocalflux_tend(meshPool, &
+                  call ocn_tracer_nonlocalflux_tend( &
                                           vertNonLocalFlux, &
                                           tracerGroupSurfaceFlux, &
                                           tracerGroupTend, err)
+                  if (config_use_brine_rejection_parameterization) then
+                     call ocn_brine_rejection_tendency(tracerGroupTend, &
+                                          layerThickness, &
+                                          seaIceSalinityFlux, &
+                                          indexSalinity, dt, err)
+                  end if
                endif ! active tracer
 
                if (computeBudgets) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -26,6 +26,8 @@ module ocn_tracer_nonlocalflux
    use mpas_pool_routines
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
+   use ocn_mesh
 
    implicit none
    private
@@ -44,7 +46,8 @@ module ocn_tracer_nonlocalflux
    !--------------------------------------------------------------------
 
    public :: ocn_tracer_nonlocalflux_tend, &
-             ocn_tracer_nonlocalflux_init
+             ocn_tracer_nonlocalflux_init, &
+             ocn_brine_rejection_tendency
 
    !--------------------------------------------------------------------
    !
@@ -60,6 +63,84 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_brine_rejction_tend
+!
+!> \brief   Computes tendency term due to brine rejection
+!> \author  Luke Van Roekel
+!> \date    11/08/24
+!> \details
+!>  This routine computes the tendency for salinity from brine rejection, based on 
+!>      Nguyen et al 2009
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_brine_rejection_tendency(tend, layerThickness, seaIceSalinityFlux, index_salinity, dt, err)
+      !----------------------------------------------------------------
+      !
+      ! variables
+      !
+      !----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend !< tracer tendency, only will modify the salinity tend here
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         seaIceSalinityFlux
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness
+
+      real, dimension(:), allocatable :: sis_flux
+
+      real (kind=RKIND) :: dt
+
+      integer, intent(in) :: index_salinity
+
+      integer :: err
+
+      !----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !----------------------------------------------------------------
+
+      integer :: iCell, k, nCells
+
+      real (kind=RKIND) :: remainder, z, integral, D, A, rejectedSalt
+
+      nCells = nCellsHalo(1)
+
+      allocate(sis_flux(nVertLevels+1))
+
+      do iCell = 1, nCells
+        if (seaIceSalinityFlux(iCell) > 0) then !only compute for salinity into ocean
+           sis_flux(:) = 0.0_RKIND
+           D = boundaryLayerDepth(iCell)
+           z = 0.0_RKIND
+           A = (config_brine_param_n + 1) / D**(config_brine_param_n+1)
+           k = minLevelCell(iCell)
+           ! need a salinity flux top and bottom and the flux into a cell is the divergence??
+           do while (z < D)
+              sis_flux(k) = A*z**config_brine_param_n*seaIceSalinityFlux(iCell)
+              z = z + layerThickness(k,iCell)
+              k = k + 1
+           end do
+           ! need to pick up the last bit that goes over
+           sis_flux(k) = 1.0_RKIND ! this should finish
+
+           do k=minLevelCell(iCell),maxLevelCell(iCell)
+              ! need to flip over so we take k+1 - k
+              tend(index_salinity, k, iCell) = tend(index_salinity, k, iCell) + &
+                 sis_flux(k+1) - sis_flux(k)
+           end do
+        end if
+      end do
+
+      deallocate(sis_flux)
+  end subroutine ocn_brine_rejection_tendency
+
+!***********************************************************************
+!
 !  routine ocn_tracer_nonlocalflux_tend
 !
 !> \brief   Computes tendency term due to non-local flux transport
@@ -70,15 +151,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_nonlocalflux_tend(meshPool, vertNonLocalFlux, surfaceTracerFlux, tend, err)!{{{
+   subroutine ocn_tracer_nonlocalflux_tend(vertNonLocalFlux, surfaceTracerFlux, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
         surfaceTracerFlux !< Input: surface tracer fluxes
@@ -110,9 +188,6 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k, iTracer, nTracers, nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND) :: fluxTopOfCell, fluxBottomOfCell
 
       err = 0
@@ -121,14 +196,9 @@ contains
 
       call mpas_timer_start('non-local flux')
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tend, dim=1)
 
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-      nCells = nCellsArray( 1 )
+      nCells = nCellsHalo( 1 )
 
       !$omp parallel
       !$omp do schedule(runtime) private(k, iTracer, fluxTopOfCell, fluxBottomOfCell)


### PR DESCRIPTION
This potential feature is meant to mimic (in a simple way) the parameterization of Nguyen et al 2009 (https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2008JC005121) which is designed to limit the penetration of brine rejection plumes in models that often leads to overly deep haloclines in the arctic.  It is my understanding of how Section 3.1 describes the parameterization.  Translated to MPAS, I think this should be transporting the `seaIceSalinityFlux` which is the salinity rejected back to the ocean in ice formation.  Here that flux is removed from the KPP non local flux and given a different shape function according to the paper.  There is still work to be done, but was hoping for input on the implementation. In particular @maltrud, @milenaveneziani and @cbegeman I'd appreciate your thoughts.