### PR TITLE
Fixes to glc-ocn flux and pressure coupling

### DIFF
--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -1500,7 +1500,8 @@ contains
 
    type (block_type), pointer :: block
 
-   real (kind=RKIND), pointer :: config_sea_level
+   real (kind=RKIND), pointer :: config_sea_level, &
+                                 config_ice_density
    character(len=StrKIND), pointer :: config_basal_mass_bal_float
 
    type (mpas_pool_type), pointer :: meshPool
@@ -1517,8 +1518,10 @@ contains
    real (kind=RKIND), dimension(:), pointer :: avgCalvingFlux
    real (kind=RKIND), dimension(:), pointer :: avgFaceMeltFlux
    real (kind=RKIND), dimension(:), pointer :: avgFloatingBMBFlux
+   real (kind=RKIND), dimension(:), pointer :: bedTopography
    real (kind=RKIND), dimension(:,:), pointer :: temperature
    integer, dimension(:), pointer :: cellMask
+   integer :: belowSeaLevelMask
    !-------------------------------------------------------------------
 
     errorCode = 0
@@ -1528,6 +1531,7 @@ contains
 
     call mpas_pool_get_config(domain % configs, 'config_sea_level', config_sea_level)
     call mpas_pool_get_config(domain % configs, 'config_basal_mass_bal_float', config_basal_mass_bal_float)
+    call mpas_pool_get_config(domain % configs, 'config_ice_density', config_ice_density)
 
     do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
@@ -1542,6 +1546,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
          call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness, timeLevel = 1)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
 
          call mpas_pool_get_array(timeAveragingPool, 'avgBareIceAblationApplied', avgBareIceAblationApplied)
@@ -1572,7 +1577,18 @@ contains
             g2x_g % rAttr(index_g2x_Sg_tbot, n) = temperature(nVertlevels,i) - SHR_CONST_TKTRIP
             ! layerThickness is not populated on init, so calculating like this instead:
             g2x_g % rAttr(index_g2x_Sg_dztbot, n) = layerThicknessFractions(nVertLevels) * thickness(i) / 2.0
-            g2x_g % rAttr(index_g2x_Sg_lithop, n) = thickness(i) * config_ice_density * SHR_CONST_G
+
+            ! A mask for quantities remapped to the ocean indicating where bedrock is below sea level
+            ! and thus where ocean can possibly be in contact with the ice sheet.
+            if (bedTopography(i) <= config_sea_level) then
+               belowSeaLevelMask = 1
+            else
+               belowSeaLevelMask = 0
+            endif
+            g2x_g % rAttr(index_g2x_Sg_below_sea_level_mask, n) = belowSeaLevelMask
+
+            ! mask lithostatic pressure to only locations below sea level
+            g2x_g % rAttr(index_g2x_Sg_lithop, n) = belowSeaLevelMask * thickness(i) * config_ice_density * SHR_CONST_G
 
             !!!Mask configurations
             g2x_g % rAttr(index_g2x_Sg_ice_covered, n) = li_mask_is_ice_int(cellMask(i))
@@ -1592,8 +1608,8 @@ contains
             g2x_g % rAttr(index_g2x_Sg_icemask_coupled_fluxes, n) = g2x_g % rAttr(index_g2x_Sg_icemask, n)
 
             ! Add masks used for ice shelf basal melt calculation
-            g2x_g % rAttr(index_g2x_Sg_icemask_floating, n) = li_mask_is_floating_ice_int(cellMask(i))
-            g2x_g % rAttr(index_g2x_Sg_icemask_grounded, n) = li_mask_is_grounded_ice_int(cellMask(i))
+            g2x_g % rAttr(index_g2x_Sg_icemask_below_sea_level, n) = belowSeaLevelMask * li_mask_is_ice_int(cellMask(i))
+            g2x_g % rAttr(index_g2x_Sg_icemask_floating, n) = belowSeaLevelMask * li_mask_is_floating_ice_int(cellMask(i))
 
          end do
 

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -1541,7 +1541,7 @@ contains
 
          call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
          call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
-         call mpas_pool_get_array(geometryPool, 'thickness', Thickness, timeLevel = 1)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness, timeLevel = 1)
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
 
          call mpas_pool_get_array(timeAveragingPool, 'avgBareIceAblationApplied', avgBareIceAblationApplied)
@@ -1572,7 +1572,7 @@ contains
             g2x_g % rAttr(index_g2x_Sg_tbot, n) = temperature(nVertlevels,i) - SHR_CONST_TKTRIP
             ! layerThickness is not populated on init, so calculating like this instead:
             g2x_g % rAttr(index_g2x_Sg_dztbot, n) = layerThicknessFractions(nVertLevels) * thickness(i) / 2.0
-            g2x_g % rAttr(index_g2x_Sg_lithop, n) = Thickness(i)*SHR_CONST_RHOICE*SHR_CONST_G
+            g2x_g % rAttr(index_g2x_Sg_lithop, n) = thickness(i) * config_ice_density * SHR_CONST_G
 
             !!!Mask configurations
             g2x_g % rAttr(index_g2x_Sg_ice_covered, n) = li_mask_is_ice_int(cellMask(i))

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -909,9 +909,9 @@ contains
          ! Finally, set whence to latest_before so we have piecewise-constant forcing.
          ! Could add, e.g., linear interpolation later.
 
-         ! NOTE: If any input ("forcing") files here contain fields that the coupler also passes, 
-         ! the input file versions here will clobber the fields passed from the coupler. 
-         
+         ! NOTE: If any input ("forcing") files here contain fields that the coupler also passes,
+         ! the input file versions here will clobber the fields passed from the coupler.
+
          call mpas_stream_mgr_read(domain % streamManager, whence=MPAS_STREAM_LATEST_BEFORE, saveActualWhen = .true., ierr=err_tmp)
          err = ior(err, err_tmp)
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
@@ -1555,11 +1555,11 @@ contains
             n = n + 1
 
             ! Fogg_rofl
-            g2x_g % rAttr(index_g2x_Fogg_rofl,n) = avgBareIceAblationApplied(i) 
+            g2x_g % rAttr(index_g2x_Fogg_rofl,n) = avgBareIceAblationApplied(i)
             ! Figg_rofi
             g2x_g % rAttr(index_g2x_Figg_rofi,n) = 0.0 ! placeholder
             ! Fogg_rofi
-            g2x_g % rAttr(index_g2x_Fogg_rofi,n) = avgCalvingFlux(i) 
+            g2x_g % rAttr(index_g2x_Fogg_rofi,n) = avgCalvingFlux(i)
             g2x_g % rAttr(index_g2x_Fogg_rofi,n) = g2x_g % rAttr(index_g2x_Fogg_rofi,n) + avgFaceMeltFlux(i)
             if (trim(config_basal_mass_bal_float) == 'ismip6') then
                ! if MALI is calculating ISMF, add that to rofi
@@ -1643,10 +1643,10 @@ contains
       character (len=StrKIND), intent(out) :: timeStamp
       real (kind=RKIND) :: secondsPerHour, secondsPerMinute, remaining
       integer :: minutes, hours, secondsLeft
-   
+
       secondsPerHour = 3600
       secondsPerMinute = 60
-   
+
       if(seconds < 0 .or. seconds > 86400) then
         secondsLeft = 00
         minutes = 00
@@ -1654,16 +1654,16 @@ contains
       else
         hours = int(seconds/secondsPerHour)
         remaining = seconds - real(hours) * secondsPerHour
-   
+
         minutes = int(remaining/secondsPerMinute)
         remaining = remaining - real(minutes) * secondsPerMinute
-   
+
         secondsLeft = int(remaining)
       end if
-   
+
       write(timeStamp,"(a,i2.2,a,i2.2,a,i2.2)") "00_",hours,":",minutes,":",secondsLeft
       timeStamp = trim(timeStamp)
