### PR TITLE
Add EAM namelist for non-asymmetric spectral partitioning of solar irradiance across visible/near infrared

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -853,6 +853,9 @@ add_default($nl,'use_rad_dt_cosz');
 #if 0., no rayleigh friction is applied
 add_default($nl, 'raytau0');
 
+# DC
+add_default($nl, 'rad_asym_vis');
+
 # these options were added for global RCE and they only work with RRTMGP
 my $rad_pkg = $cfg->get('rad');
 if ($rad_pkg eq 'rrtmgp') {

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1859,6 +1859,9 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <!-- Radiation bugfix -->
 <use_rad_dt_cosz phys="default">.true.</use_rad_dt_cosz>
 
+<!-- DC -->
+<rad_asym_vis phys="default">0.5 </rad_asym_vis>
+
 <!-- Tunable parameters for 72 layer model -->
 
 <ice_sed_ai phys="default" microphys="mg2"> 500.0     </ice_sed_ai>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4453,6 +4453,12 @@ the value is less than 0
 Default: -1
 </entry>
 
+<entry id="rad_asym_vis" type="real"  category="radiation"
+       group="radiation_nl" valid_values="" >
+Split radiation asymmetrically between VIS/NIR, coef for VIS
+Default: 0.5
+</entry>
+
 <entry id="spectralflux" type="logical"  category="radiation"
        group="radiation_nl" valid_values="" >
 Return fluxes per band in addition to the total fluxes.

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_rad.f90
@@ -68,6 +68,11 @@
       use rrtmg_sw_spcvmc, only: spcvmc_sw
 
       use perf_mod
+!DC
+!      use radiation_readnl, only: rad_asym_vis
+!      use radiation, only: radiation_readnl
+!      use radiation, only: rad_asym_vis
+      use cam_logfile,     only: iulog
 
       implicit none
 
@@ -196,6 +201,9 @@
       use rrsw_aer, only : rsrtaua, rsrpiza, rsrasya
       use rrsw_con, only : heatfac, oneminus, pi
       use rrsw_wvn, only : wavenum1, wavenum2
+
+!      use radiation_readnl, only: rad_asym_vis
+!      use radiation, only: rad_asym_vis
 
 ! ------- Declarations
 
@@ -352,6 +360,11 @@
       real(kind=r8) :: taua(nlay,nbndsw)      ! Aerosol optical depth
       real(kind=r8) :: ssaa(nlay,nbndsw)      ! Aerosol single scattering albedo
       real(kind=r8) :: asma(nlay,nbndsw)      ! Aerosol asymmetry parameter
+
+!DC
+!      real(kind=r8) :: rad_asym_vis              ! DC nl
+      real(kind=r8) :: vis_frc                   ! JPT Weight of flux VIS-ward in band 9
+      real(kind=r8) :: nir_frc                   ! JPT Weight of flux NIR-ward in band 9
 
 ! Atmosphere - setcoef
       integer :: laytrop                        ! tropopause layer index
@@ -585,8 +598,17 @@
          albdif(nbndsw) = aldif(iplon)
 !  Set band 24 (or, band 9 counting from 1) to use linear average of UV/visible
 !  and near-IR values, since this band straddles 0.7 microns: 
-         albdir(9) = 0.5*(aldir(iplon) + asdir(iplon))
-         albdif(9) = 0.5*(aldif(iplon) + asdif(iplon))
+         !DC change to read in from namelist
+!         call radiation_readnl
+         vis_frc = 0.5             ! default
+         nir_frc = 1.0 - vis_frc   ! default
+!         vis_frc = rad_asym_vis    ! DC testing namelist
+!         nir_frc = 1.0 - vis_frc   ! DC testing
+!         vis_frc = 0.555           ! JPT: Proposed value
+!         nir_frc = 1.0 - vis_frc   ! JPT: Proposed value
+         albdir(9) = (nir_frc*aldir(iplon)) + (vis_frc*asdir(iplon))
+         albdif(9) = (nir_frc*aldif(iplon)) + (vis_frc*asdif(iplon))
+!write(iulog,*) 'Rad asym vis = ',rad_asym_vis ! DC debug
 !  UV/visible bands 25-28 (10-13), 16000-50000 cm-1, 0.200-0.625 micron
          do ib=10,13
             albdir(ib) = asdir(iplon)

--- a/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
+++ b/components/eam/src/physics/rrtmg/ext/rrtmg_mcica/rrtmg_sw_spcvmc.f90
@@ -263,6 +263,9 @@
       real(kind=r8) :: zcd(nlayers+1,ngptsw), zcu(nlayers+1,ngptsw)
       real(kind=r8) :: zfd(nlayers+1,ngptsw), zfu(nlayers+1,ngptsw)
 
+! Ratio of flux in RRTMG_SW band 9 in VIS vs NIR Band
+      real(kind=r8) :: vis_frc, nir_frc
+
 ! Inactive arrays
 !     real(kind=r8) :: zbbcd(nlayers+1), zbbcu(nlayers+1)
 !     real(kind=r8) :: zbbfd(nlayers+1), zbbfu(nlayers+1)
@@ -585,6 +588,17 @@
 !   Two-stream calculations go from top to bottom; 
 !   layer indexing is reversed to go bottom to top for output arrays
 
+!   JPT 20240605: include option for an asymetric split of 9th RRTMG_SW
+!   band which straddles the VIS/NIR split sent to surface model.
+!   Current implentation breaks splits band 9 50/50. But offline simulations
+!   hyperspectral simulations suggest a ~55/45 split would more appropriate
+
+            vis_frc = 0.5             ! Default
+            nir_frc = 1.0 - vis_frc   ! Default
+!            vis_frc = 0.555           ! JPT: Proposed value
+!            nir_frc = 1.0 - vis_frc   ! JPT: Proposed value
+
+
             do jk=1,klev+1
                ikl=klev+2-jk
 
@@ -625,23 +639,23 @@
                   endif
 ! band 9 is half-NearIR and half-Visible
                else if (ibm == 9) then  
-                  puvcd(ikl) = puvcd(ikl) + 0.5_r8*zincflx(iw)*zcd(jk,iw)
-                  puvfd(ikl) = puvfd(ikl) + 0.5_r8*zincflx(iw)*zfd(jk,iw)
-                  pnicd(ikl) = pnicd(ikl) + 0.5_r8*zincflx(iw)*zcd(jk,iw)
-                  pnifd(ikl) = pnifd(ikl) + 0.5_r8*zincflx(iw)*zfd(jk,iw)
+                  puvcd(ikl) = puvcd(ikl) + vis_frc*zincflx(iw)*zcd(jk,iw)
+                  puvfd(ikl) = puvfd(ikl) + vis_frc*zincflx(iw)*zfd(jk,iw)
+                  pnicd(ikl) = pnicd(ikl) + nir_frc*zincflx(iw)*zcd(jk,iw)
+                  pnifd(ikl) = pnifd(ikl) + nir_frc*zincflx(iw)*zfd(jk,iw)
                   if (idelm .eq. 0) then
-                     puvfddir(ikl) = puvfddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt_nodel(jk)
-                     puvcddir(ikl) = puvcddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc_nodel(jk)
-                     pnifddir(ikl) = pnifddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt_nodel(jk)
-                     pnicddir(ikl) = pnicddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc_nodel(jk)
+                     puvfddir(ikl) = puvfddir(ikl) + vis_frc*zincflx(iw)*ztdbt_nodel(jk)
+                     puvcddir(ikl) = puvcddir(ikl) + vis_frc*zincflx(iw)*ztdbtc_nodel(jk)
+                     pnifddir(ikl) = pnifddir(ikl) + nir_frc*zincflx(iw)*ztdbt_nodel(jk)
+                     pnicddir(ikl) = pnicddir(ikl) + nir_frc*zincflx(iw)*ztdbtc_nodel(jk)
                   elseif (idelm .eq. 1) then
-                     puvfddir(ikl) = puvfddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt(jk)
-                     puvcddir(ikl) = puvcddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc(jk)
-                     pnifddir(ikl) = pnifddir(ikl) + 0.5_r8*zincflx(iw)*ztdbt(jk)
-                     pnicddir(ikl) = pnicddir(ikl) + 0.5_r8*zincflx(iw)*ztdbtc(jk)
+                     puvfddir(ikl) = puvfddir(ikl) + vis_frc*zincflx(iw)*ztdbt(jk)
+                     puvcddir(ikl) = puvcddir(ikl) + vis_frc*zincflx(iw)*ztdbtc(jk)
+                     pnifddir(ikl) = pnifddir(ikl) + nir_frc*zincflx(iw)*ztdbt(jk)
+                     pnicddir(ikl) = pnicddir(ikl) + nir_frc*zincflx(iw)*ztdbtc(jk)
                   endif
-                  pnicu(ikl) = pnicu(ikl) + 0.5_r8*zincflx(iw)*zcu(jk,iw)
-                  pnifu(ikl) = pnifu(ikl) + 0.5_r8*zincflx(iw)*zfu(jk,iw)
+                  pnicu(ikl) = pnicu(ikl) + nir_frc*zincflx(iw)*zcu(jk,iw)
+                  pnifu(ikl) = pnifu(ikl) + nir_frc*zincflx(iw)*zfu(jk,iw)
 ! Accumulate direct fluxes for near-IR bands
                else if (ibm == 14 .or. ibm <= 8) then  
                   pnicd(ikl) = pnicd(ikl) + zincflx(iw)*zcd(jk,iw)

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -75,6 +75,8 @@ logical :: spectralflux  = .false. ! calculate fluxes (up and down) per band.
 
 logical :: use_rad_dt_cosz  = .false. ! if true, uses the radiation dt for all cosz calculations !BSINGH - Added for solar insolation calc.
 
+real(r8) :: rad_asym_vis = 0.5_r8 ! DC add
+
 ! Flag to indicate whether to read optics from spa netcdf file
 ! NOTE: added for consistency with RRTMGP; this is non-functioning for RRTMG!
 logical :: do_spa_optics = .false.
@@ -120,7 +122,7 @@ subroutine radiation_readnl(nlfile, dtime_in)
    ! Variables defined in namelist
    namelist /radiation_nl/ iradsw, iradlw, irad_always, &
                            use_rad_dt_cosz, spectralflux, &
-                           do_spa_optics
+                           do_spa_optics, rad_asym_vis
 
    ! Read the namelist, only if called from master process
    ! TODO: better documentation and cleaner logic here?
@@ -146,6 +148,7 @@ subroutine radiation_readnl(nlfile, dtime_in)
    call mpibcast(use_rad_dt_cosz, 1, mpi_logical, mstrid, mpicom, ierr)
    call mpibcast(spectralflux, 1, mpi_logical, mstrid, mpicom, ierr)
    call mpibcast(do_spa_optics, 1, mpi_logical, mstrid, mpicom, ierr)
+   call mpibcast(rad_asym_vis, 1, mpi_logical, mstrid, mpicom, ierr)
 #endif
 
    ! Make sure nobody tries to use SPA optics with RRTMG
@@ -288,6 +291,8 @@ subroutine radiation_printopts
 10 format(' Execute SW/LW radiation continuously for the first ',i5, ' timestep(s) of this run')
 20 format(' Frequency of Shortwave Radiation calc. (IRADSW)     ',i5/, &
           ' Frequency of Longwave Radiation calc. (IRADLW)      ',i5)
+!DC
+   write(iulog,*) 'Rad asym vis = ',rad_asym_vis
 
 end subroutine radiation_printopts
 

--- a/components/eam/src/physics/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/rrtmgp/radiation.F90
@@ -1969,6 +1969,7 @@ contains
       type(cam_out_t), intent(inout) :: cam_out
       character(len=*), intent(in) :: band
       integer :: icol
+      real(kind=r8) :: vis_frc, nir_frc     !JPT  Ratio of flux in RRTMG_SW band 9  (Band 10 in RRTMGP) in VIS vs NIR Band
       real(r8), dimension(size(fluxes%bnd_flux_dn,1), &
                           size(fluxes%bnd_flux_dn,2), &
                           size(fluxes%bnd_flux_dn,3)) :: flux_dn_diffuse
@@ -2006,6 +2007,11 @@ contains
          ! Calculate diffuse flux from total and direct
          flux_dn_diffuse = fluxes%bnd_flux_dn - fluxes%bnd_flux_dn_dir
 
+         vis_frc = 0.5             ! Default
+         nir_frc = 1.0 - vis_frc   ! Default
+!         vis_frc = 0.555            ! JPT: Proposed value
+!         nir_frc = 1.0 - vis_frc    ! JPT: Proposed value
+
          ! Calculate broadband surface solar fluxes (UV/visible vs near IR) for
          ! each column.
          do icol = 1,size(fluxes%bnd_flux_dn, 1)
@@ -2013,17 +2019,17 @@ contains
             ! Direct fluxes
             cam_out%soll(icol) &
                = sum(fluxes%bnd_flux_dn_dir(icol,kbot+1,1:9)) &
-               + 0.5_r8 * fluxes%bnd_flux_dn_dir(icol,kbot+1,10)
+               + nir_frc * fluxes%bnd_flux_dn_dir(icol,kbot+1,10)
             cam_out%sols(icol) &
-               = 0.5_r8 * fluxes%bnd_flux_dn_dir(icol,kbot+1,10) &
+               = vis_frc * fluxes%bnd_flux_dn_dir(icol,kbot+1,10) &
                + sum(fluxes%bnd_flux_dn_dir(icol,kbot+1,11:14))
 
             ! Diffuse fluxes
             cam_out%solld(icol) &
                = sum(flux_dn_diffuse(icol,kbot+1,1:9)) &
-               + 0.5_r8 * flux_dn_diffuse(icol,kbot+1,10)
+               + nir_frc * flux_dn_diffuse(icol,kbot+1,10)
             cam_out%solsd(icol) &
-               = 0.5_r8 * flux_dn_diffuse(icol,kbot+1,10) &
+               = vis_frc * flux_dn_diffuse(icol,kbot+1,10) &
                + sum(flux_dn_diffuse(icol,kbot+1,11:14))
 
             ! Net shortwave flux at surface
@@ -2212,6 +2218,13 @@ contains
       integer :: ncol, iband
       character(len=10) :: subname = 'set_albedo'
 
+      real(kind=r8) :: vis_frc, nir_frc     !JPT  Ratio of flux in RRTMG_SW band 9  (Band 10 in RRTMGP) in VIS vs NIR Band
+
+      vis_frc = 0.5             ! Default
+      nir_frc = 1.0 - vis_frc   ! Default
+!      vis_frc = 0.555            ! JPT: Proposed value
+!      nir_frc = 1.0 - vis_frc    ! JPT: Proposed value
+
       ! Check dimension sizes of output arrays.
       ! albedo_dir and albedo_dif should have sizes nswbands,ncol, but ncol
       ! can change so we just check that it is less than or equal to pcols (the
@@ -2261,8 +2274,10 @@ contains
             ! Band straddles the visible to near-infrared transition, so we take
             ! the albedo to be the average of the visible and near-infrared
             ! broadband albedos
-            albedo_dir(iband,1:ncol) = 0.5 * (cam_in%aldir(1:ncol) + cam_in%asdir(1:ncol))
-            albedo_dif(iband,1:ncol) = 0.5 * (cam_in%aldif(1:ncol) + cam_in%asdif(1:ncol))
+            ! JPT 20241025: Change from a linear average to a weighted average,
+            ! weighted by the vis/nir fraction of insolation within the split rrtmg/rrtmgp band
+            albedo_dir(iband,1:ncol) = nir_frc * cam_in%aldir(1:ncol) + vis_frc * cam_in%asdir(1:ncol)
+            albedo_dif(iband,1:ncol) = nir_frc * cam_in%aldif(1:ncol) + vis_frc * cam_in%asdif(1:ncol)
 
          end if
       end do


### PR DESCRIPTION
Trying to generalize https://github.com/jtolento/E3SM/tree/asm_splt to add a namelist option to support a non-50/50 split of the RRTMG spectral band overlapping visible and near-infrared.

Juan's simulation using this split is documented here: https://acme-climate.atlassian.net/wiki/spaces/PSC/pages/4586963131/WCYCL1850_asym_splt

Opening here for visibility.