### PR TITLE
New spatially-variable horizontal upwind capability

### DIFF
--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -295,6 +295,7 @@ inline void setup_tracer_data(TracerData &tracer_data,             // out
                               const int cyclical_ymd)              // in
 {
   scorpio::register_file(trace_data_file, scorpio::Read);
+  scorpio::pretend_dim_is_unlimited(trace_data_file,"time");
   // by default, I am assuming a zonal file.
   TracerFileType tracer_file_type = ZONAL;
 

--- a/components/eamxx/tests/single-process/CMakeLists.txt
+++ b/components/eamxx/tests/single-process/CMakeLists.txt
@@ -16,19 +16,13 @@ else()
   message(STATUS "RRTMGP and COSP only supported for double precision builds; skipping")
 endif()
 if (SCREAM_ENABLE_MAM)
-  # Once the mam4xx aerosol microphysics AtmosphereProcess is running, the
-  # corresponding test here needs to be reworked with valid aerosol
-  # initial conditions.
   add_subdirectory(mam/optics)
   add_subdirectory(mam/aci)
   add_subdirectory(mam/drydep)
   add_subdirectory(mam/emissions)
   add_subdirectory(mam/constituent_fluxes)
   add_subdirectory(mam/wet_scav)
-
-  # Currently this test produces non-deterministic output.
-  # Commenting it so the other PRs can test normally
-  # add_subdirectory(mam/aero_microphys)
+  add_subdirectory(mam/aero_microphys)
 endif()
 if (SCREAM_TEST_LEVEL GREATER_EQUAL SCREAM_TEST_LEVEL_EXPERIMENTAL)
   add_subdirectory(zm)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1133,6 +1133,18 @@
 					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'. For 'constant', uses constant thickness in time from restingThickness, for linear test problems. Note that these two flags are set together for linearized test cases: config_thickness_flux_type = 'constant' linearizes the thickness equation, and config_disable_vel_hadv = .true. linearizes the momentum equation if there is no assumed mean background velocity."
 					possible_values="'upwind', 'centered', 'constant'"
 		/>
+		<nml_option name="config_use_spatially_variable_upwind" type="logical" default_value=".false."
+					description="If true, use upwindFactor to scale layerThickEdgeFlux by centered and upwind values."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_spatially_variable_upwind_hmin" type="real" default_value="1.0"
+					description="Column thickness above which we start weighting upwind with centered advection."
+					possible_values="Any positive real"
+		/>
+		<nml_option name="config_spatially_variable_upwind_hmax" type="real" default_value="10.0"
+					description="Column thickness above which advection is no longer upwinded."
+					possible_values="Any positive real"
+		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
 		<nml_option name="config_bottom_drag_mode" type="character" default_value="implicit"
@@ -1789,6 +1801,7 @@
 			<var name="fCell"/>
 			<var name="bed_elevation"/>
 			<var name="LTSRegion"/>
+			<var name="upwindFactor"/>
 		</stream>
 
 		<stream name="output_init"
@@ -1823,6 +1836,7 @@
 			<var name="landIceFloatingMask"/>
 			<var name="landIceFloatingFraction"/>
 			<var name="LTSRegion"/>
+			<var name="upwindFactor"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -3058,6 +3072,11 @@
 			 missing_value="FILLVAL" missing_value_mask="vertexMask"
 			 packages="forwardMode;analysisMode"
 		/>
+		<!-- Input fields from initial condition for spatially variable upwinding -->
+		<var name="upwindFactor" type="real" dimensions="nEdges Time" units="1"
+			description="The fraction of horizontal advection that is upwinded. Range from 0 (centered) to 1 (fully upwind)"
+		/>
+
 
 		<var name="kineticEnergyCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^-2"
 			 description="kinetic energy of horizontal velocity on cells"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1137,7 +1137,7 @@
 					description="If true, use upwindFactor to scale layerThickEdgeFlux by centered and upwind values."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_spatially_variable_upwind_hmin" type="real" default_value="1.0"
+		<nml_option name="config_spatially_variable_upwind_hmin" type="real" default_value="5.0"
 					description="Column thickness above which we start weighting upwind with centered advection."
 					possible_values="Any positive real"
 		/>

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -857,7 +857,7 @@ contains
          iEdge, k,     &! edge and vertical loop indices
          cell1, cell2, &! neighbor cell indices across an edge
          kmin, kmax     ! min,max active vertical levels
-
+      real(kind=RKIND) :: columnThickness
       ! End preamble
       !-----------------------------------------------------------------
       ! Begin code
@@ -991,18 +991,31 @@ contains
             !$acc    present(layerThickEdgeMean, layerThickEdgeFlux, &
             !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
             !$acc            upwindFactor) &
-            !$acc    private(k, kmin, kmax)
+            !$acc    private(k, kmin, kmax, columnThickness)
 #else
             !$omp parallel
-            !$omp do schedule(runtime) private(k, kmin, kmax)
+            !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2, columnThickness)
 #endif
             do iEdge = 1, nEdgesAll