-   
+
    end subroutine convert_seconds_to_timestamp!}}}
 
    subroutine add_stream_attributes(stream_manager, domain)!{{{

--- a/components/mpas-albany-landice/driver/glc_cpl_indices.F
+++ b/components/mpas-albany-landice/driver/glc_cpl_indices.F
@@ -1,5 +1,5 @@
 module glc_cpl_indices
-  
+
   use seq_flds_mod
   use mct_mod
 !  use glc_constants, only : glc_nec, glc_smb  ! TODO Will these be needed?  If so, need to add MPAS version
@@ -41,8 +41,9 @@ module glc_cpl_indices
   integer, public :: index_g2x_Sg_blit = 0 !Boundary layer interface temperature for ocean
   integer, public :: index_g2x_Sg_icemask = 0 !complete grounded/floating ice mask
   integer, public :: index_g2x_Sg_ice_covered = 0 !ice covered ice mask
-  integer, public :: index_g2x_Sg_icemask_grounded = 0 !grounded mask
+  integer, public :: index_g2x_Sg_icemask_below_sea_level = 0 !ice mask where topography is below sea level
   integer, public :: index_g2x_Sg_icemask_floating = 0 !floating mask
+  integer, public :: index_g2x_Sg_below_sea_level_mask = 0 !below sea level mask
   integer, public :: index_g2x_Sg_icemask_coupled_fluxes = 0 !ice mask for coupled fluxes
 
 contains
@@ -135,8 +136,14 @@ contains
     ! ice sheet landunit SMB vs. bare land landunit SMB.  This mask is used by
     ! CLM to differentiate bare land and ice sheet landunit types.
 
-    index_g2x_Sg_icemask_grounded =       mct_avect_indexra(g2x,'Sg_icemask_grounded',perrwith='quiet')
-    index_g2x_Sg_icemask_floating =       mct_avect_indexra(g2x,'Sg_icemask_floating',perrwith='quiet')
+    ! a mask where ice is prsent and topography is below sea level (0 or 1)
+    index_g2x_Sg_icemask_below_sea_level = mct_avect_indexra(g2x,'Sg_icemask_below_sea_level',perrwith='quiet')
+    ! a mask where ice is floating and topography is below sea level (0 or 1)
+    index_g2x_Sg_icemask_floating =        mct_avect_indexra(g2x,'Sg_icemask_floating',perrwith='quiet')
+    ! a mask of where the bed topography is below sea level (0 or 1), used to
+    ! mask fields passed to the ocean
+    index_g2x_Sg_below_sea_level_mask =   mct_avect_indexra(g2x,'Sg_below_sea_level_mask',perrwith='quiet')
+
     index_g2x_Sg_icemask_coupled_fluxes = mct_avect_indexra(g2x,'Sg_icemask_coupled_fluxes',perrwith='quiet')
     ! mask of ice sheet grid coverage where we are potentially sending non-zero
     ! fluxes (state: current snapshot)

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -880,7 +880,6 @@ add_default($nl, 'config_land_ice_flux_attenuation_coefficient');
 add_default($nl, 'config_land_ice_flux_boundaryLayerThickness');
 add_default($nl, 'config_land_ice_flux_boundaryLayerNeighborWeight');
 add_default($nl, 'config_land_ice_flux_cp_ice');
-add_default($nl, 'config_land_ice_flux_rho_ice');
 add_default($nl, 'config_land_ice_flux_explicit_topDragCoeff');
 add_default($nl, 'config_land_ice_flux_ISOMIP_gammaT');
 add_default($nl, 'config_land_ice_flux_jenkins_heat_transfer_coefficient');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -334,7 +334,6 @@ add_default($nl, 'config_land_ice_flux_attenuation_coefficient');
 add_default($nl, 'config_land_ice_flux_boundaryLayerThickness');
 add_default($nl, 'config_land_ice_flux_boundaryLayerNeighborWeight');
 add_default($nl, 'config_land_ice_flux_cp_ice');
-add_default($nl, 'config_land_ice_flux_rho_ice');
 add_default($nl, 'config_land_ice_flux_explicit_topDragCoeff');
 add_default($nl, 'config_land_ice_flux_ISOMIP_gammaT');
 add_default($nl, 'config_land_ice_flux_jenkins_heat_transfer_coefficient');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -473,7 +473,6 @@
 <config_land_ice_flux_boundaryLayerThickness>10.0</config_land_ice_flux_boundaryLayerThickness>
 <config_land_ice_flux_boundaryLayerNeighborWeight>0.0</config_land_ice_flux_boundaryLayerNeighborWeight>
 <config_land_ice_flux_cp_ice>2.009e3</config_land_ice_flux_cp_ice>
-<config_land_ice_flux_rho_ice>918</config_land_ice_flux_rho_ice>
 <config_land_ice_flux_explicit_topDragCoeff>2.5e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="oEC60to30v3wLI">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E1r2">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1772,14 +1772,6 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_land_ice_flux_rho_ice" type="real"
-	category="land_ice_fluxes" group="land_ice_fluxes">
-The density of land ice.
-
-Valid values: Any positive real number
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_land_ice_flux_explicit_topDragCoeff" type="real"
 	category="land_ice_fluxes" group="land_ice_fluxes">
 The top drag coefficient if config_use_implicit_top_drag_coeff is false.

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -145,9 +145,9 @@ module mpaso_cpl_indices
   integer :: index_x2o_Sg_blit
   integer :: index_x2o_Sg_blis
   integer :: index_x2o_Sg_lithop
-  integer :: index_x2o_Sg_icemask
-  integer :: index_x2o_Sg_icemask_grounded
+  integer :: index_x2o_Sg_icemask_below_sea_level
   integer :: index_x2o_Sg_icemask_floating
+  integer :: index_x2o_Sg_below_sea_level_mask
 
 
   ! drv -> ocn (BGC)
@@ -337,9 +337,9 @@ contains
     index_x2o_Sg_blit    = mct_avect_indexra(x2o,'Sg_blit')
     index_x2o_Sg_blis    = mct_avect_indexra(x2o,'Sg_blis')
     index_x2o_Sg_lithop  = mct_avect_indexra(x2o,'Sg_lithop')
-    index_x2o_Sg_icemask = mct_avect_indexra(x2o,'Sg_icemask')
-    index_x2o_Sg_icemask = mct_avect_indexra(x2o,'Sg_icemask_grounded')
-    index_x2o_Sg_icemask = mct_avect_indexra(x2o,'Sg_icemask_floating')
+    index_x2o_Sg_icemask_below_sea_level = mct_avect_indexra(x2o,'Sg_icemask_below_sea_level')
+    index_x2o_Sg_icemask_floating = mct_avect_indexra(x2o,'Sg_icemask_floating')
+    index_x2o_Sg_below_sea_level_mask = mct_avect_indexra(x2o,'Sg_below_sea_level_mask')
 
     if (wav_ocn_coup == 'twoway') then
        index_x2o_Sw_ustokes_wavenumber_1 = mct_avect_indexra(x2o,'Sw_ustokes_wavenumber_1')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -1,5 +1,5 @@
 module mpaso_cpl_indices
-  
+
   use seq_flds_mod
   use mct_mod
 
@@ -12,7 +12,7 @@ module mpaso_cpl_indices
 
   ! ocn -> drv
 
-  integer :: index_o2x_So_t      
+  integer :: index_o2x_So_t
   integer :: index_o2x_So_u
   integer :: index_o2x_So_v
   integer :: index_o2x_So_s
@@ -83,7 +83,7 @@ module mpaso_cpl_indices
   integer :: index_x2o_Foxx_tauy       ! meridonal wind stress (tauy)     (W/m2   )
   integer :: index_x2o_Foxx_swnet      ! net short-wave heat flux         (W/m2   )
   integer :: index_x2o_Foxx_sen        ! sensible heat flux               (W/m2   )
-  integer :: index_x2o_Foxx_lat        
+  integer :: index_x2o_Foxx_lat
   integer :: index_x2o_Foxx_lwup       ! longwave radiation (up)          (W/m2   )
   integer :: index_x2o_Faxa_lwdn       ! longwave radiation (down)        (W/m2   )
   integer :: index_x2o_Fioi_melth      ! heat flux from snow & ice melt   (W/m2   )
@@ -92,7 +92,7 @@ module mpaso_cpl_indices
   integer :: index_x2o_Fioi_bergw      ! iceberg melt flux                (kg/m2/s)
   integer :: index_x2o_Fioi_salt       ! salt                             (kg(salt)/m2/s)
   integer :: index_x2o_Foxx_evap       ! evaporation flux                 (kg/m2/s)
-  integer :: index_x2o_Faxa_prec         
+  integer :: index_x2o_Faxa_prec
   integer :: index_x2o_Faxa_snow       ! water flux due to snow           (kg/m2/s)
   integer :: index_x2o_Faxa_rain       ! water flux due to rain           (kg/m2/s)
   integer :: index_x2o_Faxa_bcphidry   ! flux: Black   Carbon hydrophilic dry deposition
@@ -122,17 +122,17 @@ module mpaso_cpl_indices
   integer :: index_x2o_Foxx_rofPN      ! PN  runoff flux                  (kg/m2/s)
   integer :: index_x2o_Foxx_rofDIC     ! DIC runoff flux                  (kg/m2/s)
   integer :: index_x2o_Foxx_rofFe      ! Fe  runoff flux                  (kg/m2/s)
-  integer :: index_x2o_Sw_ustokes_wavenumber_1      ! partitioned Stokes drift wavenumber 1 
+  integer :: index_x2o_Sw_ustokes_wavenumber_1      ! partitioned Stokes drift wavenumber 1
   integer :: index_x2o_Sw_vstokes_wavenumber_1      ! partitioned Stokes drift wavenumber 1
-  integer :: index_x2o_Sw_ustokes_wavenumber_2      ! partitioned Stokes drift wavenumber 2 
+  integer :: index_x2o_Sw_ustokes_wavenumber_2      ! partitioned Stokes drift wavenumber 2
   integer :: index_x2o_Sw_vstokes_wavenumber_2      ! partitioned Stokes drift wavenumber 2
-  integer :: index_x2o_Sw_ustokes_wavenumber_3      ! partitioned Stokes drift wavenumber 3 
+  integer :: index_x2o_Sw_ustokes_wavenumber_3      ! partitioned Stokes drift wavenumber 3
   integer :: index_x2o_Sw_vstokes_wavenumber_3      ! partitioned Stokes drift wavenumber 3
-  integer :: index_x2o_Sw_ustokes_wavenumber_4      ! partitioned Stokes drift wavenumber 4 
+  integer :: index_x2o_Sw_ustokes_wavenumber_4      ! partitioned Stokes drift wavenumber 4
   integer :: index_x2o_Sw_vstokes_wavenumber_4      ! partitioned Stokes drift wavenumber 4
-  integer :: index_x2o_Sw_ustokes_wavenumber_5      ! partitioned Stokes drift wavenumber 5 
+  integer :: index_x2o_Sw_ustokes_wavenumber_5      ! partitioned Stokes drift wavenumber 5
   integer :: index_x2o_Sw_vstokes_wavenumber_5      ! partitioned Stokes drift wavenumber 5
-  integer :: index_x2o_Sw_ustokes_wavenumber_6      ! partitioned Stokes drift wavenumber 6 
+  integer :: index_x2o_Sw_ustokes_wavenumber_6      ! partitioned Stokes drift wavenumber 6
   integer :: index_x2o_Sw_vstokes_wavenumber_6      ! partitioned Stokes drift wavenumber 6
   integer :: index_x2o_Sw_Hs         ! Significant wave height
   integer :: index_x2o_Sw_Fp         ! Peak wave frequency
@@ -177,7 +177,7 @@ contains
 
   subroutine mpaso_cpl_indices_set( )
 
-    use seq_flds_mod, only : wav_ocn_coup      
+    use seq_flds_mod, only : wav_ocn_coup
     use glc_zocnclass_mod
 
     type(mct_aVect) :: o2x      ! temporary
@@ -270,14 +270,14 @@ contains
     index_x2o_Foxx_sen      = mct_avect_indexra(x2o,'Foxx_sen')
     index_x2o_Foxx_lwup     = mct_avect_indexra(x2o,'Foxx_lwup')
     index_x2o_Faxa_lwdn     = mct_avect_indexra(x2o,'Faxa_lwdn')
-    index_x2o_Fioi_melth    = mct_avect_indexra(x2o,'Fioi_melth')   
+    index_x2o_Fioi_melth    = mct_avect_indexra(x2o,'Fioi_melth')
     index_x2o_Fioi_meltw    = mct_avect_indexra(x2o,'Fioi_meltw')
     index_x2o_Fioi_bergh    = mct_avect_indexra(x2o,'PFioi_bergh')
     index_x2o_Fioi_bergw    = mct_avect_indexra(x2o,'PFioi_bergw')
-    index_x2o_Fioi_salt     = mct_avect_indexra(x2o,'Fioi_salt')   
-    index_x2o_Faxa_prec     = mct_avect_indexra(x2o,'Faxa_prec')   
-    index_x2o_Faxa_snow     = mct_avect_indexra(x2o,'Faxa_snow')   
-    index_x2o_Faxa_rain     = mct_avect_indexra(x2o,'Faxa_rain')   
+    index_x2o_Fioi_salt     = mct_avect_indexra(x2o,'Fioi_salt')
+    index_x2o_Faxa_prec     = mct_avect_indexra(x2o,'Faxa_prec')
+    index_x2o_Faxa_snow     = mct_avect_indexra(x2o,'Faxa_snow')
+    index_x2o_Faxa_rain     = mct_avect_indexra(x2o,'Faxa_rain')
     index_x2o_Foxx_evap     = mct_avect_indexra(x2o,'Foxx_evap')
     index_x2o_Foxx_rofl     = mct_avect_indexra(x2o,'Foxx_rofl')
     index_x2o_Foxx_rofi     = mct_avect_indexra(x2o,'Foxx_rofi')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3313,11 +3313,6 @@ contains
 !      o2x_o % rAttr(index_o2x_Faoo_fdms_ocn, n) = DMSFlux(i)
 !      o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = surfaceUpwardCO2Flux(i)
 
-!JW       o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTemperature(i)
-!JW       o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerSalinity(i)
-!JW       o2x_o % rAttr(index_o2x_So_htv, n) = landIceHeatTransferVelocity(i)
-!JW       o2x_o % rAttr(index_o2x_So_stv, n) = landIceSaltTransferVelocity(i)
-
        if ( trim(config_land_ice_flux_mode) .eq. 'standalone' .or. &
             trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
@@ -3343,19 +3338,6 @@ contains
           enddo
        endif
 
-
-       !Fyke: test
-       !write(stderrUnit,*) 'n=',n
-       !write(stderrUnit,*) 'o2x_o % rAttr(index_o2x_So_blt, n)=',o2x_o % rAttr(index_o2x_So_blt, n)
-       !write(stderrUnit,*) 'o2x_o % rAttr(index_o2x_So_bls, n)=',o2x_o % rAttr(index_o2x_So_bls, n)
-       !write(stderrUnit,*) 'o2x_o % rAttr(index_o2x_So_htv, n)=',o2x_o % rAttr(index_o2x_So_htv, n)
-       !write(stderrUnit,*) 'o2x_o % rAttr(index_o2x_So_stv, n)=',o2x_o % rAttr(index_o2x_So_stv, n)
-       !write(stderrUnit,*) 'o2x_o % rAttr(index_o2x_So_rhoeff, n)=',o2x_o % rAttr(index_o2x_So_rhoeff, n)
-       !o2x_o % rAttr(index_o2x_So_blt, n) = 0._r8
-       !o2x_o % rAttr(index_o2x_So_bls, n) = 34.5_r8
-       !o2x_o % rAttr(index_o2x_So_htv, n) = 1.e-4_r8
-       !o2x_o % rAttr(index_o2x_So_stv, n) = 3.e-6_r8
-       !o2x_o % rAttr(index_o2x_So_rhoeff, n) = 1000._r8*9.81_r8*918._r8 !lithostatic pressure of 1km of ice
 
      end do
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3807,7 +3807,7 @@ contains
 
    real (kind=RKIND), dimension(:,:), pointer :: landIceInterfaceTracers
 
-   real (kind=RKIND) :: riverFactor
+   real (kind=RKIND) :: riverFactor, belowSeaLevelFraction
 
    logical :: landIceFluxesCoupled
 
@@ -4180,11 +4180,21 @@ contains
            landIceInterfaceTracers(indexIT, i) = x2o_om(n, index_x2o_Sg_blit)
            landIceInterfaceTracers(indexIS, i) = x2o_om(n, index_x2o_Sg_blis)
 
-           ! We are not yet ready for MALI to supply land-ice fraction, floating
-           !  fraction or pressure
-           ! landIceFraction(i) = x2o_om(n, index_x2o_Sg_icemask)
-           ! landIceFloatingFraction(i) = x2o_om(n, index_x2o_Sg_???)
-           ! landIcePressure(i) = x2o_om(n, index_x2o_Sg_lithop)
+           belowSeaLevelFraction = x2o_om(n, index_x2o_Sg_below_sea_level_mask)
+
+           ! normalize the masks and pressure by the fraction of the cell
+           ! that is below sea level, since this was used to mask the fields
+           ! before remapping
+           if (belowSeaLevelFraction > 0.0_RKIND) then
+              landIceFloatingFraction(i) = x2o_om(n, index_x2o_Sg_icemask_floating) / belowSeaLevelFraction
+              landIceFraction(i) = x2o_om(n, index_x2o_Sg_icemask_below_sea_level) / belowSeaLevelFraction
+              landIcePressure(i) = x2o_om(n, index_x2o_Sg_lithop) / belowSeaLevelFraction
+           else
+              landIceFloatingFraction(i) = 0.0_RKIND
+              landIceFraction(i) = 0.0_RKIND
+              landIcePressure(i) = 0.0_RKIND
+           end if
+
         end if
 
         ! BGC fields

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -127,7 +127,7 @@ module ocn_comp_mct
    integer :: itimestep, &  ! time step number for MPAS
               ocn_cpl_dt    ! length of coupling interval in seconds - set by coupler/ESMF
 
-   real (kind=RKIND) :: precFactor 
+   real (kind=RKIND) :: precFactor
 
 !=======================================================================
 
@@ -243,10 +243,10 @@ contains
     real (kind=RKIND), pointer :: &
        runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
-    ! freshwater balance adjustment 
+    ! freshwater balance adjustment
     logical, pointer :: config_use_precip_scaling
     character (len=StrKIND), pointer :: config_precip_scaling_mode
-    real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+    real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes
     real(kind=RKIND), pointer :: scalingFactor
 
 #ifdef HAVE_MOAB
@@ -848,9 +848,9 @@ contains
        ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-       ! Initialize the precipitation scaling scheme 
+       ! Initialize the precipitation scaling scheme
        call ocn_scaled_sfwf_init(domain)
-       ! Ensure a valid first guess at the initial time 
+       ! Ensure a valid first guess at the initial time
        call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
        if (config_use_precip_scaling) then
           call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
@@ -858,10 +858,10 @@ contains
           block_ptr => domain % blocklist
           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
           call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-          if (trim(config_precip_scaling_mode) == 'time-dependent') then 
+          if (trim(config_precip_scaling_mode) == 'time-dependent') then
             call mpas_pool_get_config(domain % configs, 'config_precip_scaling_initial_factor', scalingFactor)
           else if (trim(config_precip_scaling_mode) == 'constant') then
-            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', scalingFactor) 
+            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', scalingFactor)
           end if
           ! Broadcast the scalar to the field
           SFWFScalingFactor = scalingFactor
@@ -915,7 +915,7 @@ contains
       ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-      ! initialize scaled data freshwater fluxes based on water balance relationship 
+      ! initialize scaled data freshwater fluxes based on water balance relationship
        call ocn_scaled_sfwf_init(domain)
 
     end if
@@ -954,13 +954,13 @@ contains
 
     !configuration for freshwater conservation
     call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
-    if (config_use_precip_scaling) then 
+    if (config_use_precip_scaling) then
       ! independent of space so should be no need to loop over blocks
       block_ptr => domain % blocklist
       call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
       call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
       call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
-    end if 
+    end if
 
 !-----------------------------------------------------------------------
 !
@@ -1089,9 +1089,9 @@ contains
       real (kind=RKIND), pointer :: &
          runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
-      ! freshwater balance adjustment 
+      ! freshwater balance adjustment
       logical, pointer :: config_use_precip_scaling
-      real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+      real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes
 
 #ifdef HAVE_MOAB
 #ifdef MOABCOMP
@@ -1346,7 +1346,7 @@ contains
             call mpas_log_write('   Validating ocean state')
          endif
 
-        ! update scalling factors for freshwater fluxes 
+        ! update scalling factors for freshwater fluxes
         call ocn_update_scaling_factor(domain, timeLevel=1)
 
          call ocn_validate_state(domain, timeLevel=1)
@@ -2126,12 +2126,10 @@ contains
                                   riverFluxFeField,   &
                                   landIceFreshwaterFluxField, &
                                   landIceHeatFluxField, &
-                                  landIceFractionField, &
                                   windSpeed10mField, &
-                                 significantWaveHeightField, &
+                                  significantWaveHeightField, &
                                   peakWaveFrequencyField, &
                                   peakWaveDirectionField
-                                  !landIcePressureField
 
    type (field2DReal), pointer :: iceFluxPhytoCField, &
                                   iceFluxDOCField
@@ -2177,13 +2175,11 @@ contains
                                                riverFluxFe,   &
                                                landIceFreshwaterFlux, &
                                                landIceHeatFlux, &
-                                               landIceFraction, &
                                                areaCell, &
                                                windSpeed10m, &
                                                significantWaveHeight, &
                                                peakWaveFrequency, &
                                                peakWaveDirection
-                                               !landIcePressure
 
    real (kind=RKIND), dimension(:), pointer :: latCell
 
@@ -2199,7 +2195,9 @@ contains
 
    real (kind=RKIND) :: riverFactor
 
-   ! freshwater balance adjustment 
+   logical :: landIceFluxesCoupled
+
+   ! freshwater balance adjustment
    logical, pointer :: config_use_precip_scaling
 
 !-----------------------------------------------------------------------
@@ -2237,8 +2235,14 @@ contains
    !configuration for freshwater balance constrains
    call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
    if (config_use_precip_scaling) then
-      !extract scaling factors 
+      !extract scaling factors
       call seq_infodata_GetData(infodata, precip_fact=precFactor)
+   end if
+
+   if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+      landIceFluxesCoupled = .true.
+   else
+      landIceFluxesCoupled = .false.
    end if
 
    n = 0
@@ -2283,15 +2287,12 @@ contains
 
       call mpas_pool_get_field(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFluxField)
       call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
-      call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
       call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
 
       call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
 
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
-
-   !call mpas_pool_get_field(forcingPool, 'landIcePressure', landIcePressureField)
 
       windStressZonal => windStressZonalField % array
       windStressMeridional => windStressMeridionalField % array
@@ -2319,14 +2320,12 @@ contains
       landIceFreshwaterFlux => landIceFreshwaterFluxField % array
       landIceHeatFlux => landIceHeatFluxField % array
       landIceInterfaceTracers => landIceInterfaceTracersField % array
-      landIceFraction => landIceFractionField % array
       windSpeed10m => windSpeed10mField % array
       stokesDriftZonalWavenumber => stokesDriftZonalWavenumberField % array
       stokesDriftMeridionalWavenumber => stokesDriftMeridionalWavenumberField % array
       significantWaveHeight => significantWaveHeightField % array
       peakWaveFrequency => peakWaveFrequencyField % array
       peakWaveDirection => peakWaveDirectionField % array
-      !landIcePressure => landIcePressureField % array
 
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -2544,22 +2543,18 @@ contains
            end if
         endif
 
-        if ( landIceFreshwaterFluxField % isActive ) then
-           !landIceFreshwaterFlux(i) = x2o_o % rAttr(index_x2o_Fogx_qicelo, n)
+        if ( landIceFluxesCoupled ) then
+           landIceFreshwaterFlux(i) = x2o_o % rAttr(index_x2o_Fogx_qicelo, n)
+           landIceHeatFlux(i) = x2o_o % rAttr(index_x2o_Fogx_qiceho, n)
+           landIceInterfaceTracers(indexIT, i) = x2o_o % rAttr(index_x2o_Sg_blit, n)
+           landIceInterfaceTracers(indexIS, i) = x2o_o % rAttr(index_x2o_Sg_blis, n)
+
+           ! We are not yet ready for MALI to supply land-ice fraction, floating
+           !  fraction or pressure
+           ! landIceFraction(i) = x2o_o % rAttr(index_x2o_Sg_icemask, n)
+           ! landIceFloatingFraction(i) = x2o_o % rAttr(index_x2o_Sg_???, n)
+           ! landIcePressure(i) = x2o_o % rAttr(index_x2o_Sg_lithop, n)
         end if
-        if ( landIceHeatFluxField % isActive ) then
-           !landIceHeatFlux(i) = x2o_o % rAttr(index_x2o_Fogx_qiceho, n)
-        end if
-        if ( landIceInterfaceTracersField % isActive ) then
-           !landIceInterfaceTracers(indexIT, i) = x2o_o % rAttr(index_x2o_Sg_blit, n)
-           !landIceInterfaceTracers(indexIS, i) = x2o_o % rAttr(index_x2o_Sg_blis, n)
-        end if
-        if ( landIceFractionField % isActive ) then
-           !landIceFraction(i) = x2o_o % rAttr(index_x2o_Sg_icemask, n)
-        end if
-        !if ( landIcePressureField % isActive ) then
-           !landIcePressure(i) = x2o_o % rAttr(index_x2o_Sg_lithop, n)
-        !end if
 
         ! BGC fields
         if (config_use_ecosysTracers) then
@@ -2717,14 +2712,12 @@ contains
 
    call mpas_pool_get_field(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFluxField)
    call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
-   call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
    call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
 
    call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
 
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
-   !call mpas_pool_get_field(forcingPool, 'landIcePressure', landIcePressureField)
 
    ! BGC fields
    if (config_use_ecosysTracers) then
@@ -2851,21 +2844,17 @@ contains
       call mpas_dmpar_exch_halo_field(peakWaveDirectionField)
    end if
 
-   if ( landIceFreshwaterFluxField % isActive ) then
+   if ( landIceFluxesCoupled ) then
       call mpas_dmpar_exch_halo_field(landIceFreshwaterFluxField)
-   end if
-   if ( landIceHeatFluxField % isActive ) then
       call mpas_dmpar_exch_halo_field(landIceHeatFluxField)
-   end if
-   if ( landIceInterfaceTracersField % isActive ) then
       call mpas_dmpar_exch_halo_field(landIceInterfaceTracersField)
+
+      ! We are not yet ready for MALI to supply land-ice fraction, floating
+      !  fraction or pressure
+      ! call mpas_dmpar_exch_halo_field(landIceFractionField)
+      ! call mpas_dmpar_exch_halo_field(landIceFloatingFractionField)
+      ! call mpas_dmpar_exch_halo_field(landIcePressureField)
    end if
-   if ( landIceFractionField % isActive ) then
-      call mpas_dmpar_exch_halo_field(landIceFractionField)
-   end if
-!   if ( landIcePressureField % isActive ) then
-!      call mpas_dmpar_exch_halo_field(landIcePressureField)
-!   end if
 
    if ( windSpeed10mField % isActive ) then
       call mpas_dmpar_exch_halo_field(windSpeed10mField)
@@ -3751,12 +3740,10 @@ contains
                                   riverFluxFeField,   &
                                   landIceFreshwaterFluxField, &
                                   landIceHeatFluxField, &
-                                  landIceFractionField, &
                                   windSpeed10mField, &
-                                 significantWaveHeightField, &
+                                  significantWaveHeightField, &
                                   peakWaveFrequencyField, &
                                   peakWaveDirectionField
-                                  !landIcePressureField
 
    type (field2DReal), pointer :: iceFluxPhytoCField, &
                                   iceFluxDOCField
@@ -3802,13 +3789,11 @@ contains
                                                riverFluxFe,   &
                                                landIceFreshwaterFlux, &
                                                landIceHeatFlux, &
-                                               landIceFraction, &
                                                areaCell, &
                                                windSpeed10m, &
                                                significantWaveHeight, &
                                                peakWaveFrequency, &
                                                peakWaveDirection
-                                               !landIcePressure
 
    real (kind=RKIND), dimension(:), pointer :: latCell
 
@@ -3823,6 +3808,8 @@ contains
    real (kind=RKIND), dimension(:,:), pointer :: landIceInterfaceTracers
 
    real (kind=RKIND) :: riverFactor
+
+   logical :: landIceFluxesCoupled
 
 !-----------------------------------------------------------------------
 !
@@ -3879,6 +3866,12 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_ice_runoff', config_remove_ais_ice_runoff)
    call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
 
+   if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+      landIceFluxesCoupled = .true.
+   else
+      landIceFluxesCoupled = .false.
+   end if
+
    n = 0
    removedRiverRunoffFluxThisProc = 0.0_RKIND
    removedIceRunoffFluxThisProc = 0.0_RKIND
@@ -3921,15 +3914,12 @@ contains
 
       call mpas_pool_get_field(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFluxField)
       call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
-      call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
       call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
 
       call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
 
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
       call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
-
-   !call mpas_pool_get_field(forcingPool, 'landIcePressure', landIcePressureField)
 
       windStressZonal => windStressZonalField % array
       windStressMeridional => windStressMeridionalField % array
@@ -3957,14 +3947,12 @@ contains
       landIceFreshwaterFlux => landIceFreshwaterFluxField % array
       landIceHeatFlux => landIceHeatFluxField % array
       landIceInterfaceTracers => landIceInterfaceTracersField % array
-      landIceFraction => landIceFractionField % array
       windSpeed10m => windSpeed10mField % array
       stokesDriftZonalWavenumber => stokesDriftZonalWavenumberField % array
       stokesDriftMeridionalWavenumber => stokesDriftMeridionalWavenumberField % array
       significantWaveHeight => significantWaveHeightField % array
       peakWaveFrequency => peakWaveFrequencyField % array
       peakWaveDirection => peakWaveDirectionField % array
-      !landIcePressure => landIcePressureField % array
 
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -4185,22 +4173,19 @@ contains
            end if
         endif
 
-        if ( landIceFreshwaterFluxField % isActive ) then
-           !landIceFreshwaterFlux(i) = x2o_om(n, index_x2o_Fogx_qicelo)
+        if ( landIceFluxesCoupled ) then
+
+           landIceFreshwaterFlux(i) = x2o_om(n, index_x2o_Fogx_qicelo)
+           landIceHeatFlux(i) = x2o_om(n, index_x2o_Fogx_qiceho)
+           landIceInterfaceTracers(indexIT, i) = x2o_om(n, index_x2o_Sg_blit)
+           landIceInterfaceTracers(indexIS, i) = x2o_om(n, index_x2o_Sg_blis)
+
+           ! We are not yet ready for MALI to supply land-ice fraction, floating
+           !  fraction or pressure
+           ! landIceFraction(i) = x2o_om(n, index_x2o_Sg_icemask)
+           ! landIceFloatingFraction(i) = x2o_om(n, index_x2o_Sg_???)
+           ! landIcePressure(i) = x2o_om(n, index_x2o_Sg_lithop)
         end if
-        if ( landIceHeatFluxField % isActive ) then
-           !landIceHeatFlux(i) = x2o_om(n, index_x2o_Fogx_qiceho)
-        end if
-        if ( landIceInterfaceTracersField % isActive ) then
-           !landIceInterfaceTracers(indexIT, i) = x2o_om(n, index_x2o_Sg_blit)
-           !landIceInterfaceTracers(indexIS, i) = x2o_om(n, index_x2o_Sg_blis)
-        end if
-        if ( landIceFractionField % isActive ) then
-           !landIceFraction(i) = x2o_om(n, index_x2o_Sg_icemask)
-        end if
-        !if ( landIcePressureField % isActive ) then
-           !landIcePressure(i) = x2o_om(n, index_x2o_Sg_lithop)
-        !end if
 
         ! BGC fields
         if (config_use_ecosysTracers) then
@@ -4358,14 +4343,12 @@ contains
 
    call mpas_pool_get_field(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFluxField)
    call mpas_pool_get_field(forcingPool, 'landIceHeatFlux', landIceHeatFluxField)
-   call mpas_pool_get_field(forcingPool, 'landIceFraction', landIceFractionField)
    call mpas_pool_get_field(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracersField)
 
    call mpas_pool_get_field(forcingPool, 'windSpeed10m', windSpeed10mField)
 
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
    call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
-   !call mpas_pool_get_field(forcingPool, 'landIcePressure', landIcePressureField)
 
    ! BGC fields
    if (config_use_ecosysTracers) then
@@ -4492,21 +4475,18 @@ contains
       call mpas_dmpar_exch_halo_field(peakWaveDirectionField)
    end if
 
-   if ( landIceFreshwaterFluxField % isActive ) then
+   if ( landIceFluxesCoupled ) then
       call mpas_dmpar_exch_halo_field(landIceFreshwaterFluxField)
-   end if
-   if ( landIceHeatFluxField % isActive ) then
       call mpas_dmpar_exch_halo_field(landIceHeatFluxField)
-   end if
-   if ( landIceInterfaceTracersField % isActive ) then
       call mpas_dmpar_exch_halo_field(landIceInterfaceTracersField)
+
+      ! We are not yet ready for MALI to supply land-ice fraction, floating
+      !  fraction or pressure
+      ! call mpas_dmpar_exch_halo_field(landIceFractionField)
+      ! call mpas_dmpar_exch_halo_field(landIceFloatingFractionField)
+      ! call mpas_dmpar_exch_halo_field(landIcePressureField)
    end if
-   if ( landIceFractionField % isActive ) then
-      call mpas_dmpar_exch_halo_field(landIceFractionField)
-   end if
-!   if ( landIcePressureField % isActive ) then
-!      call mpas_dmpar_exch_halo_field(landIcePressureField)
-!   end if
+
 
    if ( windSpeed10mField % isActive ) then
       call mpas_dmpar_exch_halo_field(windSpeed10mField)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3007,6 +3007,7 @@ contains
                        index_avgZonalSSHGradient, index_avgMeridionalSSHGradient, &
                        nGlcZLevels
 
+
    type (block_type), pointer :: block_ptr
 
    type (mpas_pool_type), pointer :: meshPool,             &
@@ -3039,13 +3040,16 @@ contains
                                                avgRemovedRiverRunoffFlux, &
                                                avgRemovedIceRunoffFlux, &
                                                avgLandIceHeatFlux, &
-                                               avgRemovedIceRunoffHeatFlux
+                                               avgRemovedIceRunoffHeatFlux, &
+                                               avgEffectiveDensityInLandIce
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgSSHGradient, avgOceanSurfacePhytoC, &
                                                  avgOceanSurfaceDOC, layerThickness, &
                                                  avgThermalForcingAtZLevels, &
-                                                 avgThermalForcingAtZLevelsMask
+                                                 avgThermalForcingAtZLevelsMask, &
+                                                 avgLandIceBoundaryLayerTracers, &
+                                                 avgLandIceTracerTransferVelocities
 
    real (kind=RKIND) :: surfaceFreezingTemp
 
@@ -3198,6 +3202,12 @@ contains
 !    call mpas_pool_get_array(forcingPool, 'DMSFlux', DMSFlux)
 !    call mpas_pool_get_array(forcingPool, 'surfaceUpwardCO2Flux', surfaceUpwardCO2Flux)
 
+     if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+        call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
+        call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
+        call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
+     endif
+
      do i = 1, nCellsSolve
        n = n + 1
 
@@ -3314,11 +3324,11 @@ contains
 !      o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = surfaceUpwardCO2Flux(i)
 
        if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
-          o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
-          o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerTracers(indexBLS,i)
-          o2x_o % rAttr(index_o2x_So_htv, n) = landIceTracerTransferVelocities(indexHeatTrans,i)
-          o2x_o % rAttr(index_o2x_So_stv, n) = landIceTracerTransferVelocities(indexSaltTrans,i)
-          o2x_o % rAttr(index_o2x_So_rhoeff, n) = 0.0_RKIND
+          o2x_o % rAttr(index_o2x_So_blt, n) = avgLandIceBoundaryLayerTracers(indexBLT,i)
+          o2x_o % rAttr(index_o2x_So_bls, n) = avgLandIceBoundaryLayerTracers(indexBLS,i)
+          o2x_o % rAttr(index_o2x_So_htv, n) = avgLandIceTracerTransferVelocities(indexHeatTrans,i)
+          o2x_o % rAttr(index_o2x_So_stv, n) = avgLandIceTracerTransferVelocities(indexSaltTrans,i)
+          o2x_o % rAttr(index_o2x_So_rhoeff, n) = avgEffectiveDensityInLandIce(i)
        endif
        if (trim(config_glc_thermal_forcing_coupling_mode) == '3d') then
           do iLevel = 1, nGlcZLevels
@@ -4783,6 +4793,13 @@ contains
 !    call mpas_pool_get_array(forcingPool, 'DMSFlux', DMSFlux)
 !    call mpas_pool_get_array(forcingPool, 'surfaceUpwardCO2Flux', surfaceUpwardCO2Flux)
 
+
+     if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+        call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
+        call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
+        call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
+     endif
+
 ! replace 'o2x_o % rAttr(' with 'o2x_om(n, ' and ', n)' with ')'
      do i = 1, nCellsSolve
        n = n + 1
@@ -4912,13 +4929,12 @@ contains
 !JW       o2x_om(n, index_o2x_So_stv) = landIceSaltTransferVelocity(i)
 
        if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
-          o2x_om(n, index_o2x_So_blt) = landIceBoundaryLayerTracers(indexBLT,i)
-          o2x_om(n, index_o2x_So_bls) = landIceBoundaryLayerTracers(indexBLS,i)
-          o2x_om(n, index_o2x_So_htv) = landIceTracerTransferVelocities(indexHeatTrans,i)
-          o2x_om(n, index_o2x_So_stv) = landIceTracerTransferVelocities(indexSaltTrans,i)
-          o2x_om(n, index_o2x_So_rhoeff) = 0.0_RKIND
+          o2x_om(n, index_o2x_So_blt) = avgLandIceBoundaryLayerTracers(indexBLT,i)
+          o2x_om(n, index_o2x_So_bls) = avgLandIceBoundaryLayerTracers(indexBLS,i)
+          o2x_om(n, index_o2x_So_htv) = avgLandIceTracerTransferVelocities(indexHeatTrans,i)
+          o2x_om(n, index_o2x_So_stv) = avgLandIceTracerTransferVelocities(indexSaltTrans,i)
+          o2x_om(n, index_o2x_So_rhoeff) = avgEffectiveDensityInLandIce(i)
        endif
-
        !Fyke: test
        !write(stderrUnit,*) 'n=',n
        !write(stderrUnit,*) 'o2x_om(n, index_o2x_So_blt)=',o2x_om(n, index_o2x_So_blt)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3066,7 +3066,8 @@ contains
    character (len=StrKIND), pointer :: config_land_ice_flux_mode
    character (len=StrKIND), pointer :: config_glc_thermal_forcing_coupling_mode
 
-   logical :: keepFrazil
+   logical :: keepFrazil, landIceFluxesCoupled
+
 
    logical :: ocn_c2_glctf           ! .true.  => ocn to glc thermal forcing coupling on
 
@@ -3088,6 +3089,12 @@ contains
                                                 config_use_DMSTracers_sea_ice_coupling)
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers_sea_ice_coupling',  &
                                                 config_use_MacroMoleculesTracers_sea_ice_coupling)
+
+   if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+      landIceFluxesCoupled = .true.
+   else
+      landIceFluxesCoupled = .false.
+   end if
 
    ! Determine if ocn to glc thermal forcing coupling is on
    call seq_infodata_GetData(infodata, ocn_c2_glctf=ocn_c2_glctf)
@@ -3202,7 +3209,7 @@ contains
 !    call mpas_pool_get_array(forcingPool, 'DMSFlux', DMSFlux)
 !    call mpas_pool_get_array(forcingPool, 'surfaceUpwardCO2Flux', surfaceUpwardCO2Flux)
 
-     if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+     if ( landIceFluxesCoupled  ) then
         call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
         call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
         call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
@@ -3323,7 +3330,7 @@ contains
 !      o2x_o % rAttr(index_o2x_Faoo_fdms_ocn, n) = DMSFlux(i)
 !      o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = surfaceUpwardCO2Flux(i)
 
-       if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+       if ( landIceFluxesCoupled  ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = avgLandIceBoundaryLayerTracers(indexBLT,i)
           o2x_o % rAttr(index_o2x_So_bls, n) = avgLandIceBoundaryLayerTracers(indexBLS,i)
           o2x_o % rAttr(index_o2x_So_htv, n) = avgLandIceTracerTransferVelocities(indexHeatTrans,i)
@@ -4692,7 +4699,7 @@ contains
 
    character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
-   logical :: keepFrazil
+   logical :: keepFrazil, landIceFluxesCoupled
 
 
    ! get configure options
@@ -4709,6 +4716,12 @@ contains
                                                 config_use_DMSTracers_sea_ice_coupling)
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers_sea_ice_coupling',  &
                                                 config_use_MacroMoleculesTracers_sea_ice_coupling)
+
+   if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+     landIceFluxesCoupled = .true.
+   else
+     landIceFluxesCoupled = .false.
+   end if
 
    n = 0
    block_ptr => domain % blocklist
@@ -4794,7 +4807,7 @@ contains
 !    call mpas_pool_get_array(forcingPool, 'surfaceUpwardCO2Flux', surfaceUpwardCO2Flux)
 
 
-     if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+     if ( landIceFluxesCoupled ) then
         call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
         call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
         call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
@@ -4928,7 +4941,7 @@ contains
 !JW       o2x_om(n, index_o2x_So_htv) = landIceHeatTransferVelocity(i)
 !JW       o2x_om(n, index_o2x_So_stv) = landIceSaltTransferVelocity(i)
 
-       if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+       if ( landIceFluxesCoupled ) then
           o2x_om(n, index_o2x_So_blt) = avgLandIceBoundaryLayerTracers(indexBLT,i)
           o2x_om(n, index_o2x_So_bls) = avgLandIceBoundaryLayerTracers(indexBLS,i)
           o2x_om(n, index_o2x_So_htv) = avgLandIceTracerTransferVelocities(indexHeatTrans,i)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3313,8 +3313,7 @@ contains
 !      o2x_o % rAttr(index_o2x_Faoo_fdms_ocn, n) = DMSFlux(i)
 !      o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = surfaceUpwardCO2Flux(i)
 
-       if ( trim(config_land_ice_flux_mode) .eq. 'standalone' .or. &
-            trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+       if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
           o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerTracers(indexBLS,i)
           o2x_o % rAttr(index_o2x_So_htv, n) = landIceTracerTransferVelocities(indexHeatTrans,i)
@@ -4912,8 +4911,7 @@ contains
 !JW       o2x_om(n, index_o2x_So_htv) = landIceHeatTransferVelocity(i)
 !JW       o2x_om(n, index_o2x_So_stv) = landIceSaltTransferVelocity(i)
 
-       if ( trim(config_land_ice_flux_mode) .eq. 'standalone' .or. &
-            trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
+       if ( trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
           o2x_om(n, index_o2x_So_blt) = landIceBoundaryLayerTracers(indexBLT,i)
           o2x_om(n, index_o2x_So_bls) = landIceBoundaryLayerTracers(indexBLS,i)
           o2x_om(n, index_o2x_So_htv) = landIceTracerTransferVelocities(indexHeatTrans,i)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1115,10 +1115,6 @@
 					description="The specific heat capacity for ice."
 					possible_values="Any positive real number"
 		/>
-		<nml_option name="config_land_ice_flux_rho_ice" type="real" default_value="918" units="kg m^-3"
-					description="The density of land ice."
-					possible_values="Any positive real number"
-		/>
 		<nml_option name="config_land_ice_flux_explicit_topDragCoeff" type="real" default_value="2.5e-3"
 					description="The top drag coefficient if config_use_implicit_top_drag_coeff is false."
 					possible_values="Any positive real number"

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -75,7 +75,6 @@ module ocn_surface_land_ice_fluxes
 
    real (kind=RKIND) :: &
       cpLandIce,        &! specific heat for land ice
-      rhoLandIce,       &! density of land ice
       ISOMIPgammaT       ! parameter for ISOMIP formulation
 
 !***********************************************************************
@@ -835,7 +834,6 @@ contains
       jenkinsOn        = .false.
       hollandJenkinsOn = .false.
       cpLandIce        = 0.0_RKIND
-      rhoLandIce       = 0.0_RKIND
       ISOMIPgammaT     = 0.0_RKIND
 
       !*** Determine whether land ice fluxes are on
@@ -901,7 +899,6 @@ contains
       !*** Set physical values
 
       cpLandIce    = config_land_ice_flux_cp_ice
-      rhoLandIce   = config_land_ice_flux_rho_ice
       ISOMIPgammaT = config_land_ice_flux_ISOMIP_gammaT
 
    !--------------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -524,6 +524,11 @@ contains
 
       err = 0
 
+      if (landIceCoupledOn) then
+         ! All we want to do in coupled mode is to compute the total land-ice freshwater flux
+         call compute_total_land_ice_freshwater_flux(meshPool, forcingPool)
+      end if
+
       if (.not. (landIceStandaloneOn .or. landIceDataOn)) return
 
       call mpas_timer_start("land_ice_build_arrays")
@@ -536,6 +541,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       nCells = nCellsArray( size(nCellsArray) )
+
 
       if (landIceStandaloneOn) then
 
@@ -698,16 +704,9 @@ contains
 
       end if ! landIceStandaloneOn
 
-      ! Add frazil and interface melt/freeze to get total fresh water flux
-      if ( associated(frazilIceFreshwaterFlux) ) then
-          do iCell = 1, nCells
-                landIceFreshwaterFluxTotal(iCell) = landIceFreshwaterFlux(iCell) + landIceFloatingMask(iCell)*frazilIceFreshwaterFlux(iCell)
-          end do
-      else
-          do iCell = 1, nCells
-                landIceFreshwaterFluxTotal(iCell) = landIceFreshwaterFlux(iCell)
-          end do
-      end if
+      ! Okay, now if we're in standalone or data mode, time to compute
+      ! the total land-ice freshwater flux
+      call compute_total_land_ice_freshwater_flux(meshPool, forcingPool)
 
       call mpas_timer_stop("land_ice_build_arrays")
 
@@ -1196,6 +1195,82 @@ contains
 
   end subroutine compute_HJ99_melt_fluxes !}}}
 
+
+!***********************************************************************
+!
+!  routine compute_total_land_ice_freshwater_flux
+!
+!> \brief   Computes total land-ice freshwater fluxes
+!> \author  Xylar Asay-Davis
+!> \date    4/26/2025
+!>  This routine computes the total land-ice freshwater flux as the sum
+!>  of the melt flux at the ice-ocean interface and the frazil ice flux
+!>  (if available).
+!
+!-----------------------------------------------------------------------
+
+
+  subroutine compute_total_land_ice_freshwater_flux( &
+    meshPool, &
+    forcingPool) !{{{
+
+    !-----------------------------------------------------------------
+    !
+    ! input variables
+    !
+    !-----------------------------------------------------------------
+
+    type (mpas_pool_type), intent(in) :: &
+       meshPool        !< Input: mesh information
+
+    !-----------------------------------------------------------------
+    !
+    ! input/output variables
+    !
+    !-----------------------------------------------------------------
+    type (mpas_pool_type), intent(inout) :: &
+       forcingPool     !< Input: Forcing information
+
+    !-----------------------------------------------------------------
+    !
+    ! local variables
+    !
+    !-----------------------------------------------------------------
+
+    integer :: iCell, nCells
+    integer, dimension(:), pointer :: nCellsArray
+
+
+    real (kind=RKIND), dimension(:), pointer :: landIceFreshwaterFlux, &
+                                                frazilIceFreshwaterFlux, &
+                                                landIceFreshwaterFluxTotal
+
+    integer, dimension(:), pointer :: landIceFloatingMask
+
+    call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+
+    call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+    call mpas_pool_get_array(forcingPool, 'frazilIceFreshwaterFlux', frazilIceFreshwaterFlux)
+    call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFluxTotal', landIceFreshwaterFluxTotal)
+    call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
+
+    nCells = nCellsArray( size(nCellsArray) )
+
+    ! Add frazil and interface melt/freeze to get total fresh water flux
+    if (associated(frazilIceFreshwaterFlux)) then
+       do iCell = 1, nCells
+          landIceFreshwaterFluxTotal(iCell) = landIceFreshwaterFlux(iCell) + &
+             landIceFloatingMask(iCell) * frazilIceFreshwaterFlux(iCell)
+       end do
+    else
+       do iCell = 1, nCells
+          landIceFreshwaterFluxTotal(iCell) = landIceFreshwaterFlux(iCell)
+       end do
+    end if
+
+    !--------------------------------------------------------------------
+
+  end subroutine compute_total_land_ice_freshwater_flux !}}}
 
 !***********************************************************************
 

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -49,7 +49,7 @@ module seq_diag_mct
   use seq_diagBGC_mct,  only : seq_diagBGC_preprint_mct, seq_diagBGC_print_mct
 
   use prep_glc_mod,  only : prep_glc_get_l2gacc_lx_cnt_avg
-  use glc_elevclass_mod, only: glc_get_num_elevation_classes 
+  use glc_elevclass_mod, only: glc_get_num_elevation_classes
 
   implicit none
   save
@@ -269,7 +269,7 @@ module seq_diag_mct
   integer :: index_l2x_Flrl_wslake
 
   integer :: index_x2l_Sg_icemask
-  integer, allocatable :: index_l2x_Flgl_qice(:) 
+  integer, allocatable :: index_l2x_Flgl_qice(:)
   integer, allocatable :: index_x2l_Sg_ice_covered(:)
 
   integer :: index_x2l_Faxa_lwdn
@@ -347,7 +347,7 @@ module seq_diag_mct
   integer :: index_g2x_Fogg_rofi
   integer :: index_g2x_Figg_rofi
 
-  integer :: index_x2g_Flgl_qice 
+  integer :: index_x2g_Flgl_qice
   integer :: index_g2x_Sg_icemask
 
   integer :: index_x2o_Foxx_rofl_16O
@@ -889,12 +889,12 @@ contains
     logical,save             :: first_time    = .true.
     logical,save             :: flds_wiso_lnd = .false.
 
-    real(r8)                 :: l2x_Flgl_qice_col_sum ! for summing fluxes over no. of elev. classes 
+    real(r8)                 :: l2x_Flgl_qice_col_sum ! for summing fluxes over no. of elev. classes
     real(r8)                 :: effective_area
 
     character(len=64)        :: name
-    character(len= 2)        :: cnum         
-    integer(in)              :: num               
+    character(len= 2)        :: cnum
+    integer(in)              :: num
 
     !----- formats -----
     character(*),parameter :: subName = '(seq_diag_lnd_mct) '
@@ -916,7 +916,7 @@ contains
     kArea = mct_aVect_indexRA(dom_l%data,afldname)
     kl    = mct_aVect_indexRA(frac_l,lfrinname)
 
-    ! get number of elevation classes and allocate relevant sets of indices 
+    ! get number of elevation classes and allocate relevant sets of indices
     glc_nec = glc_get_num_elevation_classes()
     if (glc_nec.ge.1) then
        if (first_time) then
@@ -924,7 +924,7 @@ contains
           allocate(index_x2l_Sg_ice_covered(0:glc_nec))
        end if
     end if
-   
+
     if (present(do_l2x)) then
        if (first_time) then
           index_l2x_Fall_swnet  = mct_aVect_indexRA(l2x_l,'Fall_swnet')
@@ -989,9 +989,9 @@ contains
           l2x_Flgl_qice_col_sum = 0.0d0
           if (glc_nec.ge.1) then
              effective_area = min(frac_l%rAttr(kl,n),x2l_l%rAttr(index_x2l_Sg_icemask,n)) * dom_l%data%rAttr(kArea,n)
-             do num=0,glc_nec 
-                ! sums the contributions from fluxes in each set of elevation classes 
-                ! RHS product is flux times fraction of area in specific elevation class times land cell area 
+             do num=0,glc_nec
+                ! sums the contributions from fluxes in each set of elevation classes
+                ! RHS product is flux times fraction of area in specific elevation class times land cell area
                 l2x_Flgl_qice_col_sum = l2x_Flgl_qice_col_sum + l2x_l%rAttr(index_l2x_Flgl_qice(num),n) * &
                                                                 x2l_l%rAttr(index_x2l_Sg_ice_covered(num),n) * effective_area
              end do
@@ -1031,7 +1031,7 @@ contains
           end if
        end do
 
-       budg_dataL(f_hioff,ic,ip) = -budg_dataL(f_wioff,ic,ip)*shr_const_latice ! contribution from land ice calving currently zero 
+       budg_dataL(f_hioff,ic,ip) = -budg_dataL(f_wioff,ic,ip)*shr_const_latice ! contribution from land ice calving currently zero
        budg_dataL(f_hgsmb,ic,ip) = budg_dataL(f_wgsmb,ic,ip)*shr_const_latice
 
        ! Nneeded? Not sure if / when these should be deallocated
@@ -1321,7 +1321,7 @@ contains
   subroutine seq_diag_glc_mct( glc, frac_g, infodata, do_x2g, do_g2x )
 
     type(component_type)    , intent(in) :: glc    ! component type for instance1
-    type(mct_aVect)         , intent(in) :: frac_g ! frac bundle (may not be used / needed here) 
+    type(mct_aVect)         , intent(in) :: frac_g ! frac bundle (may not be used / needed here)
     type(seq_infodata_type) , intent(in) :: infodata
     logical                 , intent(in), optional :: do_x2g
     logical                 , intent(in), optional :: do_g2x
@@ -1391,7 +1391,7 @@ contains
 
     if( present(do_x2g))then  ! do fields from coupler to glc (x2g_)
 
-       l2gacc_lx_cnt_avg = prep_glc_get_l2gacc_lx_cnt_avg() ! counter for how many times SMB flux accumulation has occured 
+       l2gacc_lx_cnt_avg = prep_glc_get_l2gacc_lx_cnt_avg() ! counter for how many times SMB flux accumulation has occured
        ic = c_glc_gs
        kArea = mct_aVect_indexRA(dom_g%data,afldname)
        lSize = mct_avect_lSize(x2g_g)
@@ -1403,7 +1403,7 @@ contains
 
        budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) * l2gacc_lx_cnt_avg
 
