### PR TITLE
Move runoff removal from MPAS-Ocean to data runoff component

### DIFF
--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -42,6 +42,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     rof_domain_path = case.get_value("ROF_DOMAIN_PATH")
     drof_mode = case.get_value("DROF_MODE")
     rof_grid = case.get_value("ROF_GRID")
+    ocn_iceberg = case.get_value("MPASO_ICEBERG")
+    ocn_glc_ismf_coupling = case.get_value("OCN_GLC_ISMF_COUPLING")
+    ocn_forcing = case.get_value("MPASO_FORCING")
 
     #----------------------------------------------------
     # Check for incompatible options.
@@ -109,6 +112,20 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
             nmlgen.add_default("domainfile", value=full_domain_path)
         else:
             nmlgen.add_default("domainfile", value="null")
+
+    #----------------------------------------------------
+    # Set runoff modifications for ice sheets if needed
+    #----------------------------------------------------
+    if ocn_iceberg == 'true':
+        print('Setting remove_ais_rofi to .true.')
+        nmlgen.set_value("remove_ais_rofi", '.true.')
+
+    if (((ocn_glc_ismf_coupling == 'coupler') or
+         (ocn_glc_ismf_coupling == 'internal_mpaso') or
+         (ocn_glc_ismf_coupling == 'data_mpaso'))
+        and (ocn_forcing != 'active_atm')):
+        print('Setting remove_ais_rofl to .true.')
+        nmlgen.set_value("remove_ais_rofl", '.true.')
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -45,6 +45,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     ocn_iceberg = case.get_value("MPASO_ICEBERG")
     ocn_glc_ismf_coupling = case.get_value("OCN_GLC_ISMF_COUPLING")
     ocn_forcing = case.get_value("MPASO_FORCING")
+    comp_glc = case.get_value("COMP_GLC")
+    mali_prognostic_mode = case.get_value("MALI_PROGNOSTIC_MODE")
+    glc_grid = case.get_value("GLC_GRID")
 
     #----------------------------------------------------
     # Check for incompatible options.
@@ -119,14 +122,27 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     if ocn_iceberg == 'true':
         print('Setting remove_ais_rofi to .true.')
         nmlgen.set_value("remove_ais_rofi", '.true.')
+    elif comp_glc =='mali' and mali_prognostic_mode == 'PROGNOSTIC'):
+        if 'ais' in glc_grid:
+            print('Setting remove_ais_rofi to .true.')
+            nmlgen.set_value("remove_ais_rofi", '.true.')
+        if 'gis' in glc_grid:
+            print('Setting remove_gis_rofi to .true.')
+            nmlgen.set_value("remove_gis_rofi", '.true.')
 
     if (((ocn_glc_ismf_coupling == 'coupler') or
          (ocn_glc_ismf_coupling == 'internal_mpaso') or
-         (ocn_glc_ismf_coupling == 'data_mpaso') or
-         (ocn_glc_ismf_coupling == 'tf'))
+         (ocn_glc_ismf_coupling == 'data_mpaso'))
         and (ocn_forcing != 'active_atm')):
         print('Setting remove_ais_rofl to .true.')
         nmlgen.set_value("remove_ais_rofl", '.true.')
+    elif (ocn_glc_ismf_coupling == 'tf'
+          and ocn_forcing != 'active_atm'):
+        if 'ais' in glc_grid:
+            print('Setting remove_ais_rofl to .true.')
+            nmlgen.set_value("remove_ais_rofl", '.true.')
+        # Don't handle GIS because DROF rofl will be a large part
+        # surface runoff and not from ISMF
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -122,7 +122,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
 
     if (((ocn_glc_ismf_coupling == 'coupler') or
          (ocn_glc_ismf_coupling == 'internal_mpaso') or
-         (ocn_glc_ismf_coupling == 'data_mpaso'))
+         (ocn_glc_ismf_coupling == 'data_mpaso') or
+         (ocn_glc_ismf_coupling == 'tf'))
         and (ocn_forcing != 'active_atm')):
         print('Setting remove_ais_rofl to .true.')
         nmlgen.set_value("remove_ais_rofl", '.true.')

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -120,26 +120,26 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     # Set runoff modifications for ice sheets if needed
     #----------------------------------------------------
     if ocn_iceberg == 'true':