-               kmin = minLevelEdgeBot(iEdge)
-               kmax = maxLevelEdgeTop(iEdge)
-               do k = kmin,kmax
-                  layerThickEdgeFlux(k,iEdge) = (1.0_RKIND - upwindFactor(iEdge)) * layerThickEdgeMean(k,iEdge) &
-                                              + upwindFactor(iEdge)* layerThickEdgeFlux(k,iEdge)
-               end do
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              columnThickness = min(bottomDepth(cell1) + ssh(cell1), &
+                                    bottomDepth(cell2) + ssh(cell2))
+              if (columnThickness <= config_spatially_variable_upwind_hmin) then
+                upwindFactor(iEdge) = 1.0_RKIND
+              elseif (columnThickness >= config_spatially_variable_upwind_hmax) then
+                upwindFactor(iEdge) = 0.0_RKIND
+              else
+                upwindFactor(iEdge) = 1.0_RKIND - &
+                                      (columnThickness - config_spatially_variable_upwind_hmin) / &
+                                      (config_spatially_variable_upwind_hmax - config_spatially_variable_upwind_hmin)
+              end if
+              kmin = minLevelEdgeBot(iEdge)
+              kmax = maxLevelEdgeTop(iEdge)
+              do k = kmin,kmax
+                 layerThickEdgeFlux(k,iEdge) = (1.0_RKIND - upwindFactor(iEdge)) * layerThickEdgeMean(k,iEdge) &
+                                             + upwindFactor(iEdge)* layerThickEdgeFlux(k,iEdge)
+              end do
             end do
 #ifndef MPAS_OPENACC
             !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -985,7 +985,30 @@ contains
 #endif
 
         end if
-
+        if (config_use_spatially_variable_upwind) then
+#ifdef MPAS_OPENACC
+            !$acc parallel loop &
+            !$acc    present(layerThickEdgeMean, layerThickEdgeFlux, &
+            !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+            !$acc            upwindFactor) &
+            !$acc    private(k, kmin, kmax)
+#else
+            !$omp parallel
+            !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
+            do iEdge = 1, nEdgesAll
+               kmin = minLevelEdgeBot(iEdge)
+               kmax = maxLevelEdgeTop(iEdge)
+               do k = kmin,kmax
+                  layerThickEdgeFlux(k,iEdge) = (1.0_RKIND - upwindFactor(iEdge)) * layerThickEdgeMean(k,iEdge) &
+                                              + upwindFactor(iEdge)* layerThickEdgeFlux(k,iEdge)
+               end do
+            end do
+#ifndef MPAS_OPENACC
+            !$omp end do
+            !$omp end parallel
+#endif
+        endif
       case (thickEdgeFluxConstant)
          ! Use linearized version H*u where H is constant in time
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -70,6 +70,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfCell
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfEdge
 
+   real (kind=RKIND), dimension(:), pointer :: upwindFactor
    real (kind=RKIND), dimension(:), pointer :: gradSSH
    real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
    real (kind=RKIND), dimension(:), pointer :: pgf_sal
@@ -289,6 +290,10 @@ contains
                    layerThicknessCellWetDry)
          call mpas_pool_get_array(diagnosticsPool, 'sshCellWetDry', &
                    sshCellWetDry)
+      end if
+      if (config_use_spatially_variable_upwind) then
+         call mpas_pool_get_array(diagnosticsPool, 'upwindFactor', &
+                   upwindFactor)
       end if
 
       if (config_use_GM.or.config_use_Redi) then
@@ -811,6 +816,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   upwindFactor,                    &
          !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
@@ -1072,6 +1078,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   upwindFactor,                    &
          !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
@@ -1280,6 +1287,7 @@ contains
                  GMStreamFuncX,                   &
                  GMStreamFuncY,                   &
                  GMStreamFuncZ,                   &
+                 upwindFactor,                    &
                  layerThickEdgeDrag,              &
                  layerThickEdgeFlux,              &
                  layerThickEdgeMean,              &


### PR DESCRIPTION
Here we add a new capability to transition between centered and upwinded horizontal thickness advection as a function of column thickness.

Formerly, either thickness advection was centered or upwinded everywhere. With this PR, when `config_use_spatially_variable_upwinding` is `.true.`, advection is fully upwinded when the column thickness is less than `config_spatially_variable_upwind_hmin` and fully centered when column thickness is greater than `config_spatially_variable_upwind_hmax`. Between these values, there is a linear transition `layerThickEdgeFlux`