-       budg_dataL(f_hgsmb,ic,ip) = budg_dataL(f_wgsmb,ic,ip)*shr_const_latice 
+       budg_dataL(f_hgsmb,ic,ip) = budg_dataL(f_wgsmb,ic,ip)*shr_const_latice
 
     end if ! end do fields from coupler to glc (x2g_)
 
@@ -1973,7 +1973,7 @@ contains
 
        if (plev > 0) then
           ! ---- doprint ---- doprint ---- doprint ----
-  
+
           if (.not.sumdone) then
 
              if (do_bgc_budg) then
@@ -2340,7 +2340,7 @@ contains
           ! ---- doprint ---- doprint ---- doprint ----
 
           if (do_bgc_budg) then
-             call seq_diagBGC_print_mct(EClock, ip, plev) 
+             call seq_diagBGC_print_mct(EClock, ip, plev)
           endif
 
        endif  ! plev > 0

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -3061,13 +3061,13 @@ contains
     attname  = 'Sg_lithop'
     call metadata_set(attname, longname, stdname, units)
 
-    name = 'Sg_icemask_grounded'
+    name = 'Sg_icemask_below_sea_level'
     call seq_flds_add(g2x_states,trim(name))
     call seq_flds_add(x2o_states,trim(name))
-    longname = 'Grounded ice mask'
-    stdname  = 'Grounded_ice_mask'
+    longname = 'ice mask where topopgrahy is below sea level'
+    stdname  = 'ice_mask_below_sea_level'
     units    = 'unitless'