-        print('Setting remove_ais_rofi to .true.')
+        logger.info('Setting remove_ais_rofi to .true.')
         nmlgen.set_value("remove_ais_rofi", '.true.')
-    elif comp_glc =='mali' and mali_prognostic_mode == 'PROGNOSTIC'):
+    elif comp_glc =='mali' and mali_prognostic_mode == 'PROGNOSTIC':
         if 'ais' in glc_grid:
-            print('Setting remove_ais_rofi to .true.')
+            logger.info('Setting remove_ais_rofi to .true.')
             nmlgen.set_value("remove_ais_rofi", '.true.')
         if 'gis' in glc_grid:
-            print('Setting remove_gis_rofi to .true.')
+            logger.info('Setting remove_gis_rofi to .true.')
             nmlgen.set_value("remove_gis_rofi", '.true.')
 
     if (((ocn_glc_ismf_coupling == 'coupler') or
          (ocn_glc_ismf_coupling == 'internal_mpaso') or
          (ocn_glc_ismf_coupling == 'data_mpaso'))
         and (ocn_forcing != 'active_atm')):
-        print('Setting remove_ais_rofl to .true.')
+        logger.info('Setting remove_ais_rofl to .true.')
         nmlgen.set_value("remove_ais_rofl", '.true.')
     elif (ocn_glc_ismf_coupling == 'tf'
           and ocn_forcing != 'active_atm'):
         if 'ais' in glc_grid:
-            print('Setting remove_ais_rofl to .true.')
+            logger.info('Setting remove_ais_rofl to .true.')
             nmlgen.set_value("remove_ais_rofl", '.true.')
         # Don't handle GIS because DROF rofl will be a large part
         # surface runoff and not from ISMF

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -130,6 +130,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
             logger.info('Setting remove_gis_rofi to .true.')
             nmlgen.set_value("remove_gis_rofi", '.true.')
 