-    attname  = 'Sg_icemask_grounded'
+    attname  = 'Sg_icemask_below_sea_level'
     call metadata_set(attname, longname, stdname, units)
 
     name = 'Sg_icemask_floating'
@@ -3077,6 +3077,15 @@ contains
     stdname  = 'Floating_ice_mask'
     units    = 'unitless'
     attname  = 'Sg_icemask_floating'
+    call metadata_set(attname, longname, stdname, units)
+
+    name = 'Sg_below_sea_level_mask'
+    call seq_flds_add(g2x_states,trim(name))
+    call seq_flds_add(x2o_states,trim(name))
+    longname = 'Ice sheet bedrock is below sea level'
+    stdname  = 'below_sea_level_mask'
+    units    = 'unitless'
+    attname  = 'Sg_below_sea_level_mask'
     call metadata_set(attname, longname, stdname, units)
 
     name = 'Sg_tbot'

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -781,7 +781,7 @@ contains
     units    = 'kg m-3'
     attname  = 'Sa_dens'
     call metadata_set(attname, longname, stdname, units)
-    
+
     ! UoverN for use by topounits
     call seq_flds_add(a2x_states,"Sa_uovern")
     call seq_flds_add(x2l_states,"Sa_uovern")
@@ -2176,7 +2176,7 @@ contains
     endif
 
     !------------------------------
-    ! ice<->wav only exchange 
+    ! ice<->wav only exchange
     !------------------------------
 
     ! Sea ice thickness
@@ -2274,7 +2274,7 @@ contains
     units    = ' '
     attname  = 'coszen_str'
     call metadata_set(attname, longname, stdname, units)
-       
+
     if (rof_sed) then
        call seq_flds_add(l2x_fluxes,'Flrl_rofmud')
        call seq_flds_add(l2x_fluxes_to_rof,'Flrl_rofmud')
@@ -2354,7 +2354,7 @@ contains
     units    = 'kg m-2 s-1'
     attname  = 'Flrr_supply'
     call metadata_set(attname, longname, stdname, units)
-    
+
     call seq_flds_add(r2x_fluxes,'Flrr_deficit')
     call seq_flds_add(x2l_fluxes,'Flrr_deficit')
     longname = 'River model supply deficit'
@@ -3886,7 +3886,7 @@ contains
 
     !-----------------------------------------------------------------------------
     ! Read namelist for FAN NH3 emissions
-    ! If specified, the NH3 surface emission is sent to CAM. 
+    ! If specified, the NH3 surface emission is sent to CAM.
     !-----------------------------------------------------------------------------
 
     call shr_fan_readnl(nlfilename='drv_flds_in', ID=ID, fan_fields=fan_fields, have_fields=fan_have_fields)

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -390,7 +390,7 @@ contains
 
     !------ namelist -----
     character(len=CSS)  :: fldname, fldflow