+    # Assume river runoff corresponds to ISMF in Southern Ocean only for
+    # G-cases (true for JRA). When atm active, we assume liquid runoff
+    # corresonds to precip or snow melt so we do not remove it.
     if (((ocn_glc_ismf_coupling == 'coupler') or
          (ocn_glc_ismf_coupling == 'internal_mpaso') or
          (ocn_glc_ismf_coupling == 'data_mpaso'))
@@ -141,8 +144,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         if 'ais' in glc_grid:
             logger.info('Setting remove_ais_rofl to .true.')
             nmlgen.set_value("remove_ais_rofl", '.true.')
-        # Don't handle GIS because DROF rofl will be a large part
-        # surface runoff and not from ISMF
+        # Don't handle GIS because DROF rofl will be a large part of
+        # surface runoff and not correspond to ISMF
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -595,4 +595,48 @@
     </values>
   </entry>
 
+  <!-- =========================================  -->
+  <!--- ice sheet runoff modifications            -->
+  <!-- =========================================  -->
+
+  <entry id="remove_ais_rofl">
+    <type>logical</type>
+    <category>drof</category>
+    <group>drof_nml</group>
+    <desc>If true, rofl around Antarctica is set to 0</desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="remove_ais_rofi">
+    <type>logical</type>
+    <category>drof</category>
+    <group>drof_nml</group>
+    <desc>If true, rofi around Antarctica is set to 0</desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="remove_gis_rofl">
+    <type>logical</type>
+    <category>drof</category>
+    <group>drof_nml</group>
+    <desc>If true, rofl around Greenland is set to 0</desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="remove_gis_rofi">
+    <type>logical</type>
+    <category>drof</category>
+    <group>drof_nml</group>
+    <desc>If true, rofi around Greenland is set to 0</desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -449,8 +449,6 @@ CONTAINS
     integer(IN)   :: nu                ! unit number
     integer(IN)   :: nflds_r2x
     character(len=18) :: date_str
-    real(R8) latv, lonv
-    integer ilat, ilon
     integer :: index_r2x_rofl, index_r2x_rofi
 #ifdef HAVE_MOAB
     real(R8), allocatable, target :: datam(:)
@@ -532,49 +530,19 @@ CONTAINS
        ! Apply modifications around ice sheets if required
        lsize = mct_avect_lsize(r2x)
        nflds_r2x = mct_avect_nRattr(r2x)
-       ilat = mct_aVect_indexRA(ggrid%data,'lat')
-       ilon = mct_aVect_indexRA(ggrid%data,'lon')
        index_r2x_rofl = mct_avect_indexra(r2x,'Forr_rofl')
        index_r2x_rofi = mct_avect_indexra(r2x,'Forr_rofi')
        if (remove_ais_rofl) then
-          do n=1,lsize
-             lonv = ggrid%data%rAttr(ilon, n)
-             latv = ggrid%data%rAttr(ilat, n)
-             if (latv < -60.0_r8) then
-                r2x%rAttr(index_r2x_rofl,n) = 0.0_r8
-             end if
-          enddo
+          call apply_ais_mask(r2x, ggrid, lsize, index_r2x_rofl)
        endif
        if (remove_ais_rofi) then
-          do n=1,lsize
-             lonv = ggrid%data%rAttr(ilon, n)
-             latv = ggrid%data%rAttr(ilat, n)
-             if (latv < -60.0_r8) then
-                r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
-             end if
-          enddo
+          call apply_ais_mask(r2x, ggrid, lsize, index_r2x_rofi)
        endif
-       ! Note: Greenland box is approximate and includes portions of
-       ! Canadian archipelago and Iceland
        if (remove_gis_rofl) then
-          do n=1,lsize
-             lonv = ggrid%data%rAttr(ilon, n)
-             latv = ggrid%data%rAttr(ilat, n)
-             if ((latv > 59.0_r8)  .and. (latv < 83.0_r8) .and. &
-                 (lonv > 286.0_r8) .and. (lonv < 349.0_r8)) then
-                r2x%rAttr(index_r2x_rofl,n) = 0.0_r8
-             end if
-          enddo
+          call apply_gis_mask(r2x, ggrid, lsize, index_r2x_rofl)
        endif
        if (remove_gis_rofi) then
-          do n=1,lsize
-             lonv = ggrid%data%rAttr(ilon, n)
-             latv = ggrid%data%rAttr(ilat, n)
-             if ((latv > 59.0_r8)  .and. (latv < 83.0_r8) .and. &
-                 (lonv > 286.0_r8) .and. (lonv < 349.0_r8)) then
-                r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
-             end if
-          enddo
+          call apply_gis_mask(r2x, ggrid, lsize, index_r2x_rofi)
        endif
 
     end select
@@ -647,6 +615,71 @@ CONTAINS
     call t_stopf('DROF_RUN')
 
   end subroutine drof_comp_run
+
+  !===============================================================================
+  subroutine apply_ais_mask(r2x, ggrid, lsize, field_index)
+
+    implicit none
+
+    type(mct_aVect) , intent(inout) :: r2x
+    type(mct_gGrid) , pointer       :: ggrid
+    integer(IN)     , intent(in)    :: lsize
+    integer(IN)     , intent(in)    :: field_index
+
+    integer(IN) :: n, ilat
+    real(R8)    :: latv
+
+    ilat = mct_aVect_indexRA(ggrid%data,'lat')
+    do n=1,lsize
+       latv = ggrid%data%rAttr(ilat, n)
+       if (latv < -60.0_r8) then
+          r2x%rAttr(field_index,n) = 0.0_r8
+       end if
+    enddo
+
+  end subroutine apply_ais_mask
+
+  !===============================================================================
+  subroutine apply_gis_mask(r2x, ggrid, lsize, field_index)
+
+    implicit none
+
+    type(mct_aVect) , intent(inout) :: r2x
+    type(mct_gGrid) , pointer       :: ggrid
+    integer(IN)     , intent(in)    :: lsize
+    integer(IN)     , intent(in)    :: field_index
+
+    integer(IN) :: n, ilat, ilon
+    real(R8)    :: latv, lonv
+    logical     :: in_greenland, in_baffin, in_ellesmere, in_iceland
+
+    ilat = mct_aVect_indexRA(ggrid%data,'lat')
+    ilon = mct_aVect_indexRA(ggrid%data,'lon')
+
+    do n=1,lsize
+       lonv = ggrid%data%rAttr(ilon, n)
+       latv = ggrid%data%rAttr(ilat, n)
+
+       in_greenland = (latv > 59.5_r8) .and. (latv < 83.66_r8) .and. &
+                      (lonv > 287.0_r8) .and. (lonv < 349.2_r8)
+
+       in_baffin = (latv > 59.5_r8) .and. (latv < 73.0_r8) .and. &
+                   (lonv > 287.0_r8) .and. (lonv < 300.0_r8)
+
+       ! This region is a right triangle with a hypotenuse passing through Nares Strait
+       in_ellesmere = (latv > 76.5_r8) .and. (latv < 83.66_r8) .and. &
+                      (lonv > 280.0_r8) .and. &
+                      (lonv < 280.0_r8 + (latv - 76.5_r8) * 3.4_r8)
+
+       in_iceland = (latv > 63.0_r8) .and. (latv < 67.0_r8) .and. &
+                    (lonv > 334.0_r8) .and. (lonv < 347.0_r8)
+
+       if (in_greenland .and. .not.(in_baffin .or. in_ellesmere .or. in_iceland)) then
+          r2x%rAttr(field_index,n) = 0.0_r8
+       end if
+    enddo
+
+  end subroutine apply_gis_mask
 
   !===============================================================================
   subroutine drof_comp_final(my_task, master_task, logunit)

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -445,6 +445,8 @@ CONTAINS
     integer(IN)   :: nu                ! unit number
     integer(IN)   :: nflds_r2x
     character(len=18) :: date_str
+    real(R8) latv, lonv
+    integer ilat, ilon
 #ifdef HAVE_MOAB
     real(R8), allocatable, target :: datam(:)
     type(mct_list) :: temp_list
@@ -521,6 +523,24 @@ CONTAINS
 
     case('COPYALL')
        ! do nothing extra
+
+       ! TEST ZERO OUT SOME PARTS
+       ! zero out a geographic area
+       lsize = mct_avect_lsize(r2x)
+       nflds_r2x = mct_avect_nRattr(r2x)
+       ilat = mct_aVect_indexRA(ggrid%data,'lat')
+       ilon = mct_aVect_indexRA(ggrid%data,'lon')
+       do nf=1,nflds_r2x
+          do n=1,lsize
+             lonv = ggrid%data%rAttr(ilon, n)
+             latv = ggrid%data%rAttr(ilat, n)
+             if (lonv > 90.0_r8) then
+                r2x%rAttr(nf,n) = 0.0_r8
+             end if
+          enddo
+       enddo
+
+
 
     end select
     call t_stopf('drof_datamode')

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -24,6 +24,10 @@ module drof_comp_mod
   use drof_shr_mod   , only: decomp         ! namelist input
   use drof_shr_mod   , only: rest_file      ! namelist input
   use drof_shr_mod   , only: rest_file_strm ! namelist input
+  use drof_shr_mod   , only: remove_ais_rofl! namelist input
+  use drof_shr_mod   , only: remove_ais_rofi! namelist input
+  use drof_shr_mod   , only: remove_gis_rofl! namelist input
+  use drof_shr_mod   , only: remove_gis_rofi! namelist input
   use drof_shr_mod   , only: nullstr
 #ifdef HAVE_MOAB
   use seq_comm_mct,     only : mrofid ! id of moab rof app
@@ -447,6 +451,7 @@ CONTAINS
     character(len=18) :: date_str
     real(R8) latv, lonv
     integer ilat, ilon
+    integer :: index_r2x_rofl, index_r2x_rofi
 #ifdef HAVE_MOAB
     real(R8), allocatable, target :: datam(:)
     type(mct_list) :: temp_list
@@ -524,23 +529,53 @@ CONTAINS
     case('COPYALL')
        ! do nothing extra
 
-       ! TEST ZERO OUT SOME PARTS
-       ! zero out a geographic area
+       ! Apply modifications around ice sheets if required
        lsize = mct_avect_lsize(r2x)
        nflds_r2x = mct_avect_nRattr(r2x)
        ilat = mct_aVect_indexRA(ggrid%data,'lat')
        ilon = mct_aVect_indexRA(ggrid%data,'lon')
-       do nf=1,nflds_r2x
+       index_r2x_rofl = mct_avect_indexra(r2x,'Forr_rofl')
+       index_r2x_rofi = mct_avect_indexra(r2x,'Forr_rofi')
+       if (remove_ais_rofl) then
           do n=1,lsize
              lonv = ggrid%data%rAttr(ilon, n)
              latv = ggrid%data%rAttr(ilat, n)
-             if (lonv > 90.0_r8) then
-                r2x%rAttr(nf,n) = 0.0_r8
+             if (latv < -60.0_r8) then
+                r2x%rAttr(index_r2x_rofl,n) = 0.0_r8
              end if
           enddo
-       enddo
-
-
+       endif
+       if (remove_ais_rofi) then
+          do n=1,lsize
+             lonv = ggrid%data%rAttr(ilon, n)
+             latv = ggrid%data%rAttr(ilat, n)
+             if (latv < -57.0_r8) then
+                r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
+             end if
+          enddo
+       endif
+       ! Note: Greenland box is approximate and includes portions of
+       ! Canadian archipelago and Iceland
+       if (remove_gis_rofl) then
+          do n=1,lsize
+             lonv = ggrid%data%rAttr(ilon, n)
+             latv = ggrid%data%rAttr(ilat, n)
+             if ((latv > 59.0_r8)  .and. (latv < 83.0_r8) .and. &
+                 (lonv > 286.0_r8) .and. (lonv < 349.0_r8)) then
+                r2x%rAttr(index_r2x_rofl,n) = 0.0_r8
+             end if
+          enddo
+       endif
+       if (remove_gis_rofi) then
+          do n=1,lsize
+             lonv = ggrid%data%rAttr(ilon, n)
+             latv = ggrid%data%rAttr(ilat, n)
+             if ((latv > 59.0_r8)  .and. (latv < 83.0_r8) .and. &
+                 (lonv > 286.0_r8) .and. (lonv < 349.0_r8)) then
+                r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
+             end if
+          enddo
+       endif
 
     end select
     call t_stopf('drof_datamode')

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -549,9 +549,7 @@ CONTAINS
           do n=1,lsize
              lonv = ggrid%data%rAttr(ilon, n)
              latv = ggrid%data%rAttr(ilat, n)
-             ! This threshold was chosen to match the config_remove_ais_ice_runoff option
-             ! in MPAS-Ocean.  See components/mpas-ocean/driver/ocn_comp_mct.F line 2184 & 3717
-             if (latv < -57.0_r8) then
+             if (latv < -60.0_r8) then
                 r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
              end if
           enddo

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -527,7 +527,7 @@ CONTAINS
     select case (trim(datamode))
 
     case('COPYALL')
-       ! do nothing extra
+       ! COPYALL mode with optional runoff masking near ice sheets
 
        ! Apply modifications around ice sheets if required
        lsize = mct_avect_lsize(r2x)
@@ -549,6 +549,8 @@ CONTAINS
           do n=1,lsize
              lonv = ggrid%data%rAttr(ilon, n)
              latv = ggrid%data%rAttr(ilat, n)
+             ! This threshold was chosen to match the config_remove_ais_ice_runoff option
+             ! in MPAS-Ocean.  See components/mpas-ocean/driver/ocn_comp_mct.F line 2184 & 3717
              if (latv < -57.0_r8) then
                 r2x%rAttr(index_r2x_rofi,n) = 0.0_r8
              end if

--- a/components/data_comps/drof/src/drof_shr_mod.F90
+++ b/components/data_comps/drof/src/drof_shr_mod.F90
@@ -28,6 +28,10 @@ module drof_shr_mod
   character(CL) , public :: restfilm              ! model restart file namelist
   character(CL) , public :: restfils              ! stream restart file namelist
   logical       , public :: force_prognostic_true ! if true set prognostic true
+  logical       , public :: remove_ais_rofl       ! if true remove rofl around Antarctica
+  logical       , public :: remove_ais_rofi       ! if true remove rofi around Antarctica
+  logical       , public :: remove_gis_rofl       ! if true remove rofl around Greenland
+  logical       , public :: remove_gis_rofi       ! if true remove rofi around Greenland
 
   ! variables obtained from namelist read
   character(CL) , public :: rest_file             ! restart filename
@@ -76,7 +80,8 @@ CONTAINS
 
     !----- define namelist -----
     namelist / drof_nml / &
-        decomp, restfilm, restfils, force_prognostic_true
+        decomp, restfilm, restfils, force_prognostic_true, &
+        remove_ais_rofl, remove_ais_rofi, remove_gis_rofl, remove_gis_rofi
 
     !----------------------------------------------------------------------------
     ! Determine input filenamname
@@ -93,6 +98,10 @@ CONTAINS
     restfilm   = trim(nullstr)
     restfils   = trim(nullstr)
     force_prognostic_true = .false.
+    remove_ais_rofl = .false.
+    remove_ais_rofi = .false.
+    remove_gis_rofl = .false.
+    remove_gis_rofi = .false.
     if (my_task == master_task) then
        nunit = shr_file_getUnit() ! get unused unit number
        open (nunit,file=trim(filename),status="old",action="read")
@@ -107,11 +116,19 @@ CONTAINS
        write(logunit,F00)' restfilm   = ',trim(restfilm)
        write(logunit,F00)' restfils   = ',trim(restfils)
        write(logunit,F0L)' force_prognostic_true = ',force_prognostic_true
+       write(logunit,F0L)' remove_ais_rofl = ', remove_ais_rofl
+       write(logunit,F0L)' remove_ais_rofi = ', remove_ais_rofi
+       write(logunit,F0L)' remove_gis_rofl = ', remove_gis_rofl
+       write(logunit,F0L)' remove_gis_rofi = ', remove_gis_rofi
     endif
     call shr_mpi_bcast(decomp  ,mpicom,'decomp')
     call shr_mpi_bcast(restfilm,mpicom,'restfilm')
     call shr_mpi_bcast(restfils,mpicom,'restfils')
     call shr_mpi_bcast(force_prognostic_true,mpicom,'force_prognostic_true')
+    call shr_mpi_bcast(remove_ais_rofl,mpicom,'remove_ais_rofl')
+    call shr_mpi_bcast(remove_ais_rofi,mpicom,'remove_ais_rofi')
+    call shr_mpi_bcast(remove_gis_rofl,mpicom,'remove_gis_rofl')
+    call shr_mpi_bcast(remove_gis_rofi,mpicom,'remove_gis_rofi')
 
     rest_file = trim(restfilm)
     rest_file_strm = trim(restfils)

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -752,26 +752,8 @@ add_default($nl, 'config_precip_scaling_write_to_logfile');
 # Namelist group: coupling #
 ############################
 
-# When we have a data representation of icebergs, remove ice runoff
-if ($OCN_ICEBERG eq 'true') {
-	add_default($nl, 'config_remove_ais_ice_runoff', 'val'=>".true.");
-} else {
-	add_default($nl, 'config_remove_ais_ice_runoff', 'val'=>".false.");
-}
-# Assume river runoff corresponds to ISMF in Southern Ocean only for G-cases
-# (true for JRA). When atm active, we assume liquid runoff corresonds to precip
-# or snow melt so we do not remove it. In either case, the energy for melting
-# doesn't come from the ocean.
-if ((   ($OCN_GLC_ISMF_COUPLING eq 'coupler')
-     || ($OCN_GLC_ISMF_COUPLING eq 'internal_mpaso')
-     || ($OCN_GLC_ISMF_COUPLING eq 'data_mpaso')
-    )
-    && ($OCN_FORCING ne 'active_atm'))
-{
-	add_default($nl, 'config_remove_ais_river_runoff', 'val'=>".true.");
-} else {
-	add_default($nl, 'config_remove_ais_river_runoff', 'val'=>".false.");
-}
+add_default($nl, 'config_remove_ais_ice_runoff');
+add_default($nl, 'config_remove_ais_river_runoff');
 add_default($nl, 'config_scale_dismf_by_removed_ice_runoff');
 add_default($nl, 'config_ais_ice_runoff_history_days');
 add_default($nl, 'config_n_glc_z_levels', 'val'=>"$GLC_NZOC");

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -752,7 +752,25 @@ add_default($nl, 'config_precip_scaling_write_to_logfile');
 # Namelist group: coupling #
 ############################
 
-add_default($nl, 'config_remove_ais_ice_runoff');
+# handling of config_remove_ais_ice_runoff:
+if ($OCN_FORCING ne 'active_atm') {
+  # For fully coupled B-cases with active ATM/LND/ROF:
+  if ($OCN_ICEBERG eq 'true') {
+    # When we have a data representation of icebergs, remove ice runoff
+    add_default($nl, 'config_remove_ais_ice_runoff', 'val'=>".true.");
+  } else {
+    add_default($nl, 'config_remove_ais_ice_runoff', 'val'=>".false.");
+  }
+} else {
+  # For cases without active ATM/LND/ROF (i.e. G cases),
+  # removal of AIS ice runoff is handled in the DROF component,
+  # so this option should be set to false in MPAS-O.
+  add_default($nl, 'config_remove_ais_ice_runoff', 'val'=>".false.");
+}
+# The functionality of config_remove_ais_river_runoff is now handled in
+# the DROF component at components/data_comps/drof/cime_config/buildnml,
+# so there no longer is a situation where it needs to change from its
+# default value of false.
 add_default($nl, 'config_remove_ais_river_runoff');
 add_default($nl, 'config_scale_dismf_by_removed_ice_runoff');
 add_default($nl, 'config_ais_ice_runoff_history_days');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -753,7 +753,7 @@ add_default($nl, 'config_precip_scaling_write_to_logfile');
 ############################
 
 # handling of config_remove_ais_ice_runoff:
-if ($OCN_FORCING ne 'active_atm') {
+if ($OCN_FORCING eq 'active_atm') {
   # For fully coupled B-cases with active ATM/LND/ROF:
   if ($OCN_ICEBERG eq 'true') {
     # When we have a data representation of icebergs, remove ice runoff


### PR DESCRIPTION
This draft PR moves the ability to remove solid and liquid runoff from MPAS-Ocean where it currently occurs to the data runoff component.  This has several advantages:
* In puts the removal of fluxes in the component where they originate (DROF) rather than letting them pass through the coupler and then be eliminated in the destination component (MPAS-Ocean), which is a cleaner implementation.
* In G-cases with MALI using TF coupling and DIB active, zeroing rofi in MPAS-Ocean also zeros the ISMF melt flux coming from MALI as rofi.  This would also apply to G-cases with MALI applying calving fluxes.
* Coupler budgets actually reflect the runoff passed between components, as opposed to MPAS-Ocean receiving fluxes, zeroing them out, and then needing to tally how much flux was moved.

This is implemented by adding namelist options to DROF for removing rofl or rofi from either surrounding Antarctica or Greenland.  The activation for disabling AIS rofi/rofl follow the same logic as used previously to activate the config_remove_ais_ice_runoff and config_remove_ais_river_runoff options in MPAS-Ocean.  The options for Greenland are not currently used.  When these options are active, there is new code in DROF that zeros the corresponding field (rofl or rofi) in the r2x attribute vector before it is sent to the coupler.  Thus, it is as if the fluxes in those regions never existed.