-    character(len=CSS)  :: fldname_ext  ! use for moab extensions 
+    character(len=CSS)  :: fldname_ext  ! use for moab extensions
     type(mct_string)    :: mctOStr  ! mct string for output outfield
     logical :: is_state, is_flux
     integer :: i,n
@@ -802,7 +802,7 @@ contains
     units    = 'kg m-3'
     attname  = 'Sa_dens'
     call metadata_set(attname, longname, stdname, units)
-    
+
     ! UoverN for use by topounits
     call seq_flds_add(a2x_states,"Sa_uovern")
     call seq_flds_add(x2l_states,"Sa_uovern")
@@ -2196,7 +2196,7 @@ contains
     endif
 
     !------------------------------
-    ! ice<->wav only exchange 
+    ! ice<->wav only exchange
     !------------------------------
 
     ! Sea ice thickness
@@ -2373,7 +2373,7 @@ contains
     units    = 'kg m-2 s-1'
     attname  = 'Flrr_supply'
     call metadata_set(attname, longname, stdname, units)
-    
+
     call seq_flds_add(r2x_fluxes,'Flrr_deficit')
     call seq_flds_add(x2l_fluxes,'Flrr_deficit')
     longname = 'River model supply deficit'
@@ -4099,7 +4099,7 @@ contains
     call catFields(seq_flds_x2w_fields, seq_flds_x2w_states, seq_flds_x2w_fluxes)
     call catFields(seq_flds_o2x_fields_to_rof, seq_flds_o2x_states_to_rof, seq_flds_o2x_fluxes_to_rof)
     ! form character(CXX) :: seq_flds_a2x_ext_states from seq_flds_a2x_states by adding _ext in each field
-    ! first form a list 
+    ! first form a list
     call mct_list_init(temp_list ,seq_flds_a2x_fields)
     size_list=mct_list_nitem (temp_list)
     seq_flds_a2x_ext_fields=''
@@ -4133,7 +4133,7 @@ contains
     call mct_list_clean(temp_list)
 
 
-   
+
     if (seq_comm_iamroot(ID)) then
       write(logunit,*) subname//': seq_flds_dom_fields= ',trim(seq_flds_dom_fields)
       write(logunit,*) subname//': seq_flds_a2x_ext_states= ',trim(seq_flds_a2x_ext_states)
@@ -4540,7 +4540,7 @@ contains
     use shr_kind_mod    , only: r8 => SHR_KIND_R8
     implicit none
 
-    integer :: ierr, lsize 
+    integer :: ierr, lsize
     character(len=*), intent(in) :: tagname
     type(mct_aVect), intent(in) :: avx
     integer, intent(in) :: index

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -3080,13 +3080,13 @@ contains
     attname  = 'Sg_lithop'
     call metadata_set(attname, longname, stdname, units)
 
-    name = 'Sg_icemask_grounded'
+    name = 'Sg_icemask_below_sea_level'
     call seq_flds_add(g2x_states,trim(name))
     call seq_flds_add(x2o_states,trim(name))
-    longname = 'Grounded ice mask'
-    stdname  = 'Grounded_ice_mask'
+    longname = 'ice mask where topopgrahy is below sea level'
+    stdname  = 'ice_mask_below_sea_level'
     units    = 'unitless'
-    attname  = 'Sg_icemask_grounded'
+    attname  = 'Sg_icemask_below_sea_level'
     call metadata_set(attname, longname, stdname, units)
 
     name = 'Sg_icemask_floating'
@@ -3096,6 +3096,15 @@ contains
     stdname  = 'Floating_ice_mask'
     units    = 'unitless'
     attname  = 'Sg_icemask_floating'
+    call metadata_set(attname, longname, stdname, units)
+
+    name = 'Sg_below_sea_level_mask'
+    call seq_flds_add(g2x_states,trim(name))
+    call seq_flds_add(x2o_states,trim(name))
+    longname = 'Ice sheet bedrock is below sea level'
+    stdname  = 'below_sea_level_mask'
+    units    = 'unitless'
+    attname  = 'Sg_below_sea_level_mask'
     call metadata_set(attname, longname, stdname, units)
 
     name = 'Sg_tbot'
@@ -4435,7 +4444,7 @@ contains
     integer            :: num
     character(len= 16) :: cnum
     logical :: l_additional_list  ! local version of the optional additional_list argument
-    
+
     l_additional_list = .false.
     if (present(additional_list)) then
        l_additional_list = additional_list


### PR DESCRIPTION
In addition to cosmetic changes (removing commented-out code), this merge includes:

* Updating ice-shelf boundary-layer fields only in "coupled" mode. Previously, the coupler fields associated with ice-shelf boundary layer fields were being updated in "standalone" mode as well, even though they are not used.
* Using time-averaged land-ice boundary-layer fields. When computing prognostic ice-shelf melt rates in the coupler, we now use the boundary-layer fields time averaged over the coupling interval, not the instantaneous fields.
* Switching to `landIceFluxesCoupled` logical to avoid checking a string inside of nested loops.

This branch implements (or will implement) the changes described in:
https://acme-climate.atlassian.net/wiki/spaces/FAN/pages/4200497474/Design+Document+Prognostic+ice-shelf+melting+in+E3SM+coupler